### PR TITLE
Compliant with NIP-25

### DIFF
--- a/web/src/routes/(app)/timeline/Note.svelte
+++ b/web/src/routes/(app)/timeline/Note.svelte
@@ -146,10 +146,12 @@
 			return;
 		}
 
-		const tags = [
-			['e', note.id],
-			['p', note.pubkey]
-		];
+		const tags = note.tags.filter(
+			([tagName, p]) => tagName === 'e' || (tagName === 'p' && p !== note.pubkey)
+		);
+		tags.push(['e', note.id]);
+		tags.push(['p', note.pubkey]);
+		tags.push(['k', String(note.kind)]);
 		if (emoji.native === undefined && emoji.src !== undefined) {
 			tags.push(['emoji', emoji.id.replaceAll('+', '_'), emoji.src]);
 		}

--- a/web/src/routes/(app)/timeline/Note.svelte
+++ b/web/src/routes/(app)/timeline/Note.svelte
@@ -115,10 +115,10 @@
 		reactioned = true;
 
 		const content = $preferencesStore.reactionEmoji.content;
-		const tags = [
-			['e', note.id],
-			['p', note.pubkey]
-		];
+		const tags = note.tags.filter(([tagName, p]) => tagName === 'e' || (tagName === 'p' && p !== note.pubkey));
+		tags.push(['e', note.id]);
+		tags.push(['p', note.pubkey]);
+		tags.push(['k', String(note.kind)]);
 		if ($preferencesStore.reactionEmoji.url !== undefined) {
 			tags.push(['emoji', content.replaceAll(':', ''), $preferencesStore.reactionEmoji.url]);
 		}

--- a/web/src/routes/(app)/timeline/Note.svelte
+++ b/web/src/routes/(app)/timeline/Note.svelte
@@ -115,7 +115,9 @@
 		reactioned = true;
 
 		const content = $preferencesStore.reactionEmoji.content;
-		const tags = note.tags.filter(([tagName, p]) => tagName === 'e' || (tagName === 'p' && p !== note.pubkey));
+		const tags = note.tags.filter(
+			([tagName, p]) => tagName === 'e' || (tagName === 'p' && p !== note.pubkey)
+		);
 		tags.push(['e', note.id]);
 		tags.push(['p', note.pubkey]);
 		tags.push(['k', String(note.kind)]);


### PR DESCRIPTION
[NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md)には以下の通り定められています。

> The reaction event SHOULD include `e` and `p` tags from the note the user is reacting to.

また、任意ですがkタグを付けることもできます。

> The reaction event MAY include a `k` tag with the stringified kind number of the reacted event as its value.

上記の実装をPRします。  
メリットとしてはパブリックチャット等でリアクションイベントをフィルターしやすくなり、具体的には私が喜びます。
