### PR TITLE
hide form on nostr-post-checker

### DIFF
--- a/web/src/routes/(app)/content/LongFormContent.svelte
+++ b/web/src/routes/(app)/content/LongFormContent.svelte
@@ -50,7 +50,7 @@
 			<code>{JSON.stringify(event, null, 2)}</code>
 			<div>
 				Open in <a
-					href="https://koteitan.github.io/nostr-post-checker/?eid={nip19.neventEncode({
+					href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
 						id: event.id
 					})}&kind={event.kind}"
 					target="_blank"

--- a/web/src/routes/(app)/content/LongFormContent.svelte
+++ b/web/src/routes/(app)/content/LongFormContent.svelte
@@ -50,9 +50,11 @@
 			<code>{JSON.stringify(event, null, 2)}</code>
 			<div>
 				Open in <a
-					href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
-						id: event.id
-					})}&kind={event.kind}"
+					href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode(
+						{
+							id: event.id
+						}
+					)}&kind={event.kind}"
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/web/src/routes/(app)/timeline/Channel.svelte
+++ b/web/src/routes/(app)/timeline/Channel.svelte
@@ -83,7 +83,7 @@
 			<code>{JSON.stringify(event, null, 2)}</code>
 			<div>
 				Open in <a
-					href="https://koteitan.github.io/nostr-post-checker/?eid={nip19.neventEncode({
+					href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
 						id: event.id
 					})}&kind={event.kind}"
 					target="_blank"

--- a/web/src/routes/(app)/timeline/Channel.svelte
+++ b/web/src/routes/(app)/timeline/Channel.svelte
@@ -83,9 +83,11 @@
 			<code>{JSON.stringify(event, null, 2)}</code>
 			<div>
 				Open in <a
-					href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
-						id: event.id
-					})}&kind={event.kind}"
+					href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode(
+						{
+							id: event.id
+						}
+					)}&kind={event.kind}"
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/web/src/routes/(app)/timeline/Note.svelte
+++ b/web/src/routes/(app)/timeline/Note.svelte
@@ -457,7 +457,7 @@
 						</p>
 						<div>
 							Open in <a
-								href="https://koteitan.github.io/nostr-post-checker/?eid={nip19.neventEncode(
+								href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode(
 									{ id: item.event.id }
 								)}&kind={item.event.kind}"
 								target="_blank"

--- a/web/src/routes/(app)/timeline/Reaction.svelte
+++ b/web/src/routes/(app)/timeline/Reaction.svelte
@@ -75,7 +75,7 @@
 		<code>{JSON.stringify(metadata?.content, null, 2)}</code>
 		<div>
 			Open in <a
-				href="https://koteitan.github.io/nostr-post-checker/?eid={nip19.neventEncode({
+				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
 					id: event.id
 				})}&kind={event.kind}"
 				target="_blank"

--- a/web/src/routes/(app)/timeline/Reaction.svelte
+++ b/web/src/routes/(app)/timeline/Reaction.svelte
@@ -75,9 +75,11 @@
 		<code>{JSON.stringify(metadata?.content, null, 2)}</code>
 		<div>
 			Open in <a
-				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
-					id: event.id
-				})}&kind={event.kind}"
+				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode(
+					{
+						id: event.id
+					}
+				)}&kind={event.kind}"
 				target="_blank"
 				rel="noopener noreferrer"
 			>

--- a/web/src/routes/(app)/timeline/RepostedNote.svelte
+++ b/web/src/routes/(app)/timeline/RepostedNote.svelte
@@ -76,7 +76,7 @@
 		<code>{JSON.stringify(metadata?.content, null, 2)}</code>
 		<div>
 			Open in <a
-				href="https://koteitan.github.io/nostr-post-checker/?eid={nip19.neventEncode({
+				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
 					id: item.event.id
 				})}&kind={item.event.kind}"
 				target="_blank"

--- a/web/src/routes/(app)/timeline/RepostedNote.svelte
+++ b/web/src/routes/(app)/timeline/RepostedNote.svelte
@@ -76,9 +76,11 @@
 		<code>{JSON.stringify(metadata?.content, null, 2)}</code>
 		<div>
 			Open in <a
-				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
-					id: item.event.id
-				})}&kind={item.event.kind}"
+				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode(
+					{
+						id: item.event.id
+					}
+				)}&kind={item.event.kind}"
 				target="_blank"
 				rel="noopener noreferrer"
 			>

--- a/web/src/routes/(app)/timeline/Zap.svelte
+++ b/web/src/routes/(app)/timeline/Zap.svelte
@@ -101,7 +101,7 @@
 		<code>{JSON.stringify(zap.invoice, null, 2)}</code>
 		<div>
 			Open in <a
-				href="https://koteitan.github.io/nostr-post-checker/?eid={nip19.neventEncode({
+				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
 					id: event.id
 				})}&kind={event.kind}"
 				target="_blank"

--- a/web/src/routes/(app)/timeline/Zap.svelte
+++ b/web/src/routes/(app)/timeline/Zap.svelte
@@ -101,9 +101,11 @@
 		<code>{JSON.stringify(zap.invoice, null, 2)}</code>
 		<div>
 			Open in <a
-				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode({
-					id: event.id
-				})}&kind={event.kind}"
+				href="https://koteitan.github.io/nostr-post-checker/?hideform&eid={nip19.neventEncode(
+					{
+						id: event.id
+					}
+				)}&kind={event.kind}"
 				target="_blank"
 				rel="noopener noreferrer"
 			>


### PR DESCRIPTION
I added the "hideform" "hidepv" query that hide input form or contents preview in nostr-post-checker above version v1.32.

The links from nostter might be better with "hideform" since this gives more compact result.

nostr-post-checker v1.32 以降で "hideform" "hidepv" クエリによって入力フォームとコンテンツプレビューを隠す機能を付けました。

よりコンパクトな結果表示ができるので、nostter からのリンクも hideform 付きにするとよいかもと思いました。

![npc](https://github.com/SnowCait/nostter/assets/1577128/8a4b0791-c5dd-43ce-ad8f-6f35e24fa64b)