### PR TITLE
Update Badges.svelte (Fix URL of Badges)

### DIFF
--- a/web/src/lib/components/Badges.svelte
+++ b/web/src/lib/components/Badges.svelte
@@ -7,7 +7,7 @@
 <ul class="badges">
 	{#each badges as badge}
 		<li>
-			<a href="https://badges.page/b/{badge.naddr}" target="_blank" rel="noreferrer">
+			<a href="https://badges.page/a/{badge.naddr}" target="_blank" rel="noreferrer">
 				<img
 					src={badge.thumb ? badge.thumb : badge.image}
 					alt={badge.name}


### PR DESCRIPTION
プロフィール画面で badge サムネイルから badges.page へのリンクが切れていたので、修正してみました。 （サイトがリニューアルされたときに変えたのかも…）