### PR TITLE
Filter timeline items only including items to show, before passing to VirtualScroll

### DIFF
--- a/web/src/routes/(app)/TimelineView.svelte
+++ b/web/src/routes/(app)/TimelineView.svelte
@@ -25,6 +25,12 @@
 	let innerHeight: number;
 	let scrollY = writable(0);
 
+	$: visibleItems = items.filter(
+		(item) =>
+			!isMuteEvent(item.event) &&
+			!$deletedEventIdsByPubkey.get(item.event.pubkey)?.has(item.event.id)
+	);
+
 	onMount(() => {
 		console.log('Timeline.onMount');
 		scrollY.subscribe(async (y) => {
@@ -104,19 +110,15 @@
 <svelte:window bind:innerHeight bind:scrollY={$scrollY} />
 
 <section class="card">
-	<VirtualScroll data={items} key="id" let:data pageMode={true} keeps={50}>
-		{#if !isMuteEvent(data.event) && !$deletedEventIdsByPubkey
-				.get(data.event.pubkey)
-				?.has(data.event.id)}
-			<!-- svelte-ignore a11y-no-static-element-interactions -->
-			<div
-				class={canTransition ? 'canTransition-post' : ''}
-				class:related={$author?.isNotified(data.event)}
-				on:mouseup={(e) => viewDetail(e, data.event)}
-			>
-				<EventComponent item={data} {readonly} {createdAtFormat} {full} />
-			</div>
-		{/if}
+	<VirtualScroll data={visibleItems} key="id" let:data pageMode={true} keeps={50}>
+		<!-- svelte-ignore a11y-no-static-element-interactions -->
+		<div
+			class={canTransition ? 'canTransition-post' : ''}
+			class:related={$author?.isNotified(data.event)}
+			on:mouseup={(e) => viewDetail(e, data.event)}
+		>
+			<EventComponent item={data} {readonly} {createdAtFormat} {full} />
+		</div>
 	</VirtualScroll>
 </section>
 


### PR DESCRIPTION
- fixes: #1380
- related: #1283

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/90609247-3e66-4fc7-b938-9ef4fdc10567"> |  <video src="https://github.com/user-attachments/assets/d468fc27-22d7-4fea-9180-6479ac485736"> |


filter するロジックは以前と同じにしてあります。