### PR TITLE
Enhance mobile PWA visual

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -5,7 +5,7 @@
 		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
-		<meta name="viewport" content="width=device-width, initial-scale=1 viewport-fit=cover" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="theme-color" content="#f9f5f1" />
 		%sveltekit.head%
 	</head>

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -5,7 +5,8 @@
 		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1 viewport-fit=cover" />
+		<meta name="theme-color" content="#f9f5f1" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/web/src/routes/(app)/Header.svelte
+++ b/web/src/routes/(app)/Header.svelte
@@ -235,12 +235,13 @@
 			top: auto;
 			bottom: 0;
 			width: 100%;
-			height: 3.125rem;
+			height: calc(3.125rem + env(safe-area-inset-bottom));
 			background-color: var(--background);
 			position: fixed;
 			box-shadow: var(--shadow);
 			justify-content: center;
 			margin-top: 30px;
+			padding-bottom: env(safe-area-inset-bottom);
 		}
 
 		#logo-icon-wrapper {
@@ -262,7 +263,7 @@
 
 		button {
 			position: fixed;
-			bottom: calc(3.125rem + 0.75rem);
+			bottom: calc(3.125rem + 0.75rem + env(safe-area-inset-bottom));
 			right: 0.75rem;
 		}
 

--- a/web/src/routes/(app)/preferences/Theme.svelte
+++ b/web/src/routes/(app)/preferences/Theme.svelte
@@ -25,6 +25,11 @@
 					document.documentElement.classList.remove('dark');
 				}
 			}
+
+			const color = getComputedStyle(document.documentElement).getPropertyValue('--background')
+			let themeColorMetaTag: HTMLMetaElement = document.querySelector('meta[name="theme-color"]') as HTMLMetaElement
+			themeColorMetaTag.content = color
+
 		});
 	}
 </script>

--- a/web/src/routes/(app)/preferences/Theme.svelte
+++ b/web/src/routes/(app)/preferences/Theme.svelte
@@ -26,10 +26,13 @@
 				}
 			}
 
-			const color = getComputedStyle(document.documentElement).getPropertyValue('--background')
-			let themeColorMetaTag: HTMLMetaElement = document.querySelector('meta[name="theme-color"]') as HTMLMetaElement
-			themeColorMetaTag.content = color
-
+			const color = getComputedStyle(document.documentElement).getPropertyValue(
+				'--background'
+			);
+			let themeColorMetaTag: HTMLMetaElement = document.querySelector(
+				'meta[name="theme-color"]'
+			) as HTMLMetaElement;
+			themeColorMetaTag.content = color;
 		});
 	}
 </script>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -38,6 +38,11 @@
 		) {
 			document.documentElement.classList.add('dark');
 		}
+
+		const color = getComputedStyle(document.documentElement).getPropertyValue('--background')
+		let themeColorMetaTag = document.querySelector('meta[name="theme-color"]')
+		themeColorMetaTag.content = color
+
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-G1WMSV0PBP"></script>
 </svelte:head>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -39,10 +39,9 @@
 			document.documentElement.classList.add('dark');
 		}
 
-		const color = getComputedStyle(document.documentElement).getPropertyValue('--background')
-		let themeColorMetaTag = document.querySelector('meta[name="theme-color"]')
-		themeColorMetaTag.content = color
-
+		const color = getComputedStyle(document.documentElement).getPropertyValue('--background');
+		let themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
+		themeColorMetaTag.content = color;
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-G1WMSV0PBP"></script>
 </svelte:head>


### PR DESCRIPTION
PWAとしてモバイルでロードした際に、①メニューがセーフエリアを考慮したオフセットになるように + ②テーマカラーを設定することでヘッダー部分も塗つぶされるように 変更しました。


| 変更前 | 変更後 |
|---------|---------|
|![IMG_3783](https://github.com/SnowCait/nostter/assets/7270849/7256efc7-674e-4b44-855a-1ddec5768f0d)|![IMG_3782](https://github.com/SnowCait/nostter/assets/7270849/2ec4b984-eb06-4295-a758-8b9a337bd2dc)|

(issue無しPRでごめんなさい！ なのでそっとCloseでもOKです 🙇‍♂️ )