### PR TITLE
quick fix for Uncaught SyntaxError JSON.parse at routes/home/+page.svelte

### DIFF
--- a/web/src/routes/home/+page.svelte
+++ b/web/src/routes/home/+page.svelte
@@ -62,20 +62,27 @@
 		metadataEvents.sort((x, y) => x.created_at - y.created_at);
 		$userEvents = new Map(
 			metadataEvents.map((event) => {
-				const user = JSON.parse(event.content);
-				const e = {
-					...event,
-					user
-				} as UserEvent;
-				return [e.pubkey, e];
+				try {
+					const user = JSON.parse(event.content);
+					const e = {
+						...event,
+						user
+					} as UserEvent;
+					return [e.pubkey, e];
+				} catch (err) {
+					console.error(err.message, event.content);
+					return [];
+				}
 			})
 		);
 
-		for (const [, e] of $userEvents) {
-			nip57.getZapEndpoint(e).then((url) => {
-				e.user.zapEndpoint = url;
-				console.debug('[metadata]', e.user);
-			});
+		if ($userEvents) {
+			for (const [, e] of $userEvents) {
+				nip57.getZapEndpoint(e).then((url) => {
+					e.user.zapEndpoint = url;
+					console.debug('[metadata]', e.user);
+				});
+			}
 		}
 
 		console.log(`Metadata events loaded in ${Date.now() / 1000 - now} seconds`);

--- a/web/src/routes/home/+page.svelte
+++ b/web/src/routes/home/+page.svelte
@@ -61,28 +61,28 @@
 		]);
 		metadataEvents.sort((x, y) => x.created_at - y.created_at);
 		$userEvents = new Map(
-			metadataEvents.map((event) => {
-				try {
-					const user = JSON.parse(event.content);
-					const e = {
-						...event,
-						user
-					} as UserEvent;
-					return [e.pubkey, e];
-				} catch (err) {
-					console.error(err.message, event.content);
-					return [];
-				}
-			})
+			metadataEvents
+				.map((event) => {
+					try {
+						const user = JSON.parse(event.content);
+						const e = {
+							...event,
+							user
+						} as UserEvent;
+						return [e.pubkey, e];
+					} catch (error) {
+						console.error('[invalid metadata]', error, event);
+						return null;
+					}
+				})
+				.filter((x): x is [string, Event] => x !== null)
 		);
 
-		if ($userEvents) {
-			for (const [, e] of $userEvents) {
-				nip57.getZapEndpoint(e).then((url) => {
-					e.user.zapEndpoint = url;
-					console.debug('[metadata]', e.user);
-				});
-			}
+		for (const [, e] of $userEvents) {
+			nip57.getZapEndpoint(e).then((url) => {
+				e.user.zapEndpoint = url;
+				console.debug('[metadata]', e.user);
+			});
 		}
 
 		console.log(`Metadata events loaded in ${Date.now() / 1000 - now} seconds`);


### PR DESCRIPTION
sometimes following error crashes nostter.

```
Uncaught (in promise) SyntaxError: JSON.parse: bad control character in string literal at line 1 column 34 of the JSON data
    userEvents +page.svelte:66
    fetchHomeTimeline +page.svelte:64
    func +page.svelte:282
```
corrupted JSON (kind0 metadata) causes error.

this is nothing more than first aid, rewrite with better code.