### PR TITLE
Fix 500 error on /preferences

### DIFF
--- a/web/src/routes/(app)/preferences/UriScheme.svelte
+++ b/web/src/routes/(app)/preferences/UriScheme.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
+	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import { uriScheme } from '$lib/Constants';
 
@@ -9,7 +10,7 @@
 	}
 </script>
 
-{#if navigator.registerProtocolHandler !== undefined}
+{#if browser && navigator.registerProtocolHandler !== undefined}
 	<span>{$_('preferences.uri_scheme')}</span>
 	<button on:click={enableUriScheme}>{$_('preferences.enable_uri_scheme')}</button>
 {/if}


### PR DESCRIPTION
Fixed a 500 error when accessing to preferences directly.
This occurs by Vercel's Serverless Function does not have `window.navigator`.