### PR TITLE
アニメーション画像の自動再生設定を追加

### DIFF
--- a/web/src/lib/components/Nip94.svelte
+++ b/web/src/lib/components/Nip94.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Event } from 'nostr-tools';
+	import Img from './content/Img.svelte';
 
 	interface Props {
 		event: Event;
@@ -19,18 +20,10 @@
 	);
 </script>
 
-{#if mimeType !== undefined && /image\/(gif|jpg|jpeg|png|webp|bmp)/.test(mimeType)}
+{#if url !== undefined && URL.canParse(url) && mimeType !== undefined && /image\/(avif|gif|jpg|jpeg|png|webp|bmp|apng)/.test(mimeType)}
 	<a href={url} target="_blank" rel="noopener noreferrer">
-		<img src={url} alt={event.content} />
+		<Img url={new URL(url)} {mimeType} />
 	</a>
-{:else}
+{:else if url !== undefined}
 	<a href={url} target="_blank" rel="noopener noreferrer">{url}</a>
 {/if}
-
-<style>
-	img {
-		max-width: 100%;
-		max-height: 20em;
-		margin: 0.5em;
-	}
-</style>

--- a/web/src/lib/components/content/FreezeframeImage.svelte
+++ b/web/src/lib/components/content/FreezeframeImage.svelte
@@ -1,0 +1,325 @@
+<script lang="ts">
+	interface Props {
+		src: string;
+		alt: string;
+		blur?: boolean;
+	}
+
+	let { src, alt, blur = false }: Props = $props();
+
+	let canvas: HTMLCanvasElement | undefined = $state();
+	let ready = $state(false);
+	let failed = $state(false);
+	let playing = $state(false);
+	let playerSrc: string | undefined = $state();
+	let drawToken = 0;
+	let pointerType = '';
+	let touchControl = $state(false);
+	let objectUrl: string | undefined;
+
+	function drawToCanvas(
+		element: HTMLCanvasElement,
+		image: CanvasImageSource,
+		width: number,
+		height: number
+	): void {
+		if (width === 0 || height === 0) {
+			throw new Error('Image has no dimensions.');
+		}
+
+		const context = element.getContext('2d');
+		if (context === null) {
+			throw new Error('Canvas 2D context is not available.');
+		}
+
+		element.width = width;
+		element.height = height;
+		context.clearRect(0, 0, width, height);
+		context.drawImage(image, 0, 0, width, height);
+	}
+
+	function setPlayerSrc(src: string | undefined) {
+		if (objectUrl !== undefined && objectUrl !== src) {
+			URL.revokeObjectURL(objectUrl);
+			objectUrl = undefined;
+		}
+
+		if (src?.startsWith('blob:')) {
+			objectUrl = src;
+		}
+
+		playerSrc = src;
+	}
+
+	async function drawBlobFrame(element: HTMLCanvasElement, imageSrc: string): Promise<string> {
+		const response = await fetch(imageSrc);
+		if (!response.ok) {
+			throw new Error(`Failed to fetch image: ${response.status}`);
+		}
+
+		const blob = await response.blob();
+		const url = URL.createObjectURL(blob);
+		try {
+			if (typeof createImageBitmap === 'function') {
+				const bitmap = await createImageBitmap(blob);
+				try {
+					drawToCanvas(element, bitmap, bitmap.width, bitmap.height);
+				} finally {
+					bitmap.close();
+				}
+			} else {
+				await drawImageElement(element, url);
+			}
+		} catch (error) {
+			URL.revokeObjectURL(url);
+			throw error;
+		}
+
+		return url;
+	}
+
+	async function drawImageElement(element: HTMLCanvasElement, imageSrc: string): Promise<void> {
+		await new Promise<void>((resolve, reject) => {
+			const image = new Image();
+			image.decoding = 'sync';
+			image.onload = () => {
+				try {
+					drawToCanvas(element, image, image.naturalWidth, image.naturalHeight);
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			};
+			image.onerror = () => {
+				reject(new Error('Failed to load image.'));
+			};
+			image.src = imageSrc;
+		});
+	}
+
+	async function drawStillFrame(element: HTMLCanvasElement, imageSrc: string, token: number) {
+		ready = false;
+		failed = false;
+		playing = false;
+		touchControl = false;
+		setPlayerSrc(undefined);
+
+		let nextPlayerSrc: string | undefined;
+		try {
+			nextPlayerSrc = await drawBlobFrame(element, imageSrc);
+		} catch {
+			await drawImageElement(element, imageSrc);
+			nextPlayerSrc = imageSrc;
+		}
+
+		if (token === drawToken) {
+			setPlayerSrc(nextPlayerSrc);
+			ready = true;
+		} else if (nextPlayerSrc?.startsWith('blob:')) {
+			URL.revokeObjectURL(nextPlayerSrc);
+		}
+	}
+
+	function play() {
+		if (ready && !failed) {
+			playing = true;
+		}
+	}
+
+	function stop() {
+		playing = false;
+	}
+
+	function toggle() {
+		if (ready && !failed) {
+			playing = !playing;
+		}
+	}
+
+	function pointerEnter(event: PointerEvent) {
+		if (event.pointerType === 'mouse') {
+			touchControl = false;
+			play();
+		}
+	}
+
+	function pointerLeave(event: PointerEvent) {
+		if (event.pointerType === 'mouse') {
+			stop();
+		}
+	}
+
+	function controlPointerDown(event: PointerEvent) {
+		pointerType = event.pointerType;
+		if (event.pointerType !== 'mouse') {
+			touchControl = true;
+		}
+	}
+
+	function controlClick(event: MouseEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		if (pointerType === 'mouse') {
+			touchControl = false;
+		}
+		toggle();
+	}
+
+	function controlKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			event.stopPropagation();
+			touchControl = true;
+			toggle();
+		}
+	}
+
+	$effect(() => {
+		const element = canvas;
+		const imageSrc = src;
+		if (element === undefined) {
+			return;
+		}
+
+		const token = ++drawToken;
+		drawStillFrame(element, imageSrc, token).catch((error) => {
+			if (token === drawToken) {
+				console.warn('[freezeframe image]', imageSrc, error);
+				failed = true;
+				ready = false;
+				playing = false;
+			}
+		});
+
+		return () => {
+			drawToken++;
+			setPlayerSrc(undefined);
+		};
+	});
+</script>
+
+<span
+	class="freezeframe-image"
+	onpointerenter={pointerEnter}
+	onpointerleave={pointerLeave}
+	role="group"
+	aria-label={alt}
+>
+	<canvas
+		class="global-content-image freezeframe-canvas"
+		class:blur
+		hidden={failed}
+		bind:this={canvas}
+		aria-hidden="true"
+	></canvas>
+	{#if failed}
+		<img class="global-content-image" class:blur {src} alt="" aria-hidden="true" />
+	{:else if playerSrc !== undefined}
+		<img
+			class="global-content-image freezeframe-player"
+			class:playing
+			class:blur
+			src={playerSrc}
+			alt=""
+			aria-hidden="true"
+		/>
+	{/if}
+	{#if ready && !failed && (!playing || touchControl)}
+		<span
+			class="freezeframe-control"
+			class:playing
+			onpointerdown={controlPointerDown}
+			onclick={controlClick}
+			onkeydown={controlKeydown}
+			role="button"
+			tabindex="0"
+			aria-label={playing ? 'Stop animation' : 'Play animation'}
+			aria-pressed={playing}
+		></span>
+	{/if}
+</span>
+
+<style>
+	.freezeframe-image {
+		position: relative;
+		display: inline-grid;
+		grid-template-areas: 'image';
+		max-width: 100%;
+		line-height: 0;
+		vertical-align: middle;
+	}
+
+	.freezeframe-canvas,
+	.freezeframe-player {
+		grid-area: image;
+	}
+
+	.freezeframe-canvas {
+		display: block;
+		box-sizing: border-box;
+		object-fit: contain;
+	}
+
+	.freezeframe-player {
+		display: block;
+		box-sizing: border-box;
+		object-fit: contain;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.freezeframe-image .freezeframe-player {
+		border-color: transparent;
+	}
+
+	.freezeframe-player.playing {
+		opacity: 1;
+	}
+
+	.freezeframe-control {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 3em;
+		height: 3em;
+		transform: translate(-50%, -50%);
+		border: 1px solid rgb(255 255 255 / 80%);
+		border-radius: 50%;
+		background: rgb(0 0 0 / 55%);
+		box-shadow: 0 2px 8px rgb(0 0 0 / 25%);
+		cursor: pointer;
+	}
+
+	.freezeframe-control::before {
+		position: absolute;
+		top: 50%;
+		left: 54%;
+		width: 0;
+		height: 0;
+		transform: translate(-50%, -50%);
+		border-top: 0.65em solid transparent;
+		border-bottom: 0.65em solid transparent;
+		border-left: 1em solid white;
+		content: '';
+	}
+
+	.freezeframe-control.playing::before,
+	.freezeframe-control.playing::after {
+		top: 50%;
+		width: 0.35em;
+		height: 1.25em;
+		transform: translateY(-50%);
+		border: 0;
+		background: white;
+	}
+
+	.freezeframe-control.playing::before {
+		left: 36%;
+	}
+
+	.freezeframe-control.playing::after {
+		position: absolute;
+		left: 56%;
+		content: '';
+	}
+</style>

--- a/web/src/lib/components/content/FreezeframeImage.svelte
+++ b/web/src/lib/components/content/FreezeframeImage.svelte
@@ -25,6 +25,7 @@
 >
 	<canvas
 		class="global-content-image freezeframe-canvas"
+		class:playing={freezeframe.playing}
 		class:blur
 		hidden={freezeframe.failed}
 		bind:this={canvas}
@@ -78,6 +79,10 @@
 		object-fit: contain;
 	}
 
+	.freezeframe-canvas.playing {
+		opacity: 0;
+	}
+
 	.freezeframe-player {
 		display: block;
 		box-sizing: border-box;
@@ -92,6 +97,10 @@
 
 	.freezeframe-player.playing {
 		opacity: 1;
+	}
+
+	.freezeframe-image .freezeframe-player.playing {
+		border-color: lightgray;
 	}
 
 	.freezeframe-control {

--- a/web/src/lib/components/content/FreezeframeImage.svelte
+++ b/web/src/lib/components/content/FreezeframeImage.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { createFreezeframeImageState } from '$lib/media/FreezeframeImageState.svelte';
+
 	interface Props {
 		src: string;
 		alt: string;
@@ -8,233 +10,49 @@
 	let { src, alt, blur = false }: Props = $props();
 
 	let canvas: HTMLCanvasElement | undefined = $state();
-	let ready = $state(false);
-	let failed = $state(false);
-	let playing = $state(false);
-	let playerSrc: string | undefined = $state();
-	let drawToken = 0;
-	let pointerType = '';
-	let touchControl = $state(false);
-	let objectUrl: string | undefined;
-
-	function drawToCanvas(
-		element: HTMLCanvasElement,
-		image: CanvasImageSource,
-		width: number,
-		height: number
-	): void {
-		if (width === 0 || height === 0) {
-			throw new Error('Image has no dimensions.');
-		}
-
-		const context = element.getContext('2d');
-		if (context === null) {
-			throw new Error('Canvas 2D context is not available.');
-		}
-
-		element.width = width;
-		element.height = height;
-		context.clearRect(0, 0, width, height);
-		context.drawImage(image, 0, 0, width, height);
-	}
-
-	function setPlayerSrc(src: string | undefined) {
-		if (objectUrl !== undefined && objectUrl !== src) {
-			URL.revokeObjectURL(objectUrl);
-			objectUrl = undefined;
-		}
-
-		if (src?.startsWith('blob:')) {
-			objectUrl = src;
-		}
-
-		playerSrc = src;
-	}
-
-	async function drawBlobFrame(element: HTMLCanvasElement, imageSrc: string): Promise<string> {
-		const response = await fetch(imageSrc);
-		if (!response.ok) {
-			throw new Error(`Failed to fetch image: ${response.status}`);
-		}
-
-		const blob = await response.blob();
-		const url = URL.createObjectURL(blob);
-		try {
-			if (typeof createImageBitmap === 'function') {
-				const bitmap = await createImageBitmap(blob);
-				try {
-					drawToCanvas(element, bitmap, bitmap.width, bitmap.height);
-				} finally {
-					bitmap.close();
-				}
-			} else {
-				await drawImageElement(element, url);
-			}
-		} catch (error) {
-			URL.revokeObjectURL(url);
-			throw error;
-		}
-
-		return url;
-	}
-
-	async function drawImageElement(element: HTMLCanvasElement, imageSrc: string): Promise<void> {
-		await new Promise<void>((resolve, reject) => {
-			const image = new Image();
-			image.decoding = 'sync';
-			image.onload = () => {
-				try {
-					drawToCanvas(element, image, image.naturalWidth, image.naturalHeight);
-					resolve();
-				} catch (error) {
-					reject(error);
-				}
-			};
-			image.onerror = () => {
-				reject(new Error('Failed to load image.'));
-			};
-			image.src = imageSrc;
-		});
-	}
-
-	async function drawStillFrame(element: HTMLCanvasElement, imageSrc: string, token: number) {
-		ready = false;
-		failed = false;
-		playing = false;
-		touchControl = false;
-		setPlayerSrc(undefined);
-
-		let nextPlayerSrc: string | undefined;
-		try {
-			nextPlayerSrc = await drawBlobFrame(element, imageSrc);
-		} catch {
-			await drawImageElement(element, imageSrc);
-			nextPlayerSrc = imageSrc;
-		}
-
-		if (token === drawToken) {
-			setPlayerSrc(nextPlayerSrc);
-			ready = true;
-		} else if (nextPlayerSrc?.startsWith('blob:')) {
-			URL.revokeObjectURL(nextPlayerSrc);
-		}
-	}
-
-	function play() {
-		if (ready && !failed) {
-			playing = true;
-		}
-	}
-
-	function stop() {
-		playing = false;
-	}
-
-	function toggle() {
-		if (ready && !failed) {
-			playing = !playing;
-		}
-	}
-
-	function pointerEnter(event: PointerEvent) {
-		if (event.pointerType === 'mouse') {
-			touchControl = false;
-			play();
-		}
-	}
-
-	function pointerLeave(event: PointerEvent) {
-		if (event.pointerType === 'mouse') {
-			stop();
-		}
-	}
-
-	function controlPointerDown(event: PointerEvent) {
-		pointerType = event.pointerType;
-		if (event.pointerType !== 'mouse') {
-			touchControl = true;
-		}
-	}
-
-	function controlClick(event: MouseEvent) {
-		event.preventDefault();
-		event.stopPropagation();
-		if (pointerType === 'mouse') {
-			touchControl = false;
-		}
-		toggle();
-	}
-
-	function controlKeydown(event: KeyboardEvent) {
-		if (event.key === 'Enter' || event.key === ' ') {
-			event.preventDefault();
-			event.stopPropagation();
-			touchControl = true;
-			toggle();
-		}
-	}
-
-	$effect(() => {
-		const element = canvas;
-		const imageSrc = src;
-		if (element === undefined) {
-			return;
-		}
-
-		const token = ++drawToken;
-		drawStillFrame(element, imageSrc, token).catch((error) => {
-			if (token === drawToken) {
-				console.warn('[freezeframe image]', imageSrc, error);
-				failed = true;
-				ready = false;
-				playing = false;
-			}
-		});
-
-		return () => {
-			drawToken++;
-			setPlayerSrc(undefined);
-		};
+	const freezeframe = createFreezeframeImageState({
+		canvas: () => canvas,
+		src: () => src
 	});
 </script>
 
 <span
 	class="freezeframe-image"
-	onpointerenter={pointerEnter}
-	onpointerleave={pointerLeave}
+	onpointerenter={freezeframe.pointerEnter}
+	onpointerleave={freezeframe.pointerLeave}
 	role="group"
 	aria-label={alt}
 >
 	<canvas
 		class="global-content-image freezeframe-canvas"
 		class:blur
-		hidden={failed}
+		hidden={freezeframe.failed}
 		bind:this={canvas}
 		aria-hidden="true"
 	></canvas>
-	{#if failed}
+	{#if freezeframe.failed}
 		<img class="global-content-image" class:blur {src} alt="" aria-hidden="true" />
-	{:else if playerSrc !== undefined}
+	{:else if freezeframe.playerSrc !== undefined}
 		<img
 			class="global-content-image freezeframe-player"
-			class:playing
+			class:playing={freezeframe.playing}
 			class:blur
-			src={playerSrc}
+			src={freezeframe.playerSrc}
 			alt=""
 			aria-hidden="true"
 		/>
 	{/if}
-	{#if ready && !failed && (!playing || touchControl)}
+	{#if freezeframe.ready && !freezeframe.failed && (!freezeframe.playing || freezeframe.touchControl)}
 		<span
 			class="freezeframe-control"
-			class:playing
-			onpointerdown={controlPointerDown}
-			onclick={controlClick}
-			onkeydown={controlKeydown}
+			class:playing={freezeframe.playing}
+			onpointerdown={freezeframe.controlPointerDown}
+			onclick={freezeframe.controlClick}
+			onkeydown={freezeframe.controlKeydown}
 			role="button"
 			tabindex="0"
-			aria-label={playing ? 'Stop animation' : 'Play animation'}
-			aria-pressed={playing}
+			aria-label={freezeframe.playing ? 'Stop animation' : 'Play animation'}
+			aria-pressed={freezeframe.playing}
 		></span>
 	{/if}
 </span>

--- a/web/src/lib/components/content/Imeta.svelte
+++ b/web/src/lib/components/content/Imeta.svelte
@@ -10,8 +10,9 @@
 	let url = $derived(
 		tag.find((entry) => entry.startsWith('url '))?.substring('url '.length) ?? ''
 	);
+	let mimeType = $derived(tag.find((entry) => entry.startsWith('m '))?.substring('m '.length));
 </script>
 
 {#if URL.canParse(url)}
-	<Img url={new URL(url)} />
+	<Img url={new URL(url)} {mimeType} />
 {/if}

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -1,18 +1,28 @@
 <script lang="ts">
 	import { followees } from '$lib/stores/Author';
-	import { imageOptimization } from '$lib/stores/Preference';
+	import { enableAutoPlayAnimatedImages, imageOptimization } from '$lib/stores/Preference';
 	import type { Event } from 'nostr-typedef';
 	import { getContext } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import { Img, type ImgSrc } from 'svelte-remote-image';
+	import FreezeframeImage from './FreezeframeImage.svelte';
 
 	interface Props {
 		url: URL;
+		mimeType?: string | null;
 	}
 
-	let { url }: Props = $props();
+	let { url, mimeType = undefined }: Props = $props();
 
 	const { href: src, pathname } = $derived(url);
+	const normalizedMimeType = $derived(mimeType?.split(';', 1)[0]?.trim().toLowerCase());
+	const animatedImageMimeType = $derived(
+		normalizedMimeType === 'image/gif' ||
+			normalizedMimeType === 'image/webp' ||
+			normalizedMimeType === 'image/apng'
+	);
+	const animatedImagePath = $derived(/\.(gif|webp|apng)$/i.test(pathname));
+	const animatedImage = $derived(animatedImageMimeType || animatedImagePath);
 	const events = getContext<Event[] | undefined>('events');
 	const blur = events !== undefined && !events.some((event) => $followees.includes(event.pubkey));
 
@@ -23,7 +33,9 @@
 </script>
 
 <span class="img-wrapper">
-	{#if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
+	{#if !$enableAutoPlayAnimatedImages && animatedImage}
+		<FreezeframeImage {src} alt={src} {blur} />
+	{:else if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
 		<Img class="global-content-image{blur ? ' blur' : ''}" src={imageSrc} alt={src} />
 	{:else}
 		<img class="global-content-image" class:blur {src} alt={src} />
@@ -40,6 +52,7 @@
 		margin: 0.5em;
 		border: 1px solid lightgray;
 		border-radius: 5px;
+		box-sizing: border-box;
 		vertical-align: middle;
 	}
 

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { getAnimatedImageType } from '$lib/media/AnimatedImage';
+	import { createAnimatedImageState } from '$lib/media/AnimatedImageState.svelte';
 	import { followees } from '$lib/stores/Author';
 	import { enableAutoPlayAnimatedImages, imageOptimization } from '$lib/stores/Preference';
 	import type { Event } from 'nostr-typedef';
@@ -15,14 +17,12 @@
 	let { url, mimeType = undefined }: Props = $props();
 
 	const { href: src, pathname } = $derived(url);
-	const normalizedMimeType = $derived(mimeType?.split(';', 1)[0]?.trim().toLowerCase());
-	const animatedImageMimeType = $derived(
-		normalizedMimeType === 'image/gif' ||
-			normalizedMimeType === 'image/webp' ||
-			normalizedMimeType === 'image/apng'
-	);
-	const animatedImagePath = $derived(/\.(gif|webp|apng)$/i.test(pathname));
-	const animatedImage = $derived(animatedImageMimeType || animatedImagePath);
+	const animatedImageType = $derived(getAnimatedImageType(mimeType, pathname));
+	const animatedImage = createAnimatedImageState({
+		src: () => src,
+		type: () => animatedImageType,
+		autoPlay: () => $enableAutoPlayAnimatedImages
+	});
 	const events = getContext<Event[] | undefined>('events');
 	const blur = events !== undefined && !events.some((event) => $followees.includes(event.pubkey));
 
@@ -33,8 +33,10 @@
 </script>
 
 <span class="img-wrapper">
-	{#if !$enableAutoPlayAnimatedImages && animatedImage}
+	{#if !$enableAutoPlayAnimatedImages && animatedImage.animated}
 		<FreezeframeImage {src} alt={src} {blur} />
+	{:else if !$enableAutoPlayAnimatedImages && animatedImage.checking}
+		<span class="global-content-image animated-image-checking"></span>
 	{:else if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
 		<Img class="global-content-image{blur ? ' blur' : ''}" src={imageSrc} alt={src} />
 	{:else}
@@ -54,6 +56,13 @@
 		border-radius: 5px;
 		box-sizing: border-box;
 		vertical-align: middle;
+	}
+
+	.img-wrapper :global(.global-content-image.animated-image-checking) {
+		display: inline-block;
+		width: min(16em, calc(100% - 1.5em));
+		height: 10em;
+		background: var(--accent-surface-low);
 	}
 
 	.img-wrapper :global(.global-content-image.blur),

--- a/web/src/lib/components/content/Url.svelte
+++ b/web/src/lib/components/content/Url.svelte
@@ -100,7 +100,7 @@
 			{#if preview}
 				<div>
 					<a href={link.href} target="_blank" rel="noopener noreferrer">
-						<Img url={link} />
+						<Img url={link} mimeType={contentType} />
 					</a>
 				</div>
 			{:else}

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -120,6 +120,7 @@
 		},
 		"auto_refresh": "Auto refresh",
 		"media_preview": "Media preview",
+		"autoplay_animated_images": "Auto-play animated images",
 		"image_optimization": "Image size reduction",
 		"image_optimization_none": "None",
 		"media_uploader": {

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -119,6 +119,7 @@
 		},
 		"auto_refresh": "自動更新",
 		"media_preview": "メディアプレビュー",
+		"autoplay_animated_images": "アニメーション画像を自動再生",
 		"image_optimization": "画像軽量化",
 		"image_optimization_none": "なし",
 		"media_uploader": {

--- a/web/src/lib/media/AnimatedImage.ts
+++ b/web/src/lib/media/AnimatedImage.ts
@@ -1,0 +1,361 @@
+export type AnimatedImageType = 'gif' | 'png' | 'webp' | 'avif';
+
+type ImageDecoderTrack = {
+	animated?: boolean;
+	frameCount?: number;
+};
+
+type ImageDecoderTrackList = {
+	ready: Promise<ImageDecoderTrackList>;
+	selectedTrack?: ImageDecoderTrack;
+};
+
+type ImageDecoderInstance = {
+	close(): void;
+	tracks: ImageDecoderTrackList;
+};
+
+type ImageDecoderConstructor = {
+	new (init: { data: ArrayBuffer; type: string }): ImageDecoderInstance;
+	isTypeSupported?: (type: string) => Promise<boolean>;
+};
+
+const animatedImageCache = new Map<string, Promise<boolean>>();
+const gifSignature = [0x47, 0x49, 0x46, 0x38];
+const pngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const webpSignature = [0x52, 0x49, 0x46, 0x46];
+
+export function getAnimatedImageType(
+	mimeType: string | null | undefined,
+	pathname: string
+): AnimatedImageType | undefined {
+	const normalizedMimeType = mimeType?.split(';', 1)[0]?.trim().toLowerCase();
+	if (normalizedMimeType === 'image/gif' || /\.gif$/i.test(pathname)) {
+		return 'gif';
+	}
+	if (
+		normalizedMimeType === 'image/png' ||
+		normalizedMimeType === 'image/apng' ||
+		/\.(apng|png)$/i.test(pathname)
+	) {
+		return 'png';
+	}
+	if (normalizedMimeType === 'image/webp' || /\.webp$/i.test(pathname)) {
+		return 'webp';
+	}
+	if (normalizedMimeType === 'image/avif' || /\.avif$/i.test(pathname)) {
+		return 'avif';
+	}
+
+	return undefined;
+}
+
+export function detectAnimatedImage(src: string, type: AnimatedImageType): Promise<boolean> {
+	const cacheKey = `${type}:${src}`;
+	const cached = animatedImageCache.get(cacheKey);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const promise = detectAnimatedImageUncached(src, type);
+	animatedImageCache.set(cacheKey, promise);
+	return promise;
+}
+
+function getAscii(bytes: Uint8Array, offset: number, length: number): string {
+	if (offset + length > bytes.length) {
+		return '';
+	}
+
+	return String.fromCharCode(...bytes.slice(offset, offset + length));
+}
+
+function isBytes(bytes: Uint8Array, offset: number, expected: number[]): boolean {
+	return expected.every((byte, index) => bytes[offset + index] === byte);
+}
+
+function getImageDecoderType(type: AnimatedImageType): string {
+	switch (type) {
+		case 'gif':
+			return 'image/gif';
+		case 'png':
+			return 'image/png';
+		case 'webp':
+			return 'image/webp';
+		case 'avif':
+			return 'image/avif';
+	}
+}
+
+function getImageDecoder(): ImageDecoderConstructor | undefined {
+	return (globalThis as typeof globalThis & { ImageDecoder?: ImageDecoderConstructor })
+		.ImageDecoder;
+}
+
+async function canUseImageDecoder(type: AnimatedImageType): Promise<boolean> {
+	const decoder = getImageDecoder();
+	if (decoder === undefined) {
+		return false;
+	}
+	if (decoder.isTypeSupported === undefined) {
+		return true;
+	}
+
+	try {
+		return await decoder.isTypeSupported(getImageDecoderType(type));
+	} catch {
+		return false;
+	}
+}
+
+async function detectWithImageDecoder(
+	buffer: ArrayBuffer,
+	type: AnimatedImageType
+): Promise<boolean | undefined> {
+	const Decoder = getImageDecoder();
+	if (Decoder === undefined) {
+		return undefined;
+	}
+
+	const decoder = new Decoder({
+		data: buffer.slice(0),
+		type: getImageDecoderType(type)
+	});
+	try {
+		const tracks = await decoder.tracks.ready;
+		const track = tracks.selectedTrack;
+		if (track === undefined) {
+			return undefined;
+		}
+
+		return track.animated === true || (track.frameCount ?? 1) > 1;
+	} finally {
+		decoder.close();
+	}
+}
+
+function skipGifSubBlocks(bytes: Uint8Array, offset: number): number | undefined {
+	while (offset < bytes.length) {
+		const length = bytes[offset];
+		offset += 1;
+		if (length === 0) {
+			return offset;
+		}
+		offset += length;
+	}
+
+	return undefined;
+}
+
+function parseAnimatedGif(buffer: ArrayBuffer): boolean | undefined {
+	const bytes = new Uint8Array(buffer);
+	if (!isBytes(bytes, 0, gifSignature) || bytes.length < 13) {
+		return false;
+	}
+
+	let offset = 13;
+	const packed = bytes[10];
+	if ((packed & 0x80) !== 0) {
+		offset += 3 * 2 ** ((packed & 0x07) + 1);
+	}
+
+	let frames = 0;
+	while (offset < bytes.length) {
+		const introducer = bytes[offset];
+		if (introducer === 0x3b) {
+			return frames > 1;
+		}
+		if (introducer === 0x21) {
+			const nextOffset = skipGifSubBlocks(bytes, offset + 2);
+			if (nextOffset === undefined) {
+				return undefined;
+			}
+			offset = nextOffset;
+			continue;
+		}
+		if (introducer !== 0x2c) {
+			return false;
+		}
+		if (offset + 10 > bytes.length) {
+			return undefined;
+		}
+
+		frames += 1;
+		if (frames > 1) {
+			return true;
+		}
+
+		const imagePacked = bytes[offset + 9];
+		offset += 10;
+		if ((imagePacked & 0x80) !== 0) {
+			offset += 3 * 2 ** ((imagePacked & 0x07) + 1);
+		}
+		if (offset >= bytes.length) {
+			return undefined;
+		}
+
+		offset = skipGifSubBlocks(bytes, offset + 1) ?? bytes.length;
+		if (offset === bytes.length) {
+			return undefined;
+		}
+	}
+
+	return undefined;
+}
+
+function parseAnimatedPng(buffer: ArrayBuffer): boolean | undefined {
+	const bytes = new Uint8Array(buffer);
+	if (!isBytes(bytes, 0, pngSignature)) {
+		return false;
+	}
+
+	const view = new DataView(buffer);
+	let offset = pngSignature.length;
+	while (offset + 12 <= bytes.length) {
+		const length = view.getUint32(offset);
+		const type = getAscii(bytes, offset + 4, 4);
+		const nextOffset = offset + 12 + length;
+
+		if (nextOffset > bytes.length) {
+			return undefined;
+		}
+		if (type === 'acTL') {
+			return true;
+		}
+		if (type === 'IDAT' || type === 'IEND') {
+			return false;
+		}
+
+		offset = nextOffset;
+	}
+
+	return undefined;
+}
+
+function parseAnimatedWebp(buffer: ArrayBuffer): boolean | undefined {
+	const bytes = new Uint8Array(buffer);
+	if (!isBytes(bytes, 0, webpSignature) || getAscii(bytes, 8, 4) !== 'WEBP') {
+		return false;
+	}
+
+	const view = new DataView(buffer);
+	let offset = 12;
+	while (offset + 8 <= bytes.length) {
+		const type = getAscii(bytes, offset, 4);
+		const length = view.getUint32(offset + 4, true);
+		const dataOffset = offset + 8;
+		const nextOffset = dataOffset + length + (length % 2);
+
+		if (nextOffset > bytes.length) {
+			return undefined;
+		}
+		if (type === 'ANIM' || type === 'ANMF') {
+			return true;
+		}
+		if (type === 'VP8X' && length > 0 && (bytes[dataOffset] & 0x02) !== 0) {
+			return true;
+		}
+
+		offset = nextOffset;
+	}
+
+	return false;
+}
+
+function parseAnimatedAvif(buffer: ArrayBuffer): boolean | undefined {
+	const bytes = new Uint8Array(buffer);
+	if (bytes.length < 16) {
+		return undefined;
+	}
+
+	const view = new DataView(buffer);
+	let offset = 0;
+	while (offset + 8 <= bytes.length) {
+		const size = view.getUint32(offset);
+		const type = getAscii(bytes, offset + 4, 4);
+		if (size < 8 || offset + size > bytes.length) {
+			return undefined;
+		}
+		if (type !== 'ftyp') {
+			offset += size;
+			continue;
+		}
+
+		if (getAscii(bytes, offset + 8, 4) === 'avis') {
+			return true;
+		}
+		for (let brandOffset = offset + 16; brandOffset + 4 <= offset + size; brandOffset += 4) {
+			if (getAscii(bytes, brandOffset, 4) === 'avis') {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	return undefined;
+}
+
+function parseAnimatedImage(buffer: ArrayBuffer, type: AnimatedImageType): boolean | undefined {
+	switch (type) {
+		case 'gif':
+			return parseAnimatedGif(buffer);
+		case 'png':
+			return parseAnimatedPng(buffer);
+		case 'webp':
+			return parseAnimatedWebp(buffer);
+		case 'avif':
+			return parseAnimatedAvif(buffer);
+	}
+}
+
+async function fetchImageBytes(src: string, headers?: HeadersInit): Promise<ArrayBuffer> {
+	const response = await fetch(src, { headers });
+	if (!response.ok) {
+		throw new Error(`Failed to fetch image bytes: ${response.status}`);
+	}
+
+	return await response.arrayBuffer();
+}
+
+async function detectAnimatedImageUncached(src: string, type: AnimatedImageType): Promise<boolean> {
+	if (await canUseImageDecoder(type)) {
+		let buffer: ArrayBuffer;
+		try {
+			buffer = await fetchImageBytes(src);
+		} catch {
+			return true;
+		}
+
+		try {
+			const decoded = await detectWithImageDecoder(buffer, type);
+			if (decoded !== undefined) {
+				return decoded;
+			}
+		} catch {
+			// Fall back to container scanning when ImageDecoder cannot inspect the image.
+		}
+
+		return parseAnimatedImage(buffer, type) === true;
+	}
+
+	try {
+		const partial = parseAnimatedImage(
+			await fetchImageBytes(src, {
+				Range: 'bytes=0-262143'
+			}),
+			type
+		);
+		if (partial !== undefined) {
+			return partial;
+		}
+	} catch {
+		return true;
+	}
+
+	try {
+		return parseAnimatedImage(await fetchImageBytes(src), type) === true;
+	} catch {
+		return true;
+	}
+}

--- a/web/src/lib/media/AnimatedImageState.svelte.ts
+++ b/web/src/lib/media/AnimatedImageState.svelte.ts
@@ -1,0 +1,56 @@
+import { detectAnimatedImage, type AnimatedImageType } from './AnimatedImage';
+
+type AnimatedImageStateOptions = {
+	src: () => string;
+	type: () => AnimatedImageType | undefined;
+	autoPlay: () => boolean;
+};
+
+type AnimatedImageState = {
+	animated: boolean;
+	checking: boolean;
+};
+
+export function createAnimatedImageState(options: AnimatedImageStateOptions): AnimatedImageState {
+	const state = $state({
+		animated: false,
+		checking: false
+	});
+
+	$effect(() => {
+		const src = options.src();
+		const type = options.type();
+		if (options.autoPlay() || type === undefined) {
+			state.animated = false;
+			state.checking = false;
+			return;
+		}
+
+		let cancelled = false;
+		state.animated = false;
+		state.checking = true;
+		detectAnimatedImage(src, type)
+			.then((animated) => {
+				if (!cancelled) {
+					state.animated = animated;
+				}
+			})
+			.catch((error) => {
+				if (!cancelled) {
+					console.warn('[detect animated image]', src, error);
+					state.animated = true;
+				}
+			})
+			.finally(() => {
+				if (!cancelled) {
+					state.checking = false;
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	return state;
+}

--- a/web/src/lib/media/FreezeframeImage.ts
+++ b/web/src/lib/media/FreezeframeImage.ts
@@ -1,0 +1,81 @@
+function drawToCanvas(
+	element: HTMLCanvasElement,
+	image: CanvasImageSource,
+	width: number,
+	height: number
+): void {
+	if (width === 0 || height === 0) {
+		throw new Error('Image has no dimensions.');
+	}
+
+	const context = element.getContext('2d');
+	if (context === null) {
+		throw new Error('Canvas 2D context is not available.');
+	}
+
+	element.width = width;
+	element.height = height;
+	context.clearRect(0, 0, width, height);
+	context.drawImage(image, 0, 0, width, height);
+}
+
+async function drawImageElement(element: HTMLCanvasElement, src: string): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		const image = new Image();
+		image.decoding = 'sync';
+		image.onload = () => {
+			try {
+				drawToCanvas(element, image, image.naturalWidth, image.naturalHeight);
+				resolve();
+			} catch (error) {
+				reject(error);
+			}
+		};
+		image.onerror = () => {
+			reject(new Error('Failed to load image.'));
+		};
+		image.src = src;
+	});
+}
+
+async function drawBlobFrame(element: HTMLCanvasElement, src: string): Promise<string> {
+	const response = await fetch(src);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch image: ${response.status}`);
+	}
+
+	const blob = await response.blob();
+	const url = URL.createObjectURL(blob);
+	try {
+		if (typeof createImageBitmap === 'function') {
+			const bitmap = await createImageBitmap(blob);
+			try {
+				drawToCanvas(element, bitmap, bitmap.width, bitmap.height);
+			} finally {
+				bitmap.close();
+			}
+		} else {
+			await drawImageElement(element, url);
+		}
+	} catch (error) {
+		URL.revokeObjectURL(url);
+		throw error;
+	}
+
+	return url;
+}
+
+export function revokeObjectImageSrc(src: string | undefined): void {
+	if (src?.startsWith('blob:')) {
+		URL.revokeObjectURL(src);
+	}
+}
+
+export async function drawStillFrame(element: HTMLCanvasElement, src: string): Promise<string> {
+	try {
+		return await drawBlobFrame(element, src);
+	} catch {
+		await drawImageElement(element, src);
+		return src;
+	}
+}

--- a/web/src/lib/media/FreezeframeImageState.svelte.ts
+++ b/web/src/lib/media/FreezeframeImageState.svelte.ts
@@ -1,0 +1,156 @@
+import { drawStillFrame, revokeObjectImageSrc } from './FreezeframeImage';
+
+type FreezeframeImageStateOptions = {
+	canvas: () => HTMLCanvasElement | undefined;
+	src: () => string;
+};
+
+type FreezeframeImageState = {
+	ready: boolean;
+	failed: boolean;
+	playing: boolean;
+	playerSrc: string | undefined;
+	touchControl: boolean;
+	pointerEnter(event: PointerEvent): void;
+	pointerLeave(event: PointerEvent): void;
+	controlPointerDown(event: PointerEvent): void;
+	controlClick(event: MouseEvent): void;
+	controlKeydown(event: KeyboardEvent): void;
+};
+
+export function createFreezeframeImageState(
+	options: FreezeframeImageStateOptions
+): FreezeframeImageState {
+	let drawToken = 0;
+	let pointerType = '';
+	let objectUrl: string | undefined;
+
+	const state = $state<FreezeframeImageState>({
+		ready: false,
+		failed: false,
+		playing: false,
+		playerSrc: undefined,
+		touchControl: false,
+		pointerEnter,
+		pointerLeave,
+		controlPointerDown,
+		controlClick,
+		controlKeydown
+	});
+
+	function setPlayerSrc(src: string | undefined): void {
+		if (objectUrl !== undefined && objectUrl !== src) {
+			revokeObjectImageSrc(objectUrl);
+			objectUrl = undefined;
+		}
+
+		if (src?.startsWith('blob:')) {
+			objectUrl = src;
+		}
+
+		state.playerSrc = src;
+	}
+
+	function reset(): void {
+		state.ready = false;
+		state.failed = false;
+		state.playing = false;
+		state.touchControl = false;
+		setPlayerSrc(undefined);
+	}
+
+	async function loadStillFrame(
+		element: HTMLCanvasElement,
+		src: string,
+		token: number
+	): Promise<void> {
+		reset();
+
+		const nextPlayerSrc = await drawStillFrame(element, src);
+		if (token === drawToken) {
+			setPlayerSrc(nextPlayerSrc);
+			state.ready = true;
+		} else {
+			revokeObjectImageSrc(nextPlayerSrc);
+		}
+	}
+
+	function play(): void {
+		if (state.ready && !state.failed) {
+			state.playing = true;
+		}
+	}
+
+	function stop(): void {
+		state.playing = false;
+	}
+
+	function toggle(): void {
+		if (state.ready && !state.failed) {
+			state.playing = !state.playing;
+		}
+	}
+
+	function pointerEnter(event: PointerEvent): void {
+		if (event.pointerType === 'mouse') {
+			state.touchControl = false;
+			play();
+		}
+	}
+
+	function pointerLeave(event: PointerEvent): void {
+		if (event.pointerType === 'mouse') {
+			stop();
+		}
+	}
+
+	function controlPointerDown(event: PointerEvent): void {
+		pointerType = event.pointerType;
+		if (event.pointerType !== 'mouse') {
+			state.touchControl = true;
+		}
+	}
+
+	function controlClick(event: MouseEvent): void {
+		event.preventDefault();
+		event.stopPropagation();
+		if (pointerType === 'mouse') {
+			state.touchControl = false;
+		}
+		toggle();
+	}
+
+	function controlKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			event.stopPropagation();
+			state.touchControl = true;
+			toggle();
+		}
+	}
+
+	$effect(() => {
+		const element = options.canvas();
+		const src = options.src();
+		if (element === undefined) {
+			return;
+		}
+
+		const token = ++drawToken;
+		loadStillFrame(element, src, token).catch((error) => {
+			if (token === drawToken) {
+				console.warn('[freezeframe image]', src, error);
+				state.failed = true;
+				state.ready = false;
+				state.playing = false;
+			}
+		});
+
+		return () => {
+			drawToken++;
+			setPlayerSrc(undefined);
+		};
+	});
+
+	return state;
+}

--- a/web/src/lib/stores/Preference.ts
+++ b/web/src/lib/stores/Preference.ts
@@ -29,7 +29,16 @@ export const enablePreview = writable(
 	browser ? new WebStorage(localStorage).get('preference:preview') !== 'false' : true
 );
 
+export const enableAutoPlayAnimatedImages = writable(
+	browser ? getEnableAutoPlayAnimatedImages() : true
+);
+
 export const imageOptimization = writable(browser ? getImageOptimization() : '');
+
+function getEnableAutoPlayAnimatedImages(): boolean {
+	const storage = new WebStorage(localStorage);
+	return storage.get('preference:autoplay-animated-images') !== 'false';
+}
 
 function getImageOptimization(): string {
 	const value = new WebStorage(localStorage).get('preference:image-optimization') ?? '';

--- a/web/src/routes/(app)/preferences/+page.svelte
+++ b/web/src/routes/(app)/preferences/+page.svelte
@@ -16,6 +16,7 @@
 	import Theme from './Theme.svelte';
 	import UriScheme from './UriScheme.svelte';
 	import EnablePreview from './EnablePreview.svelte';
+	import EnableAutoPlayAnimatedImages from './EnableAutoPlayAnimatedImages.svelte';
 	import DeveloperMode from './DeveloperMode.svelte';
 	import WebStorage from './WebStorage.svelte';
 	import RelayStates from './RelayStates.svelte';
@@ -92,6 +93,7 @@
 	<div><Language /></div>
 	<div><AutoRefresh /></div>
 	<div><EnablePreview /></div>
+	<div><EnableAutoPlayAnimatedImages /></div>
 	<div><NotificationVisibility /></div>
 	<div><ImageOptimization /></div>
 	<div><Notification /></div>

--- a/web/src/routes/(app)/preferences/EnableAutoPlayAnimatedImages.svelte
+++ b/web/src/routes/(app)/preferences/EnableAutoPlayAnimatedImages.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { WebStorage } from '$lib/WebStorage';
+	import { enableAutoPlayAnimatedImages } from '$lib/stores/Preference';
+	import { _ } from 'svelte-i18n';
+
+	if (browser) {
+		enableAutoPlayAnimatedImages.subscribe((value) => {
+			const storage = new WebStorage(localStorage);
+			storage.set('preference:autoplay-animated-images', JSON.stringify(value));
+		});
+	}
+</script>
+
+<label>
+	<input type="checkbox" bind:checked={$enableAutoPlayAnimatedImages} />
+	<span>{$_('preferences.autoplay_animated_images')}</span>
+</label>


### PR DESCRIPTION
## 概要
- GIF だけでなく APNG/PNG、WebP、AVIF を対象にしたアニメーション画像の自動再生設定を追加します。
- freezeframe の挙動を参考にしつつ、外部ライブラリ本体と同梱 CSS には依存しない実装にしています。
- 画像種別判定、アニメーション判定、freezeframe の描画/状態管理を `Img.svelte` と `FreezeframeImage.svelte` から分離しました。
- 透過 PNG/GIF などの再生時に first-frame が背面に残って見える問題を修正しました。

Ref: https://github.com/SnowCait/nostter/pull/1924

## 確認
- `./node_modules/.bin/prettier --write ...`
- `./node_modules/.bin/eslint ...`
- `git diff --check`
- `npm run check` は既存の unrelated diagnostics で失敗します: `Restriction.ts`, `EmojiPicker.svelte`, `Gdpr.svelte`, `channels/[nevent=note]/+page.svelte`, `relays/[url]/+page.svelte`