### PR TITLE
Eliminate the gap between the top and bottom of custom emojis

### DIFF
--- a/web/src/routes/(app)/content/CustomEmoji.svelte
+++ b/web/src/routes/(app)/content/CustomEmoji.svelte
@@ -8,6 +8,6 @@
 <style>
 	img {
 		max-height: 1.5em;
-		vertical-align: middle;
+		vertical-align: top;
 	}
 </style>


### PR DESCRIPTION
カスタム絵文字の上下に隙間があったのを詰めてみました。
![kubipaka](https://github.com/SnowCait/nostter/assets/496156/693c51d0-4c14-4dee-b5da-0a1f7a2b6348)