### PR TITLE
Build config

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -8,8 +8,7 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true,
-		"moduleResolution": "Node"
+		"strict": true
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//


### PR DESCRIPTION
Apply default `moduleResolution: "bundler"` of `.svelte-kit/tsconfig.json`.

Relates to #924 