### PR TITLE
fix: update nostr-remote-image to 0.4.3 in order to show alt text

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,7 +27,7 @@
 				"rxjs": "^7.8.1",
 				"svelte-easy-crop": "^3.0.0",
 				"svelte-i18n": "^4.0.0",
-				"svelte-remote-image": "0.4.2"
+				"svelte-remote-image": "0.4.3"
 			},
 			"devDependencies": {
 				"@beyonk/gdpr-cookie-consent-banner": "^11.0.0",
@@ -5886,9 +5886,9 @@
 			}
 		},
 		"node_modules/svelte-remote-image": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/svelte-remote-image/-/svelte-remote-image-0.4.2.tgz",
-			"integrity": "sha512-OXAbKPF89kM+qlmIHY+7/s6Pb1gPf52ih6rf1tu07VzPO4YipVbV1L3uI74UuqlVQSvrCJGtvw6X9sCT9ePPpg==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/svelte-remote-image/-/svelte-remote-image-0.4.3.tgz",
+			"integrity": "sha512-z/s/nxkeY+6yCDmpCsNtfEtyujCnTzR1jUq177h1A8ZuSiiVxvAOox6LwI0sn64CeXgh7gdh0Ut6FaUtN80umw==",
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0",
 				"svelte": "^4.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -60,7 +60,7 @@
 		"rx-nostr-crypto": "^3.1.1",
 		"rxjs": "^7.8.1",
 		"svelte-i18n": "^4.0.0",
-		"svelte-remote-image": "0.4.2",
+		"svelte-remote-image": "0.4.3",
 		"svelte-easy-crop": "^3.0.0"
 	}
 }


### PR DESCRIPTION
If the image fails to load and there is no fallback destination, display alt text.