### PR TITLE
Fix repeated scroll-to-top animation jitter

### DIFF
--- a/web/src/lib/components/Timeline.svelte
+++ b/web/src/lib/components/Timeline.svelte
@@ -85,6 +85,8 @@
 
 	async function scrollToTop(): Promise<void> {
 		await scrollWindowToTopOnce({
+			// Prune the timeline after reaching the top so the DOM update does not shift the
+			// starting scroll position or fight the browser's smooth-scroll animation.
 			afterScroll: async () => {
 				timeline.scrollToTop();
 				await tick();

--- a/web/src/lib/components/Timeline.svelte
+++ b/web/src/lib/components/Timeline.svelte
@@ -15,13 +15,12 @@
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import { findChannelId } from '$lib/EventHelper';
 	import IconChevronsUp from '@tabler/icons-svelte-runes/icons/chevrons-up';
-	import { sleep } from '$lib/Helper';
 	import { HomeTimeline } from '$lib/timelines/HomeTimeline';
 	import { excludeKinds } from '$lib/TimelineFilter';
 	import { MouseButton } from '$lib/DomHelper';
 	import { scrollY } from 'svelte/reactivity/window';
 	import { isVisibleNotification } from '$lib/preferences/NotificationVisibility.svelte';
-	import { onTimelineScrollToTop } from '$lib/timelines/ScrollToTop';
+	import { onTimelineScrollToTop, scrollWindowToTopOnce } from '$lib/timelines/ScrollToTop';
 
 	interface Props {
 		timeline: NewTimeline;
@@ -85,17 +84,11 @@
 	//#region Scroll to top
 
 	async function scrollToTop(): Promise<void> {
-		timeline.scrollToTop();
-		await tick();
-		window.scrollTo({
-			top: 0,
-			behavior: 'smooth'
-		});
-		// The reflection is not complete immediately after the tick
-		await sleep(500);
-		window.scrollTo({
-			top: 0,
-			behavior: 'smooth'
+		await scrollWindowToTopOnce({
+			afterScroll: async () => {
+				timeline.scrollToTop();
+				await tick();
+			}
 		});
 	}
 

--- a/web/src/lib/timelines/ScrollToTop.test.ts
+++ b/web/src/lib/timelines/ScrollToTop.test.ts
@@ -99,6 +99,24 @@ describe('scrollWindowToTopOnce', () => {
 		await first;
 	});
 
+	it('keeps the first call options while coalescing', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+		const firstAfterScroll = vi.fn();
+		const secondAfterScroll = vi.fn();
+
+		const first = scrollWindowToTopOnce({ afterScroll: firstAfterScroll });
+		const second = scrollWindowToTopOnce({ afterScroll: secondAfterScroll });
+
+		expect(first).toBe(second);
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+		await first;
+
+		expect(firstAfterScroll).toHaveBeenCalledTimes(1);
+		expect(secondAfterScroll).not.toHaveBeenCalled();
+	});
+
 	it('runs prepare only once during a burst', async () => {
 		const browser = installWindowMock({ initialScrollY: 1000 });
 		let resolvePrepare: (() => void) | undefined;

--- a/web/src/lib/timelines/ScrollToTop.test.ts
+++ b/web/src/lib/timelines/ScrollToTop.test.ts
@@ -258,4 +258,33 @@ describe('timeline scroll-to-top requests', () => {
 		dispose();
 		expect(requestTimelineScrollToTop('/home')).toBe(false);
 	});
+
+	it('does not report a request as handled when the matching handler throws synchronously', () => {
+		vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+		const error = new Error('scroll failed');
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const dispose = onTimelineScrollToTop('/home', () => {
+			throw error;
+		});
+
+		expect(requestTimelineScrollToTop('/home')).toBe(false);
+		expect(consoleError).toHaveBeenCalledWith('[timeline scroll-to-top]', error);
+
+		dispose();
+	});
+
+	it('handles async handler rejections without unhandled promise rejections', async () => {
+		vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+		const error = new Error('scroll rejected');
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const dispose = onTimelineScrollToTop('/home', () => Promise.reject(error));
+
+		expect(requestTimelineScrollToTop('/home')).toBe(true);
+		await Promise.resolve();
+		expect(consoleError).toHaveBeenCalledWith('[timeline scroll-to-top]', error);
+
+		dispose();
+	});
 });

--- a/web/src/lib/timelines/ScrollToTop.test.ts
+++ b/web/src/lib/timelines/ScrollToTop.test.ts
@@ -74,6 +74,7 @@ function installWindowMock(options: { reducedMotion?: boolean; initialScrollY?: 
 }
 
 afterEach(() => {
+	vi.useRealTimers();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 });
@@ -298,6 +299,35 @@ describe('scrollWindowToTopOnce', () => {
 			top: 0,
 			behavior: 'auto'
 		});
+	});
+
+	it('resolves via timeout if animation frames stop', async () => {
+		vi.useFakeTimers();
+		const browser = installWindowMock({ initialScrollY: 1000 });
+
+		const operation = scrollWindowToTopOnce({ timeoutMs: 10 });
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenLastCalledWith({
+			top: 0,
+			behavior: 'smooth'
+		});
+
+		await vi.advanceTimersByTimeAsync(10);
+		await operation;
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(2);
+		expect(browser.scrollTo).toHaveBeenLastCalledWith({
+			top: 0,
+			behavior: 'auto'
+		});
+
+		browser.setScrollY(500);
+		const later = scrollWindowToTopOnce({ timeoutMs: 10 });
+		expect(browser.scrollTo).toHaveBeenCalledTimes(3);
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+		await later;
 	});
 
 	it('does nothing when window is unavailable', async () => {

--- a/web/src/lib/timelines/ScrollToTop.test.ts
+++ b/web/src/lib/timelines/ScrollToTop.test.ts
@@ -166,6 +166,54 @@ describe('scrollWindowToTopOnce', () => {
 		await first;
 	});
 
+	it('logs prepare errors, resolves, and clears the in-flight guard', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+		const error = new Error('prepare failed');
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		await expect(
+			scrollWindowToTopOnce({
+				prepare: () => {
+					throw error;
+				}
+			})
+		).resolves.toBeUndefined();
+
+		expect(consoleError).toHaveBeenCalledWith('[window scroll-to-top]', error);
+		expect(browser.scrollTo).not.toHaveBeenCalled();
+
+		const later = scrollWindowToTopOnce();
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+		await later;
+	});
+
+	it('logs afterScroll errors, resolves, and performs final correction', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+		const error = new Error('afterScroll failed');
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const operation = scrollWindowToTopOnce({
+			afterScroll: () => {
+				browser.setScrollY(20);
+				return Promise.reject(error);
+			}
+		});
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+
+		await expect(operation).resolves.toBeUndefined();
+
+		expect(consoleError).toHaveBeenCalledWith('[window scroll-to-top]', error);
+		expect(browser.scrollTo).toHaveBeenLastCalledWith({
+			top: 0,
+			behavior: 'auto'
+		});
+	});
+
 	it('allows a later call after the in-flight operation completes', async () => {
 		const browser = installWindowMock({ initialScrollY: 1000 });
 

--- a/web/src/lib/timelines/ScrollToTop.test.ts
+++ b/web/src/lib/timelines/ScrollToTop.test.ts
@@ -5,6 +5,23 @@ import {
 	scrollWindowToTopOnce
 } from './ScrollToTop';
 
+function installTimelineEventWindowMock(): void {
+	vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+
+	if (typeof CustomEvent === 'undefined') {
+		class TestCustomEvent<T = unknown> extends Event {
+			readonly detail: T;
+
+			constructor(type: string, eventInitDict?: CustomEventInit<T>) {
+				super(type, eventInitDict);
+				this.detail = eventInitDict?.detail as T;
+			}
+		}
+
+		vi.stubGlobal('CustomEvent', TestCustomEvent);
+	}
+}
+
 function installWindowMock(options: { reducedMotion?: boolean; initialScrollY?: number } = {}) {
 	let scrollY = options.initialScrollY ?? 1000;
 	let now = 0;
@@ -243,8 +260,8 @@ describe('scrollWindowToTopOnce', () => {
 });
 
 describe('timeline scroll-to-top requests', () => {
-	it('reports whether a target-specific timeline request was handled', () => {
-		vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+	it('reports whether a target-specific timeline request was accepted', () => {
+		installTimelineEventWindowMock();
 
 		const handler = vi.fn();
 		const dispose = onTimelineScrollToTop('/home', handler);
@@ -259,8 +276,8 @@ describe('timeline scroll-to-top requests', () => {
 		expect(requestTimelineScrollToTop('/home')).toBe(false);
 	});
 
-	it('does not report a request as handled when the matching handler throws synchronously', () => {
-		vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+	it('does not report a request as accepted when the matching handler throws synchronously', () => {
+		installTimelineEventWindowMock();
 		const error = new Error('scroll failed');
 		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -275,7 +292,7 @@ describe('timeline scroll-to-top requests', () => {
 	});
 
 	it('handles async handler rejections without unhandled promise rejections', async () => {
-		vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+		installTimelineEventWindowMock();
 		const error = new Error('scroll rejected');
 		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/web/src/lib/timelines/ScrollToTop.test.ts
+++ b/web/src/lib/timelines/ScrollToTop.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	onTimelineScrollToTop,
+	requestTimelineScrollToTop,
+	scrollWindowToTopOnce
+} from './ScrollToTop';
+
+function installWindowMock(options: { reducedMotion?: boolean; initialScrollY?: number } = {}) {
+	let scrollY = options.initialScrollY ?? 1000;
+	let now = 0;
+	const rafCallbacks: FrameRequestCallback[] = [];
+
+	const scrollTo = vi.fn((scrollOptions: ScrollToOptions) => {
+		if (scrollOptions.behavior === 'auto') {
+			scrollY = Number(scrollOptions.top ?? 0);
+		}
+	});
+
+	const windowMock = {
+		get scrollY() {
+			return scrollY;
+		},
+		scrollTo,
+		matchMedia: vi.fn(
+			() =>
+				({
+					matches: options.reducedMotion ?? false
+				}) as MediaQueryList
+		),
+		requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
+			rafCallbacks.push(callback);
+			return rafCallbacks.length;
+		})
+	} as unknown as Window & typeof globalThis;
+
+	vi.stubGlobal('window', windowMock);
+	vi.stubGlobal('performance', {
+		now: vi.fn(() => now)
+	});
+
+	return {
+		windowMock,
+		scrollTo,
+		setScrollY(value: number) {
+			scrollY = value;
+		},
+		setNow(value: number) {
+			now = value;
+		},
+		flushRaf() {
+			const callbacks = rafCallbacks.splice(0);
+			for (const callback of callbacks) {
+				callback(now);
+			}
+		}
+	};
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('scrollWindowToTopOnce', () => {
+	it('performs one smooth scroll by default', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+
+		const operation = scrollWindowToTopOnce();
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenCalledWith({
+			top: 0,
+			behavior: 'smooth'
+		});
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+
+		await operation;
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+	});
+
+	it('coalesces repeated calls while a smooth scroll is in flight', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+
+		const first = scrollWindowToTopOnce();
+		const second = scrollWindowToTopOnce();
+
+		expect(first).toBe(second);
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenCalledWith({
+			top: 0,
+			behavior: 'smooth'
+		});
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+
+		await first;
+	});
+
+	it('runs prepare only once during a burst', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+		let resolvePrepare: (() => void) | undefined;
+		const prepare = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolvePrepare = resolve;
+				})
+		);
+
+		const first = scrollWindowToTopOnce({ prepare });
+		const second = scrollWindowToTopOnce({ prepare });
+
+		expect(first).toBe(second);
+		expect(prepare).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).not.toHaveBeenCalled();
+
+		resolvePrepare?.();
+		await Promise.resolve();
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenCalledWith({
+			top: 0,
+			behavior: 'smooth'
+		});
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+
+		await first;
+	});
+
+	it('allows a later call after the in-flight operation completes', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+
+		const first = scrollWindowToTopOnce();
+		browser.setScrollY(0);
+		browser.flushRaf();
+		await first;
+
+		browser.setScrollY(500);
+		const second = scrollWindowToTopOnce();
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(2);
+		expect(browser.scrollTo).toHaveBeenLastCalledWith({
+			top: 0,
+			behavior: 'smooth'
+		});
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+		await second;
+	});
+
+	it('runs afterScroll after the window reaches the top', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+		const afterScroll = vi.fn(() => {
+			expect(window.scrollY).toBe(0);
+		});
+
+		const operation = scrollWindowToTopOnce({ afterScroll });
+
+		expect(afterScroll).not.toHaveBeenCalled();
+
+		browser.setScrollY(0);
+		browser.flushRaf();
+
+		await operation;
+
+		expect(afterScroll).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses auto behavior for long-distance scrolls', async () => {
+		const browser = installWindowMock({ initialScrollY: 5000 });
+
+		await scrollWindowToTopOnce();
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenCalledWith({
+			top: 0,
+			behavior: 'auto'
+		});
+	});
+
+	it('uses auto behavior when reduced motion is requested', async () => {
+		const browser = installWindowMock({ reducedMotion: true, initialScrollY: 1000 });
+
+		await scrollWindowToTopOnce();
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenCalledWith({
+			top: 0,
+			behavior: 'auto'
+		});
+	});
+
+	it('uses auto correction if smooth scrolling does not reach the top before timeout', async () => {
+		const browser = installWindowMock({ initialScrollY: 1000 });
+
+		const operation = scrollWindowToTopOnce({ timeoutMs: 10 });
+		expect(browser.scrollTo).toHaveBeenCalledTimes(1);
+		expect(browser.scrollTo).toHaveBeenLastCalledWith({
+			top: 0,
+			behavior: 'smooth'
+		});
+
+		browser.setNow(20);
+		browser.flushRaf();
+
+		await operation;
+
+		expect(browser.scrollTo).toHaveBeenCalledTimes(2);
+		expect(browser.scrollTo).toHaveBeenLastCalledWith({
+			top: 0,
+			behavior: 'auto'
+		});
+	});
+
+	it('does nothing when window is unavailable', async () => {
+		vi.stubGlobal('window', undefined);
+
+		await expect(scrollWindowToTopOnce()).resolves.toBeUndefined();
+	});
+});
+
+describe('timeline scroll-to-top requests', () => {
+	it('reports whether a target-specific timeline request was handled', () => {
+		vi.stubGlobal('window', new EventTarget() as Window & typeof globalThis);
+
+		const handler = vi.fn();
+		const dispose = onTimelineScrollToTop('/home', handler);
+
+		expect(requestTimelineScrollToTop('/public')).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
+
+		expect(requestTimelineScrollToTop('/home')).toBe(true);
+		expect(handler).toHaveBeenCalledTimes(1);
+
+		dispose();
+		expect(requestTimelineScrollToTop('/home')).toBe(false);
+	});
+});

--- a/web/src/lib/timelines/ScrollToTop.ts
+++ b/web/src/lib/timelines/ScrollToTop.ts
@@ -1,16 +1,31 @@
 const timelineScrollToTopEvent = 'nostter:timeline-scroll-to-top';
 
+const defaultScrollTimeoutMs = 900;
+const defaultCorrectionThresholdPx = 1;
+const defaultMaxSmoothScrollDistancePx = 4000;
+
+let scrollWindowToTopInFlight: Promise<void> | undefined;
+
 type TimelineScrollToTopDetail = {
 	target: string;
 };
 
-export function requestTimelineScrollToTop(target: string): void {
+type ScrollWindowToTopOnceOptions = {
+	prepare?: () => void | Promise<void>;
+	afterScroll?: () => void | Promise<void>;
+	timeoutMs?: number;
+	correctionThresholdPx?: number;
+	maxSmoothScrollDistancePx?: number;
+};
+
+export function requestTimelineScrollToTop(target: string): boolean {
 	if (typeof window === 'undefined') {
-		return;
+		return false;
 	}
-	window.dispatchEvent(
+	return !window.dispatchEvent(
 		new CustomEvent<TimelineScrollToTopDetail>(timelineScrollToTopEvent, {
-			detail: { target }
+			detail: { target },
+			cancelable: true
 		})
 	);
 }
@@ -28,8 +43,94 @@ export function onTimelineScrollToTop(
 			return;
 		}
 
+		event.preventDefault();
 		void handler();
 	};
 	window.addEventListener(timelineScrollToTopEvent, listener);
 	return () => window.removeEventListener(timelineScrollToTopEvent, listener);
+}
+
+export function scrollWindowToTopOnce(options: ScrollWindowToTopOnceOptions = {}): Promise<void> {
+	if (typeof window === 'undefined') {
+		return Promise.resolve();
+	}
+
+	if (scrollWindowToTopInFlight !== undefined) {
+		return scrollWindowToTopInFlight;
+	}
+
+	scrollWindowToTopInFlight = scrollWindowToTopOnceInternal(options).finally(() => {
+		scrollWindowToTopInFlight = undefined;
+	});
+
+	return scrollWindowToTopInFlight;
+}
+
+async function scrollWindowToTopOnceInternal({
+	prepare,
+	afterScroll,
+	timeoutMs = defaultScrollTimeoutMs,
+	correctionThresholdPx = defaultCorrectionThresholdPx,
+	maxSmoothScrollDistancePx = defaultMaxSmoothScrollDistancePx
+}: ScrollWindowToTopOnceOptions): Promise<void> {
+	const preparation = prepare?.();
+	if (preparation !== undefined) {
+		await preparation;
+	}
+
+	const behavior = getPreferredScrollBehavior(maxSmoothScrollDistancePx);
+
+	window.scrollTo({
+		top: 0,
+		behavior
+	});
+
+	if (behavior === 'smooth') {
+		await waitUntilWindowNearTop(timeoutMs, correctionThresholdPx);
+	}
+
+	correctWindowScrollToTop(correctionThresholdPx);
+
+	const afterScrollOperation = afterScroll?.();
+	if (afterScrollOperation !== undefined) {
+		await afterScrollOperation;
+	}
+
+	correctWindowScrollToTop(correctionThresholdPx);
+}
+
+function getPreferredScrollBehavior(maxSmoothScrollDistancePx: number): ScrollBehavior {
+	if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+		return 'auto';
+	}
+
+	return window.scrollY > maxSmoothScrollDistancePx ? 'auto' : 'smooth';
+}
+
+function correctWindowScrollToTop(thresholdPx: number): void {
+	if (window.scrollY <= thresholdPx) {
+		return;
+	}
+
+	window.scrollTo({
+		top: 0,
+		behavior: 'auto'
+	});
+}
+
+function waitUntilWindowNearTop(timeoutMs: number, thresholdPx: number): Promise<void> {
+	return new Promise((resolve) => {
+		const startedAt = performance.now();
+
+		const step = () => {
+			if (window.scrollY <= thresholdPx || performance.now() - startedAt >= timeoutMs) {
+				resolve();
+				return;
+			}
+
+			window.requestAnimationFrame(step);
+		};
+
+		window.requestAnimationFrame(step);
+	});
 }

--- a/web/src/lib/timelines/ScrollToTop.ts
+++ b/web/src/lib/timelines/ScrollToTop.ts
@@ -8,7 +8,7 @@ let scrollWindowToTopInFlight: Promise<void> | undefined;
 
 type TimelineScrollToTopDetail = {
 	target: string;
-	handled: boolean;
+	accepted: boolean;
 };
 
 type ScrollWindowToTopOnceOptions = {
@@ -28,18 +28,25 @@ type ScrollWindowToTopOnceOptions = {
 	maxSmoothScrollDistancePx?: number;
 };
 
+/**
+ * Dispatches a target-specific timeline scroll-to-top request.
+ *
+ * Returns true when a matching timeline listener accepts the request by invoking
+ * its handler without throwing synchronously. It does not mean that the async
+ * scroll operation has completed or cannot fail later.
+ */
 export function requestTimelineScrollToTop(target: string): boolean {
 	if (typeof window === 'undefined') {
 		return false;
 	}
 
-	const detail: TimelineScrollToTopDetail = { target, handled: false };
+	const detail: TimelineScrollToTopDetail = { target, accepted: false };
 	window.dispatchEvent(
 		new CustomEvent<TimelineScrollToTopDetail>(timelineScrollToTopEvent, {
 			detail
 		})
 	);
-	return detail.handled;
+	return detail.accepted;
 }
 
 export function onTimelineScrollToTop(
@@ -58,7 +65,7 @@ export function onTimelineScrollToTop(
 
 		try {
 			const result = handler();
-			timelineScrollToTopDetail.handled = true;
+			timelineScrollToTopDetail.accepted = true;
 			void Promise.resolve(result).catch(reportTimelineScrollToTopError);
 		} catch (error) {
 			reportTimelineScrollToTopError(error);

--- a/web/src/lib/timelines/ScrollToTop.ts
+++ b/web/src/lib/timelines/ScrollToTop.ts
@@ -79,11 +79,19 @@ function reportTimelineScrollToTopError(error: unknown): void {
 	console.error('[timeline scroll-to-top]', error);
 }
 
+function reportWindowScrollToTopError(error: unknown): void {
+	console.error('[window scroll-to-top]', error);
+}
+
 /**
  * Starts one window scroll-to-top operation at a time. Calls made while another
  * operation is in flight return the same promise and intentionally keep the first
  * call's options. This prevents repeated UI input from queuing extra scrolls or
  * duplicate timeline mutations.
+ *
+ * The returned promise does not reject. Scroll-to-top is a best-effort UI action;
+ * failures are logged and the in-flight guard is cleared so future requests can
+ * still run.
  */
 export function scrollWindowToTopOnce(options: ScrollWindowToTopOnceOptions = {}): Promise<void> {
 	if (typeof window === 'undefined') {
@@ -94,9 +102,11 @@ export function scrollWindowToTopOnce(options: ScrollWindowToTopOnceOptions = {}
 		return scrollWindowToTopInFlight;
 	}
 
-	scrollWindowToTopInFlight = scrollWindowToTopOnceInternal(options).finally(() => {
-		scrollWindowToTopInFlight = undefined;
-	});
+	scrollWindowToTopInFlight = scrollWindowToTopOnceInternal(options)
+		.catch(reportWindowScrollToTopError)
+		.finally(() => {
+			scrollWindowToTopInFlight = undefined;
+		});
 
 	return scrollWindowToTopInFlight;
 }
@@ -126,12 +136,14 @@ async function scrollWindowToTopOnceInternal({
 
 	correctWindowScrollToTop(correctionThresholdPx);
 
-	const afterScrollOperation = afterScroll?.();
-	if (afterScrollOperation !== undefined) {
-		await afterScrollOperation;
+	try {
+		const afterScrollOperation = afterScroll?.();
+		if (afterScrollOperation !== undefined) {
+			await afterScrollOperation;
+		}
+	} finally {
+		correctWindowScrollToTop(correctionThresholdPx);
 	}
-
-	correctWindowScrollToTop(correctionThresholdPx);
 }
 
 function getPreferredScrollBehavior(maxSmoothScrollDistancePx: number): ScrollBehavior {

--- a/web/src/lib/timelines/ScrollToTop.ts
+++ b/web/src/lib/timelines/ScrollToTop.ts
@@ -167,17 +167,33 @@ function correctWindowScrollToTop(thresholdPx: number): void {
 
 function waitUntilWindowNearTop(timeoutMs: number, thresholdPx: number): Promise<void> {
 	return new Promise((resolve) => {
+		let resolved = false;
 		const startedAt = performance.now();
 
+		const finish = () => {
+			if (resolved) {
+				return;
+			}
+
+			resolved = true;
+			clearTimeout(timeoutId);
+			resolve();
+		};
+
 		const step = () => {
+			if (resolved) {
+				return;
+			}
+
 			if (window.scrollY <= thresholdPx || performance.now() - startedAt >= timeoutMs) {
-				resolve();
+				finish();
 				return;
 			}
 
 			window.requestAnimationFrame(step);
 		};
 
+		const timeoutId = setTimeout(finish, timeoutMs);
 		window.requestAnimationFrame(step);
 	});
 }

--- a/web/src/lib/timelines/ScrollToTop.ts
+++ b/web/src/lib/timelines/ScrollToTop.ts
@@ -11,7 +11,16 @@ type TimelineScrollToTopDetail = {
 };
 
 type ScrollWindowToTopOnceOptions = {
+	/**
+	 * Runs before the scroll starts. Only the first call's callback runs while a scroll is
+	 * already in flight; later calls are coalesced into that same operation.
+	 */
 	prepare?: () => void | Promise<void>;
+	/**
+	 * Runs once after the window reaches the top. This is useful for timeline DOM
+	 * pruning that would otherwise cause scroll anchoring/layout shifts at the start
+	 * of the animation. Only the first call's callback runs while coalescing.
+	 */
 	afterScroll?: () => void | Promise<void>;
 	timeoutMs?: number;
 	correctionThresholdPx?: number;
@@ -22,12 +31,16 @@ export function requestTimelineScrollToTop(target: string): boolean {
 	if (typeof window === 'undefined') {
 		return false;
 	}
-	return !window.dispatchEvent(
+
+	// dispatchEvent returns false when a cancelable event was prevented. Matching
+	// timeline listeners call preventDefault() to claim that they handled the request.
+	const wasHandled = !window.dispatchEvent(
 		new CustomEvent<TimelineScrollToTopDetail>(timelineScrollToTopEvent, {
 			detail: { target },
 			cancelable: true
 		})
 	);
+	return wasHandled;
 }
 
 export function onTimelineScrollToTop(
@@ -50,6 +63,12 @@ export function onTimelineScrollToTop(
 	return () => window.removeEventListener(timelineScrollToTopEvent, listener);
 }
 
+/**
+ * Starts one window scroll-to-top operation at a time. Calls made while another
+ * operation is in flight return the same promise and intentionally keep the first
+ * call's options. This prevents repeated UI input from queuing extra scrolls or
+ * duplicate timeline mutations.
+ */
 export function scrollWindowToTopOnce(options: ScrollWindowToTopOnceOptions = {}): Promise<void> {
 	if (typeof window === 'undefined') {
 		return Promise.resolve();

--- a/web/src/lib/timelines/ScrollToTop.ts
+++ b/web/src/lib/timelines/ScrollToTop.ts
@@ -8,6 +8,7 @@ let scrollWindowToTopInFlight: Promise<void> | undefined;
 
 type TimelineScrollToTopDetail = {
 	target: string;
+	handled: boolean;
 };
 
 type ScrollWindowToTopOnceOptions = {
@@ -32,15 +33,13 @@ export function requestTimelineScrollToTop(target: string): boolean {
 		return false;
 	}
 
-	// dispatchEvent returns false when a cancelable event was prevented. Matching
-	// timeline listeners call preventDefault() to claim that they handled the request.
-	const wasHandled = !window.dispatchEvent(
+	const detail: TimelineScrollToTopDetail = { target, handled: false };
+	window.dispatchEvent(
 		new CustomEvent<TimelineScrollToTopDetail>(timelineScrollToTopEvent, {
-			detail: { target },
-			cancelable: true
+			detail
 		})
 	);
-	return wasHandled;
+	return detail.handled;
 }
 
 export function onTimelineScrollToTop(
@@ -52,15 +51,25 @@ export function onTimelineScrollToTop(
 	}
 	const listener = (event: Event) => {
 		const detail = event instanceof CustomEvent ? event.detail : undefined;
-		if ((detail as TimelineScrollToTopDetail | undefined)?.target !== target) {
+		const timelineScrollToTopDetail = detail as TimelineScrollToTopDetail | undefined;
+		if (timelineScrollToTopDetail?.target !== target) {
 			return;
 		}
 
-		event.preventDefault();
-		void handler();
+		try {
+			const result = handler();
+			timelineScrollToTopDetail.handled = true;
+			void Promise.resolve(result).catch(reportTimelineScrollToTopError);
+		} catch (error) {
+			reportTimelineScrollToTopError(error);
+		}
 	};
 	window.addEventListener(timelineScrollToTopEvent, listener);
 	return () => window.removeEventListener(timelineScrollToTopEvent, listener);
+}
+
+function reportTimelineScrollToTopError(error: unknown): void {
+	console.error('[timeline scroll-to-top]', error);
 }
 
 /**

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -8,10 +8,12 @@
 	import { openNoteDialog } from '$lib/stores/NoteDialog';
 	import { fetchLastNotification } from '$lib/author/Notifications';
 	import { onMount } from 'svelte';
+	import { page } from '$app/state';
 	import Gdpr from '$lib/components/Gdpr.svelte';
 	import '$lib/styles/menu.css';
 	import { fetchMinutes } from '$lib/Helper';
 	import { followees } from '$lib/stores/Author';
+	import { requestTimelineScrollToTop, scrollWindowToTopOnce } from '$lib/timelines/ScrollToTop';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
@@ -57,10 +59,11 @@
 		}
 
 		if (event.key === '1') {
-			scrollTo({
-				top: 0,
-				behavior: 'smooth'
-			});
+			event.preventDefault();
+
+			if (!event.repeat && !requestTimelineScrollToTop(page.url.pathname)) {
+				void scrollWindowToTopOnce();
+			}
 		}
 
 		// Konami

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -59,6 +59,8 @@
 		}
 
 		if (event.key === '1') {
+			// Consume repeated keydown events as part of the shortcut, but do not start
+			// additional scroll operations for them.
 			event.preventDefault();
 
 			if (!event.repeat) {

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -36,13 +36,10 @@
 	let hiddenAt: number | undefined;
 
 	function keyboardShortcut(event: KeyboardEvent) {
-		const element = event.target as HTMLElement;
-		if (
-			['INPUT', 'TEXTAREA'].includes(element.tagName) ||
-			element.closest('dialog[open]') !== null
-		) {
+		if (!(event.target instanceof Element) || shouldIgnoreKeyboardShortcut(event.target)) {
 			return;
 		}
+		const element = event.target;
 
 		console.debug(
 			`[${event.type}]`,
@@ -58,16 +55,12 @@
 			event.preventDefault();
 		}
 
-		if (event.key === '1') {
-			// Consume repeated keydown events as part of the shortcut, but do not start
-			// additional scroll operations for them.
+		if (event.key === '1' && !event.repeat) {
 			event.preventDefault();
 
-			if (!event.repeat) {
-				const handledByTimeline = requestTimelineScrollToTop(page.url.pathname);
-				if (!handledByTimeline) {
-					void scrollWindowToTopOnce();
-				}
+			const acceptedByTimeline = requestTimelineScrollToTop(page.url.pathname);
+			if (!acceptedByTimeline) {
+				void scrollWindowToTopOnce();
 			}
 		}
 
@@ -83,6 +76,18 @@
 			konamiIndex = 0;
 			rotateLogo();
 		}
+	}
+
+	function shouldIgnoreKeyboardShortcut(element: Element): boolean {
+		if (['INPUT', 'TEXTAREA', 'SELECT'].includes(element.tagName)) {
+			return true;
+		}
+
+		if (element instanceof HTMLElement && element.isContentEditable) {
+			return true;
+		}
+
+		return element.closest('dialog[open]') !== null;
 	}
 
 	function rotateLogo() {

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -61,8 +61,11 @@
 		if (event.key === '1') {
 			event.preventDefault();
 
-			if (!event.repeat && !requestTimelineScrollToTop(page.url.pathname)) {
-				void scrollWindowToTopOnce();
+			if (!event.repeat) {
+				const handledByTimeline = requestTimelineScrollToTop(page.url.pathname);
+				if (!handledByTimeline) {
+					void scrollWindowToTopOnce();
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes repeated scroll-to-top animation jitter when users rapidly click an already-active timeline navigation item such as Home or Public.

The previous behavior could start multiple concurrent scroll-to-top tasks. In `Timeline.svelte`, each task performed a smooth scroll, waited 500 ms, and then performed another smooth scroll. Rapid clicks therefore stacked multiple smooth scroll animations and delayed follow-up scrolls, causing visible thrashing.

This PR introduces a single-flight window scroll-to-top helper and routes timeline scroll-to-top actions through it.

## Changes

- Adds a guarded `scrollWindowToTopOnce()` helper in `ScrollToTop.ts`.
- Coalesces repeated scroll-to-top calls while a scroll operation is already in flight.
- Preserves smooth scrolling for normal-distance scrolls.
- Uses instant scrolling for long-distance scroll-to-top operations where browser smooth scrolling feels poor.
- Respects `prefers-reduced-motion: reduce`.
- Removes the delayed second smooth scroll from `Timeline.svelte`.
- Defers timeline view trimming until after the viewport reaches the top to avoid a small start-of-scroll position shift.
- Uses a quiet `behavior: 'auto'` correction only if the page is still not near the top after the wait window or after timeline DOM reflection.
- Routes the `1` keyboard shortcut through the same target-specific timeline request path as the Home/Public buttons, with a generic guarded fallback for pages without a timeline handler.
- Adds focused tests for coalescing, reduced motion, completion/reset behavior, long-distance instant scrolling, timeout correction, timeline request handling, and SSR/no-window safety.

## User-facing behavior

- Clicking active Home/Public once still scrolls to top.
- Repeated clicks during the animation no longer stack or restart animations.
- The floating timeline scroll-to-top button remains functional and uses the same guarded behavior.
- The keyboard shortcut now follows the same timeline-aware path as the buttons and no longer thrashes on key repeat.
- Long-distance scroll-to-top actions use an instant jump instead of a low-quality long smooth animation.
- Normal navigation, middle-click, and modifier-click behavior are preserved.

## Verification

Automated checks:

- [ ] `npm run check` — fails on pre-existing unrelated type issues also present before this branch (`Restriction.ts` missing local Cloudflare env exports, `Gdpr.svelte` typings/window `dataLayer`, and `channels/[nevent=note]/+page.svelte` state type).
- [x] `npm test -- --run`
- [x] `npm run lint` — passes with the existing `Nicovideo.svelte` warning.
- [x] `CLOUDFLARE_ACCOUNT_ID=dummy CLOUDFLARE_API_TOKEN=dummy CLOUDFLARE_KV_NAMESPACE_ID=dummy npm run build`

Manual checks:

- [x] Home/Public/button and keyboard shortcut behavior was manually verified locally by the reporter.

## Notes

The fix intentionally does not remove the existing active-route scroll-to-top feature. It makes the scroll execution single-flight, aligns the keyboard shortcut with the button path, avoids trimming the timeline before the scroll begins, and removes the delayed second smooth animation that caused stacked motion.
