### PR TITLE
Fix missing latest posts on profile notes timeline

### DIFF
--- a/web/src/routes/(app)/[slug=npub]/(tabs)/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/+page.svelte
@@ -1,34 +1,23 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { nip05 } from 'nostr-tools';
-	import { createRxOneshotReq, now, uniq } from 'rx-nostr';
-	import { tap } from 'rxjs';
 	import { afterNavigate, replaceState } from '$app/navigation';
-	import { authorActionReqEmit } from '$lib/author/Action';
 	import { metadataStore, storeMetadata } from '$lib/cache/Events';
-	import { metadataReqEmit, referencesReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
-	import { pubkey as authorPubkey } from '$lib/stores/Author';
-	import { Timeline } from '$lib/Timeline';
-	import { EventItem } from '$lib/Items';
-	import { minTimelineLength } from '$lib/Constants';
+	import { metadataReqEmit, referencesReqEmit } from '$lib/timelines/MainTimeline';
 	import { replaceableEvents, replaceableEventsReqEmit } from '$lib/Profile';
 	import type { LayoutProps } from './$types';
 	import { developerMode } from '$lib/stores/Preference';
-	import TimelineView from '../../TimelineView.svelte';
+	import Notes from './Notes.svelte';
 	import PinnedNote from '$lib/components/items/PinnedNote.svelte';
 	import ProfileTabs from './ProfileTabs.svelte';
 
 	let { data }: LayoutProps = $props();
 
 	let metadata = $derived($metadataStore.get(data.pubkey));
-
-	let items = $state<EventItem[]>([]);
 	let slug = $derived(page.params.slug!);
 
 	afterNavigate(() => {
 		console.debug('[npub page]', data.pubkey);
-
-		items = [];
 
 		if (metadata === undefined) {
 			if (data.metadataEvent !== undefined) {
@@ -67,103 +56,12 @@
 			}
 		});
 	}
-
-	async function load() {
-		console.debug('[npub page timeline load]', data.pubkey);
-
-		let firstLength = items.length;
-		let count = 0;
-		let until =
-			items.length > 0 ? Math.min(...items.map((item) => item.event.created_at)) : now();
-		let seconds = 12 * 60 * 60;
-
-		while (items.length - firstLength < minTimelineLength && count < 10) {
-			const since = until - seconds;
-			console.debug(
-				'[rx-nostr user timeline period]',
-				new Date(since * 1000),
-				new Date(until * 1000)
-			);
-
-			const filters = Timeline.createChunkedFilters([data.pubkey], since, until);
-			console.debug('[rx-nostr user timeline REQ]', filters, rxNostr.getAllRelayStatus());
-			const pastEventsReq = createRxOneshotReq({ filters });
-			console.debug('[rx-nostr user timeline req ID]', pastEventsReq);
-			await new Promise<void>((resolve, reject) => {
-				rxNostr
-					.use(pastEventsReq)
-					.pipe(
-						tie,
-						uniq(),
-						tap(({ event }) => {
-							referencesReqEmit(event);
-							authorActionReqEmit(event);
-						})
-					)
-					.subscribe({
-						next: (packet) => {
-							console.debug('[rx-nostr user timeline packet]', packet);
-							if (
-								!(
-									since <= packet.event.created_at &&
-									packet.event.created_at < until
-								)
-							) {
-								console.warn(
-									'[rx-nostr user timeline out of period]',
-									packet,
-									since,
-									until
-								);
-								return;
-							}
-							if (items.some((x) => x.event.id === packet.event.id)) {
-								console.warn('[rx-nostr user timeline duplicate]', packet.event);
-								return;
-							}
-							const item = new EventItem(packet.event);
-							const index = items.findIndex(
-								(x) => x.event.created_at < item.event.created_at
-							);
-							if (index < 0) {
-								items.push(item);
-							} else {
-								items.splice(index, 0, item);
-							}
-							items = items;
-						},
-						complete: () => {
-							console.debug(
-								'[rx-nostr user timeline complete]',
-								pastEventsReq.rxReqId
-							);
-							resolve();
-						},
-						error: (error) => {
-							reject(error);
-						}
-					});
-			});
-
-			until -= seconds;
-			seconds *= 2;
-			count++;
-			console.debug(
-				'[rx-nostr user timeline loaded]',
-				pastEventsReq.rxReqId,
-				count,
-				until,
-				seconds / 3600,
-				items.length
-			);
-		}
-	}
 </script>
 
 <ProfileTabs tab="notes" {slug} />
 
 <PinnedNote pubkey={data.pubkey} {slug} />
 
-<section>
-	<TimelineView {items} readonly={!$authorPubkey} {load} />
-</section>
+{#key data.pubkey}
+	<Notes pubkey={data.pubkey} />
+{/key}

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/Notes.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/Notes.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { createRxOneshotReq, now, uniq } from 'rx-nostr';
+	import { tap } from 'rxjs';
+	import { authorActionReqEmit } from '$lib/author/Action';
+	import { referencesReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
+	import { pubkey as authorPubkey } from '$lib/stores/Author';
+	import { Timeline } from '$lib/Timeline';
+	import { EventItem } from '$lib/Items';
+	import { minTimelineLength } from '$lib/Constants';
+	import TimelineView from '../../TimelineView.svelte';
+
+	interface Props {
+		pubkey: string;
+	}
+
+	let { pubkey }: Props = $props();
+
+	let items = $state<EventItem[]>([]);
+
+	async function load() {
+		console.debug('[npub page timeline load]', pubkey);
+
+		let firstLength = items.length;
+		let count = 0;
+		let until =
+			items.length > 0 ? Math.min(...items.map((item) => item.event.created_at)) : now();
+		let seconds = 12 * 60 * 60;
+
+		while (items.length - firstLength < minTimelineLength && count < 10) {
+			const since = until - seconds;
+			console.debug(
+				'[rx-nostr user timeline period]',
+				new Date(since * 1000),
+				new Date(until * 1000)
+			);
+
+			const filters = Timeline.createChunkedFilters([pubkey], since, until);
+			console.debug('[rx-nostr user timeline REQ]', filters, rxNostr.getAllRelayStatus());
+			const pastEventsReq = createRxOneshotReq({ filters });
+			console.debug('[rx-nostr user timeline req ID]', pastEventsReq);
+			await new Promise<void>((resolve, reject) => {
+				rxNostr
+					.use(pastEventsReq)
+					.pipe(
+						tie,
+						uniq(),
+						tap(({ event }) => {
+							referencesReqEmit(event);
+							authorActionReqEmit(event);
+						})
+					)
+					.subscribe({
+						next: (packet) => {
+							console.debug('[rx-nostr user timeline packet]', packet);
+							if (
+								!(
+									since <= packet.event.created_at &&
+									packet.event.created_at < until
+								)
+							) {
+								console.warn(
+									'[rx-nostr user timeline out of period]',
+									packet,
+									since,
+									until
+								);
+								return;
+							}
+							if (items.some((x) => x.event.id === packet.event.id)) {
+								console.warn('[rx-nostr user timeline duplicate]', packet.event);
+								return;
+							}
+							const item = new EventItem(packet.event);
+							const index = items.findIndex(
+								(x) => x.event.created_at < item.event.created_at
+							);
+							if (index < 0) {
+								items.push(item);
+							} else {
+								items.splice(index, 0, item);
+							}
+							items = items;
+						},
+						complete: () => {
+							console.debug(
+								'[rx-nostr user timeline complete]',
+								pastEventsReq.rxReqId
+							);
+							resolve();
+						},
+						error: (error) => {
+							reject(error);
+						}
+					});
+			});
+
+			until -= seconds;
+			seconds *= 2;
+			count++;
+			console.debug(
+				'[rx-nostr user timeline loaded]',
+				pastEventsReq.rxReqId,
+				count,
+				until,
+				seconds / 3600,
+				items.length
+			);
+		}
+	}
+</script>
+
+<section>
+	<TimelineView {items} readonly={!$authorPubkey} {load} />
+</section>


### PR DESCRIPTION
The notes tab reset items via afterNavigate's `items = []`, which raced with the async load(). When the reset landed after load() had inserted the newest window and advanced its cursor past it, the newest posts were wiped and never refetched. This was triggered without any profile-to- profile navigation: overwriteSlug()'s replaceState (npub -> NIP-05) re- fires afterNavigate, re-running the reset mid-load.

Move the timeline state (items + load) into a Notes child component and mount it keyed by pubkey via {#key data.pubkey}, removing the manual reset. items lifecycle is now tied to the component mount, so no reset can interrupt an in-flight load. Keying on pubkey (not slug) means replaceState slug normalization no longer remounts/wipes the timeline.