### PR TITLE
Implement delayed processing control for media uploads

### DIFF
--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -27,6 +27,7 @@
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
 	import ProfileIcon from '../profile/ProfileIcon.svelte';
 	import IconMoodSmile from '@tabler/icons-svelte/icons/mood-smile';
+	import Loading from '$lib/components/Loading.svelte';
 
 	export function clear(): void {
 		console.log('[note editor clear]');
@@ -605,7 +606,10 @@
 		{/each}
 	{/if}
 	{#if uploading}
-		<div>Uploading...</div>
+		<div class="uploading">
+			<p>Uploading...</p>
+			<Loading/>
+		</div>	
 	{/if}
 	{#if content !== ''}
 		<section class="preview card">
@@ -693,11 +697,21 @@
 		margin: 1rem;
 		max-height: 30rem;
 		overflow-y: auto;
+		text-align: center;
 	}
 
 	.options {
 		display: flex;
 		height: 30px;
+	}
+
+	.uploading {
+		text-align: center;
+		padding-bottom: 0.7em;
+	}
+
+	.uploading p {
+		padding-bottom: 0.6em;
 	}
 
 	.emoji-picker {

--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -608,8 +608,8 @@
 	{#if uploading}
 		<div class="uploading">
 			<p>Uploading...</p>
-			<Loading/>
-		</div>	
+			<Loading />
+		</div>
 	{/if}
 	{#if content !== ''}
 		<section class="preview card">

--- a/web/src/lib/media/FileStorageServer.ts
+++ b/web/src/lib/media/FileStorageServer.ts
@@ -39,7 +39,7 @@ export class FileStorageServer implements Media {
 				['method', method]
 			]
 		});
-		console.debug('[media uplaod auth]', event);
+		console.debug('[media upload auth]', event);
 
 		const response = await fetch(apiUrl, {
 			method,
@@ -56,6 +56,47 @@ export class FileStorageServer implements Media {
 		const data = await response.json();
 
 		console.log('[media upload result]', data);
+
+		// If the media provider uses delayed processing, we need to wait for the processing to be done
+		const startTime = now();
+		while (data.processing_url) {
+
+			const processingEvent = await Signer.signEvent({
+				kind: 27235 as Kind,
+				content: '',
+				created_at: now(),
+				tags: [
+					['u', data.processing_url],
+					['method', 'GET']
+				]
+			});
+
+			console.debug('[media upload processing auth]', event);
+
+			const processing = await fetch(data.processing_url, {
+				headers: {
+					Authorization: `Nostr ${btoa(JSON.stringify(processingEvent))}`
+				}
+			});
+	
+			if (!processing.ok) {
+				throw new Error(await processing.text());
+			}
+
+			const processingData = await processing.json();
+
+			console.log('[media upload processing result]', processingData);
+		
+			if (processingData.status === "success") {
+				break
+			}
+
+			if (now() - startTime > 60) {
+				throw new Error('Failed to upload (timeout)'); // 60 seconds timeout
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		}
 
 		const url = filterTags('url', data.nip94_event.tags).at(0);
 		if (url === undefined) {

--- a/web/src/lib/media/FileStorageServer.ts
+++ b/web/src/lib/media/FileStorageServer.ts
@@ -60,7 +60,6 @@ export class FileStorageServer implements Media {
 		// If the media provider uses delayed processing, we need to wait for the processing to be done
 		const startTime = now();
 		while (data.processing_url) {
-
 			const processingEvent = await Signer.signEvent({
 				kind: 27235 as Kind,
 				content: '',
@@ -78,7 +77,7 @@ export class FileStorageServer implements Media {
 					Authorization: `Nostr ${btoa(JSON.stringify(processingEvent))}`
 				}
 			});
-	
+
 			if (!processing.ok) {
 				throw new Error(await processing.text());
 			}
@@ -86,9 +85,9 @@ export class FileStorageServer implements Media {
 			const processingData = await processing.json();
 
 			console.log('[media upload processing result]', processingData);
-		
-			if (processingData.status === "success") {
-				break
+
+			if (processingData.status === 'success') {
+				break;
 			}
 
 			if (now() - startTime > 60) {


### PR DESCRIPTION
In this PR, I've implemented a control mechanism to handle delayed media processing on NIP-96 servers. This feature is critical when the media provider does not process the uploaded files immediately, but instead queues them for later processing.

Previously, attempting to access the media URL immediately after upload could result in a "file not found" error if the server had not finished processing the file. This fix ensures that the client waits for the file to be fully processed and accessible by continuously polling the processing_url until the status indicates success.

A small visual improvement was added as well

![image](https://github.com/user-attachments/assets/62b3659a-b1ef-4bd3-ac4a-15efc3badeb8)
