### PR TITLE
Add preference "AutoPlay GIF"

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
 				"async-lock": "^1.4.1",
 				"emoji-kitchen-mart": "^6.0.5",
 				"escape-string-regexp": "^5.0.0",
+				"freezeframe": "^5.0.2",
 				"light-bolt11-decoder": "^3.1.1",
 				"nip07-awaiter": "^1.0.0",
 				"nostr-tools": "^2.18.2",
@@ -3708,6 +3709,12 @@
 			"dependencies": {
 				"tabbable": "^6.2.0"
 			}
+		},
+		"node_modules/freezeframe": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/freezeframe/-/freezeframe-5.0.2.tgz",
+			"integrity": "sha512-Lp1ltC2vJGBqxdW5U4Hx+JMW+s9KfTPpxKhSTlpmQxYX5oK66y3GIZo56Jie4XtSOApSbfc8SBcsbZzeTNKfFg==",
+			"license": "MIT"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",

--- a/web/package.json
+++ b/web/package.json
@@ -58,6 +58,7 @@
 		"async-lock": "^1.4.1",
 		"emoji-kitchen-mart": "^6.0.5",
 		"escape-string-regexp": "^5.0.0",
+		"freezeframe": "^5.0.2",
 		"light-bolt11-decoder": "^3.1.1",
 		"nip07-awaiter": "^1.0.0",
 		"nostr-tools": "^2.18.2",

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -22,8 +22,7 @@
 	let imgElement: HTMLElement;
 
 	onMount(async () => {
-		const isAutoPlayGif =
-			new WebStorage(localStorage).get('preference:autoplay-gif') !== 'false';
+		const isAutoPlayGif = new WebStorage(localStorage).get('preference:autoplay-gif') !== 'false';
 		if (/\.gif$/i.test(pathname) && imgElement && !isAutoPlayGif) {
 			const FreezeFrame = (await import('freezeframe')).default;
 			new FreezeFrame(imgElement, {
@@ -55,6 +54,7 @@
 		width: fit-content;
 		white-space: normal;
 		max-width: calc(100% - 1.5em);
+		width: 100%;
 		max-height: 20em;
 		margin: 0.5em;
 		border: 1px solid lightgray;

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -54,6 +54,26 @@
 		border: 1px solid lightgray;
 		border-radius: 5px;
 		vertical-align: middle;
+	{:else}
+		<div class="global-content-image">
+			<img bind:this={imgElement} {src} alt={src} />
+		</div>
+	{/if}
+	{#if blur}
+		<button>{$_('content.show')}</button>
+	{/if}
+</span>
+
+<style>
+	.img-wrapper :global(.global-content-image) {
+		width: fit-content;
+		white-space: normal;
+		max-width: calc(100% - 1.5em);
+		max-height: 20em;
+		margin: 0.5em;
+		border: 1px solid lightgray;
+		border-radius: 5px;
+		vertical-align: middle;
 	}
 
 	.img-wrapper :global(.global-content-image.blur),

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -6,6 +6,7 @@
 	import { _ } from 'svelte-i18n';
 	import { Img, type ImgSrc } from 'svelte-remote-image';
 	import { onMount } from 'svelte';
+	import { WebStorage } from '$lib/WebStorage';
 
 	export let url: URL;
 
@@ -21,7 +22,9 @@
 	let imgElement: HTMLElement;
 
 	onMount(async () => {
-		if (/\.gif$/i.test(pathname) && imgElement) {
+		const isAutoPlayGif =
+			new WebStorage(localStorage).get('preference:autoplay-gif') !== 'false';
+		if (/\.gif$/i.test(pathname) && imgElement && !isAutoPlayGif) {
 			const FreezeFrame = (await import('freezeframe')).default;
 			new FreezeFrame(imgElement, {
 				trigger: 'hover',

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -29,7 +29,7 @@
 			new FreezeFrame(imgElement, {
 				trigger: 'hover',
 				overlay: true,
-				responsive: true
+				responsive: false
 			});
 		}
 	});
@@ -47,9 +47,7 @@
 </span>
 
 <style>
-	.img-wrapper :global(.global-content-image),
-	.img-wrapper :global(.ff-canvas),
-	.img-wrapper img {
+	.img-wrapper :global(.global-content-image) {
 		max-width: calc(100% - 1.5em);
 		max-height: 20em;
 		margin: 0.5em;
@@ -58,18 +56,13 @@
 		vertical-align: middle;
 	}
 
-	.img-wrapper.blur :global(.global-content-image.blur),
-	.img-wrapper.blur :global(.ff-canvas),
-	.img-wrapper.blur img {
+	.img-wrapper :global(.global-content-image.blur),
+	img.blur {
 		filter: blur(8px);
 	}
 
 	.img-wrapper {
 		position: relative;
-	}
-
-	.img-wrapper :global(.ff-container) {
-		display: inline-block;
 	}
 
 	button {

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -22,7 +22,8 @@
 	let imgElement: HTMLElement;
 
 	onMount(async () => {
-		const isAutoPlayGif = new WebStorage(localStorage).get('preference:autoplay-gif') !== 'false';
+		const isAutoPlayGif =
+			new WebStorage(localStorage).get('preference:autoplay-gif') !== 'false';
 		if (/\.gif$/i.test(pathname) && imgElement && !isAutoPlayGif) {
 			const FreezeFrame = (await import('freezeframe')).default;
 			new FreezeFrame(imgElement, {

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -35,14 +35,16 @@
 	});
 </script>
 
-<span class="img-wrapper" class:blur>
-	{#if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
-		<Img class="global-content-image{blur ? ' blur' : ''}" src={imageSrc} alt={src} />
-	{:else}
-		<div class="global-content-image">
-			<img bind:this={imgElement} {src} alt={src} />
-		</div>
-	{/if}
+<span class="img-wrapper">
+	<span class:blur>
+		{#if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
+			<Img class="global-content-image" src={imageSrc} alt={src} />
+		{:else}
+			<div class="global-content-image">
+				<img bind:this={imgElement} {src} alt={src} />
+			</div>
+		{/if}
+	</span>
 	{#if blur}
 		<button>{$_('content.show')}</button>
 	{/if}
@@ -60,8 +62,7 @@
 		vertical-align: middle;
 	}
 
-	.img-wrapper :global(.global-content-image.blur),
-	img.blur {
+	.blur {
 		filter: blur(8px);
 	}
 

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -54,12 +54,18 @@
 		width: fit-content;
 		white-space: normal;
 		max-width: calc(100% - 1.5em);
-		width: 100%;
 		max-height: 20em;
 		margin: 0.5em;
 		border: 1px solid lightgray;
 		border-radius: 5px;
 		vertical-align: middle;
+	}
+
+	.img-wrapper :global(.global-content-image img) {
+		max-width: 100%;
+		height: auto;
+		display: block;
+		border-radius: 5px;
 	}
 
 	.blur {

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -39,22 +39,6 @@
 	{#if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
 		<Img class="global-content-image{blur ? ' blur' : ''}" src={imageSrc} alt={src} />
 	{:else}
-		<img bind:this={imgElement} class="global-content-image" {src} alt={src} />
-	{/if}
-	{#if blur}
-		<button>{$_('content.show')}</button>
-	{/if}
-</span>
-
-<style>
-	.img-wrapper :global(.global-content-image) {
-		max-width: calc(100% - 1.5em);
-		max-height: 20em;
-		margin: 0.5em;
-		border: 1px solid lightgray;
-		border-radius: 5px;
-		vertical-align: middle;
-	{:else}
 		<div class="global-content-image">
 			<img bind:this={imgElement} {src} alt={src} />
 		</div>

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -5,6 +5,7 @@
 	import { getContext } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import { Img, type ImgSrc } from 'svelte-remote-image';
+	import { onMount } from 'svelte';
 
 	export let url: URL;
 
@@ -16,13 +17,26 @@
 		img: `${$imageOptimization}width=800,quality=60,format=webp/${src}`,
 		fallback: [src]
 	};
+
+	let imgElement: HTMLElement;
+
+	onMount(async () => {
+		if (/\.gif$/i.test(pathname) && imgElement) {
+			const FreezeFrame = (await import('freezeframe')).default;
+			new FreezeFrame(imgElement, {
+				trigger: 'hover',
+				overlay: true,
+				responsive: true
+			});
+		}
+	});
 </script>
 
-<span class="img-wrapper">
+<span class="img-wrapper" class:blur>
 	{#if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
 		<Img class="global-content-image{blur ? ' blur' : ''}" src={imageSrc} alt={src} />
 	{:else}
-		<img class="global-content-image" class:blur {src} alt={src} />
+		<img bind:this={imgElement} class="global-content-image" {src} alt={src} />
 	{/if}
 	{#if blur}
 		<button>{$_('content.show')}</button>
@@ -30,7 +44,9 @@
 </span>
 
 <style>
-	.img-wrapper :global(.global-content-image) {
+	.img-wrapper :global(.global-content-image),
+	.img-wrapper :global(.ff-canvas),
+	.img-wrapper img {
 		max-width: calc(100% - 1.5em);
 		max-height: 20em;
 		margin: 0.5em;
@@ -39,13 +55,18 @@
 		vertical-align: middle;
 	}
 
-	.img-wrapper :global(.global-content-image.blur),
-	img.blur {
+	.img-wrapper.blur :global(.global-content-image.blur),
+	.img-wrapper.blur :global(.ff-canvas),
+	.img-wrapper.blur img {
 		filter: blur(8px);
 	}
 
 	.img-wrapper {
 		position: relative;
+	}
+
+	.img-wrapper :global(.ff-container) {
+		display: inline-block;
 	}
 
 	button {

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -111,6 +111,7 @@
 		},
 		"auto_refresh": "Auto refresh",
 		"media_preview": "Media preview",
+		"autoplay_gif": "Auto-play GIF",
 		"image_optimization": "Image optimization",
 		"image_optimization_none": "None",
 		"media_uploader": {

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -110,6 +110,7 @@
 		},
 		"auto_refresh": "自動更新",
 		"media_preview": "メディアプレビュー",
+		"autoplay_gif": "GIF画像を自動再生",
 		"image_optimization": "画像最適化",
 		"image_optimization_none": "なし",
 		"media_uploader": {

--- a/web/src/lib/stores/Preference.ts
+++ b/web/src/lib/stores/Preference.ts
@@ -29,6 +29,10 @@ export const enablePreview = writable(
 	browser ? new WebStorage(localStorage).get('preference:preview') !== 'false' : true
 );
 
+export const enableAutoPlayGif = writable(
+	browser ? new WebStorage(localStorage).get('preference:autoplay-gif') !== 'false' : true
+);
+
 export const imageOptimization = writable(browser ? getImageOptimization() : '');
 
 function getImageOptimization(): string {

--- a/web/src/routes/(app)/preferences/+page.svelte
+++ b/web/src/routes/(app)/preferences/+page.svelte
@@ -16,6 +16,7 @@
 	import Theme from './Theme.svelte';
 	import UriScheme from './UriScheme.svelte';
 	import EnablePreview from './EnablePreview.svelte';
+	import EnableAutoPlayGif from './EnableAutoPlayGif.svelte';
 	import DeveloperMode from './DeveloperMode.svelte';
 	import WebStorage from './WebStorage.svelte';
 	import RelayStates from './RelayStates.svelte';
@@ -89,6 +90,7 @@
 	<div><Language /></div>
 	<div><AutoRefresh /></div>
 	<div><EnablePreview /></div>
+	<div><EnableAutoPlayGif /></div>
 	<div><ImageOptimization /></div>
 	<div><Notification /></div>
 	<div><UriScheme /></div>

--- a/web/src/routes/(app)/preferences/EnableAutoPlayGif.svelte
+++ b/web/src/routes/(app)/preferences/EnableAutoPlayGif.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { browser } from '$app/environment';
+	import { WebStorage } from '$lib/WebStorage';
+	import { enableAutoPlayGif } from '$lib/stores/Preference';
+
+	if (browser) {
+		enableAutoPlayGif.subscribe((value) => {
+			const storage = new WebStorage(localStorage);
+			storage.set('preference:autoplay-gif', JSON.stringify(value));
+		});
+	}
+</script>
+
+<label>
+	<input type="checkbox" bind:checked={$enableAutoPlayGif} />
+	<span>{$_('preferences.autoplay_gif')}</span>
+</label>


### PR DESCRIPTION
Issue: #1888 

## Overview
Introduced a new setting in the Preferences menu to toggle "Auto-play GIF". When this setting is disabled, GIF images in the timeline will display as static images by default and will only play when hovered over.

### KeyChanges
- Added an "Auto-play GIF" checkbox to the preferences page (default: true)
- When set to false, GIFs are paused using freezeframe.js and show an overlay icon. They will play only on mouse hover.

## Problem
- [x] [The CSS is applied differently in the stopped and playing states, causing a misalignment.](https://github.com/user-attachments/assets/6b2aad07-4570-43f6-b307-29f36c15554b)
- [x] Image overflow (side scroll-bar)
- [ ] Canvas element border is misalignment.
- [ ] Image(contains all image type) aspect ratio is incorrect (Firefox only issue)
- [ ] Border radius of canvas element is not applied.
- [ ] Image border attributes are overlapping.