### PR TITLE
Fix tablet layout overflow after embed previews load

### DIFF
--- a/web/src/lib/components/EventMetadata.svelte
+++ b/web/src/lib/components/EventMetadata.svelte
@@ -62,6 +62,7 @@
 		display: flex;
 		flex-direction: row;
 		gap: 12px;
+		min-width: 0;
 	}
 
 	.picture {
@@ -90,6 +91,7 @@
 		font-size: 15px;
 		font-weight: 400;
 		width: calc(100% - 60px);
+		min-width: 0;
 
 		/* Workaround for unnecessary space */
 		display: flex;
@@ -100,6 +102,7 @@
 		display: flex;
 		flex-direction: row;
 		gap: 0.3rem;
+		min-width: 0;
 	}
 
 	.display_name {

--- a/web/src/lib/components/content/Nicovideo.svelte
+++ b/web/src/lib/components/content/Nicovideo.svelte
@@ -23,4 +23,17 @@
 	});
 </script>
 
-<div bind:this={playerElement}></div>
+<div class="player" bind:this={playerElement}></div>
+
+<style>
+	.player {
+		width: 100%;
+		max-width: 100%;
+		overflow: hidden;
+	}
+
+	.player :global(iframe) {
+		display: block;
+		max-width: 100%;
+	}
+</style>

--- a/web/src/lib/components/content/Url.svelte
+++ b/web/src/lib/components/content/Url.svelte
@@ -65,7 +65,7 @@
 	<ExternalLink {link} />
 {:else if Twitter.isTweetUrl(link)}
 	{#if preview}
-		<div bind:this={twitterWidget}>
+		<div class="twitter-widget" bind:this={twitterWidget}>
 			<blockquote class="twitter-tweet">
 				<a
 					href={link.href.replace('x.com', 'twitter.com')}
@@ -130,3 +130,20 @@
 		<ExternalLink {link} />
 	{/await}
 {/if}
+
+<style>
+	.twitter-widget {
+		width: 100%;
+		max-width: 100%;
+		overflow: hidden;
+	}
+
+	.twitter-widget :global(.twitter-tweet),
+	.twitter-widget :global(iframe) {
+		max-width: 100%;
+	}
+
+	.twitter-widget :global(iframe) {
+		display: block;
+	}
+</style>

--- a/web/src/lib/components/content/YouTube.svelte
+++ b/web/src/lib/components/content/YouTube.svelte
@@ -49,12 +49,15 @@
 <style>
 	iframe {
 		width: 100%;
+		max-width: 100%;
+		display: block;
 		aspect-ratio: 640 / 360;
 	}
 
 	iframe.short {
 		height: 28rem;
-		width: 22rem;
+		width: min(22rem, 100%);
+		margin: 0 auto;
 	}
 
 	@media (max-width: 600px) {

--- a/web/src/lib/components/items/Note.svelte
+++ b/web/src/lib/components/items/Note.svelte
@@ -160,7 +160,17 @@
 
 	.content {
 		margin: 0.2rem 0 0 0;
+		min-width: 0;
 		overflow: auto;
+	}
+
+	.content :global(blockquote),
+	.content :global(iframe) {
+		max-width: 100%;
+	}
+
+	.content :global(iframe) {
+		display: block;
 	}
 
 	.content.shorten {

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -167,7 +167,7 @@
 		margin: 0 auto;
 		padding: 0 2.25rem;
 		display: grid;
-		grid-template-columns: 220px 598px;
+		grid-template-columns: 220px minmax(0, 598px);
 		gap: 2.25rem;
 	}
 
@@ -185,6 +185,7 @@
 		margin: 0 auto;
 		grid-column: 2 / 3;
 		max-width: 598px;
+		min-width: 0;
 		width: 100%;
 	}
 
@@ -201,7 +202,7 @@
 		.app {
 			max-width: calc(926px - (220px - 2.25rem));
 			gap: 1.5rem;
-			grid-template-columns: 3.125rem auto;
+			grid-template-columns: 3.125rem minmax(0, 1fr);
 		}
 
 		header {


### PR DESCRIPTION
## 概要
タブレット幅でノート詳細ページを開いたあと、embed プレビューの読み込み完了をきっかけにレイアウト全体が横方向へ広がり、ページに水平スクロールバーが出る問題を修正します。

再現報告として受けた URL:
`/nevent1qvzqqqqqqypzpq749dpk85k3h3dqnr08henuzg9lklqva680alvwkmjzxu40y35fqyv8wumn8ghj7mn0wd68ytnxv4jxjan9wfek2tn2wqqs6amnwvaz7tmev9382tndv5q32amnwvaz7tmnw3skw6twvuh8jctzw5hx6egpzamhxue69uhkummnw3ex2ctd9ehkx6rp9ehkuegpypmhxue69uhhyetvv9uj66ns9ehx7um5wgh8w6tjv4jxuet59e48qqgawaehxw309ah8yetvv9uj66ns9e3j6um5v4kxcctj9ehx2aqpp4mhxue69uhkummn9ekx7mqqyr2xh8jy0jrxljztrsz6n2hjkws0fect4gmrjqnjx4wz80hz7wkrweltek6`

## 原因
タブレット幅ではアプリ全体が 2 カラムの `grid` になっており、`main` カラム側が `auto` / 固定寄りの幅計算のままでした。
その状態で本文内の embed (`iframe` / external widget / generated blockquote) が実幅を持って描画されると、`grid` と `flex` の最小幅計算に引っ張られて `main` カラム自体が縮めなくなり、ページ全体が横方向へはみ出していました。

特に以下が重なっていました。
- レイアウトの 2 カラム目が `minmax(0, ...)` になっていない
- `EventMetadata` / `Note` 側の flex 子要素に `min-width: 0` がなく、本文が内容幅を保持しやすい
- Twitter / YouTube / Nicovideo の embed ラッパーや `iframe` に、親幅へ収めるための明示的な制約が不足している

## 変更内容
- `web/src/routes/(app)/+layout.svelte`
  - `grid-template-columns` を `minmax(0, ...)` ベースに変更
  - `main` に `min-width: 0` を追加して、タブレット幅でも 2 カラム目が縮められるように変更
- `web/src/lib/components/EventMetadata.svelte`
  - `article` / `.note` / `.user` に `min-width: 0` を追加
  - 本文やメタ情報が flex 最小幅計算で親を押し広げないように変更
- `web/src/lib/components/items/Note.svelte`
  - `.content` に `min-width: 0` を追加
  - 本文内の `blockquote` / `iframe` を `max-width: 100%` に制限
- `web/src/lib/components/content/Url.svelte`
  - Twitter widget 用ラッパーを追加し、`width: 100%` / `max-width: 100%` / `overflow: hidden` を適用
  - 生成される `iframe` も横にはみ出さないよう制限
- `web/src/lib/components/content/YouTube.svelte`
  - 通常動画の `iframe` に `max-width: 100%` と `display: block` を追加
  - Shorts 用の固定幅 `22rem` を `min(22rem, 100%)` に変更して、タブレット幅でも親幅を超えないように変更
- `web/src/lib/components/content/Nicovideo.svelte`
  - embed スクリプト挿入先をラップし、`width: 100%` / `max-width: 100%` / `overflow: hidden` を適用

## 期待される効果
- タブレット幅で embed 読み込み後にページ全体の横スクロールが出なくなる
- Twitter / YouTube / Nicovideo の埋め込みが本文カラム幅に収まる
- ノート詳細以外でも、同じ本文描画経路を使う画面で幅押し広げが起きにくくなる

## 確認内容
- `git diff --check`
- `npx prettier --check src/routes/'(app)'/+layout.svelte src/lib/components/EventMetadata.svelte src/lib/components/items/Note.svelte src/lib/components/content/Url.svelte src/lib/components/content/YouTube.svelte src/lib/components/content/Nicovideo.svelte`
- `npx eslint src/routes/'(app)'/+layout.svelte src/lib/components/EventMetadata.svelte src/lib/components/items/Note.svelte src/lib/components/content/Url.svelte src/lib/components/content/YouTube.svelte src/lib/components/content/Nicovideo.svelte`
  - `Nicovideo.svelte` の `svelte/no-dom-manipulating` warning は既存実装由来で、新規 warning ではありません

## 補足
- `npm run check` は実行しましたが、今回の変更とは別の既存 TypeScript エラーにより失敗しています
- 確認時点で見えている既存エラー:
  - `src/lib/server/Restriction.ts`
  - `src/lib/components/EmojiPicker.svelte`
  - `src/lib/components/Gdpr.svelte`
  - `src/routes/(app)/channels/[nevent=note]/+page.svelte`
  - `src/routes/(app)/relays/[url]/+page.svelte`

## レビュー観点
- タブレット幅で対象 URL を開き、embed 読み込み後に水平スクロールバーが消えているか
- YouTube Shorts / Twitter / Nicovideo の各埋め込みで、副作用なく縦横比と表示幅が維持されているか
- 既存のモバイル表示・デスクトップ表示にレイアウト崩れが出ていないか
