### PR TITLE
Add UI for search query options

### DIFF
--- a/web/src/lib/Search.test.ts
+++ b/web/src/lib/Search.test.ts
@@ -28,6 +28,14 @@ describe('parseSearchQuery', () => {
 		const { fromPubkeys } = parseSearchQuery(`from:${nprofile}`);
 		expect(fromPubkeys).toStrictEqual([hex]);
 	});
+	it('uses since at 0:00 and until at the next day 0:00', () => {
+		const { since, until } = parseSearchQuery('since:2025-01-01 until:2025-06-06');
+		// until covers the whole specified day, so it is exactly one day after since's start unit.
+		const startOf = (date: string) =>
+			Math.floor(new Date(date).getTime() / 1000) + new Date(date).getTimezoneOffset() * 60;
+		expect(since).toBe(startOf('2025-01-01'));
+		expect(until).toBe(startOf('2025-06-06') + 24 * 60 * 60);
+	});
 	it('extracts kinds, hashtags and keyword', () => {
 		const { kinds, hashtags, keyword } = parseSearchQuery('kind:1 kind:6 #nostr hello world');
 		expect(kinds).toStrictEqual([1, 6]);

--- a/web/src/lib/Search.test.ts
+++ b/web/src/lib/Search.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { buildSearchQuery, decodeToPubkey, extractDateInputs, parseSearchQuery } from './Search';
+
+const hex = '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+const npub = nip19.npubEncode(hex);
+const nprofile = nip19.nprofileEncode({ pubkey: hex, relays: ['wss://relay.example'] });
+
+describe('decodeToPubkey', () => {
+	it('decodes npub', () => {
+		expect(decodeToPubkey(npub)).toBe(hex);
+	});
+	it('decodes nprofile to its pubkey', () => {
+		expect(decodeToPubkey(nprofile)).toBe(hex);
+	});
+	it('returns undefined for invalid input', () => {
+		expect(decodeToPubkey('not-a-key')).toBeUndefined();
+	});
+});
+
+describe('parseSearchQuery', () => {
+	it('parses npub in from/to', () => {
+		const { fromPubkeys, toPubkeys } = parseSearchQuery(`from:${npub} to:${npub}`);
+		expect(fromPubkeys).toStrictEqual([hex]);
+		expect(toPubkeys).toStrictEqual([hex]);
+	});
+	it('parses nprofile in from', () => {
+		const { fromPubkeys } = parseSearchQuery(`from:${nprofile}`);
+		expect(fromPubkeys).toStrictEqual([hex]);
+	});
+	it('extracts kinds, hashtags and keyword', () => {
+		const { kinds, hashtags, keyword } = parseSearchQuery('kind:1 kind:6 #nostr hello world');
+		expect(kinds).toStrictEqual([1, 6]);
+		expect(hashtags).toStrictEqual(['nostr']);
+		expect(keyword).toBe('hello world');
+	});
+});
+
+describe('extractDateInputs', () => {
+	it('extracts raw since/until date strings', () => {
+		expect(extractDateInputs('since:2025-01-01 until:2025-06-06')).toStrictEqual({
+			sinceDate: '2025-01-01',
+			untilDate: '2025-06-06'
+		});
+	});
+	it('returns undefined when absent', () => {
+		expect(extractDateInputs('hello')).toStrictEqual({
+			sinceDate: undefined,
+			untilDate: undefined
+		});
+	});
+});
+
+describe('buildSearchQuery', () => {
+	it('builds tokens from structured parts', () => {
+		const q = buildSearchQuery({
+			kinds: [1, 6],
+			fromPubkeys: [hex],
+			toPubkeys: [hex],
+			sinceDate: '2025-01-01',
+			untilDate: '2025-06-06',
+			keyword: '#nostr hello'
+		});
+		expect(q).toBe(
+			`from:${npub} to:${npub} kind:1 kind:6 since:2025-01-01 until:2025-06-06 #nostr hello`
+		);
+	});
+
+	it('round-trips dates and pubkeys through parseSearchQuery', () => {
+		const original = `from:${npub} kind:1 since:2025-01-01 until:2025-06-06 #nostr bitcoin`;
+		const { fromPubkeys, kinds, hashtags, keyword } = parseSearchQuery(original);
+		const { sinceDate, untilDate } = extractDateInputs(original);
+		const rebuilt = buildSearchQuery({
+			fromPubkeys,
+			kinds,
+			sinceDate,
+			untilDate,
+			keyword: [keyword, ...hashtags.map((h) => `#${h}`)].join(' ').trim()
+		});
+		// Parsing the rebuilt query yields the same structured values.
+		const reparsed = parseSearchQuery(rebuilt);
+		expect(reparsed.fromPubkeys).toStrictEqual(fromPubkeys);
+		expect(reparsed.kinds).toStrictEqual(kinds);
+		expect(reparsed.hashtags).toStrictEqual(hashtags);
+		expect(reparsed.keyword).toBe(keyword);
+		expect(extractDateInputs(rebuilt)).toStrictEqual({
+			sinceDate: '2025-01-01',
+			untilDate: '2025-06-06'
+		});
+	});
+
+	it('normalizes nprofile input to npub on rebuild', () => {
+		const { fromPubkeys } = parseSearchQuery(`from:${nprofile}`);
+		expect(buildSearchQuery({ fromPubkeys })).toBe(`from:${npub}`);
+	});
+
+	it('skips invalid kinds', () => {
+		expect(buildSearchQuery({ kinds: [1, NaN, -1] })).toBe('kind:1');
+	});
+});

--- a/web/src/lib/Search.ts
+++ b/web/src/lib/Search.ts
@@ -10,6 +10,96 @@ import { fetchEvents } from './RxNostrHelper';
 export const searchScopes = ['all', 'nostr', 'following', 'mine'] as const;
 export type SearchScope = (typeof searchScopes)[number];
 
+const fromRegexp = /from:(nostr:)?((?:npub1|nprofile1)[a-z0-9]{6,})/g;
+const toRegexp = /to:(nostr:)?((?:npub1|nprofile1)[a-z0-9]{6,})/g;
+const kindRegexp = /kind:(\d+)/g;
+const sinceRegexp = /since:([0-9-]+)/;
+const untilRegexp = /until:([0-9-]+)/;
+
+/**
+ * Decode an npub or nprofile bech32 string to a hex pubkey.
+ * Returns undefined for invalid input or other entity types.
+ */
+export function decodeToPubkey(bech32: string): string | undefined {
+	try {
+		const decoded = nip19.decode(bech32);
+		if (decoded.type === 'npub') {
+			return decoded.data;
+		}
+		if (decoded.type === 'nprofile') {
+			return decoded.data.pubkey;
+		}
+	} catch {
+		// ignore invalid bech32
+	}
+	return undefined;
+}
+
+export interface SearchQueryParts {
+	fromPubkeys?: string[];
+	toPubkeys?: string[];
+	kinds?: number[];
+	keyword?: string;
+	sinceDate?: string;
+	untilDate?: string;
+}
+
+/**
+ * Build a search query string from structured parts.
+ * Inverse of parseSearchQuery: pubkeys are encoded to npub, dates are kept as
+ * `YYYY-MM-DD` strings, and the free keyword (which may contain inline
+ * `#hashtag`) is appended at the end.
+ */
+export function buildSearchQuery(parts: SearchQueryParts): string {
+	const tokens: string[] = [];
+
+	for (const hex of parts.fromPubkeys ?? []) {
+		try {
+			tokens.push(`from:${nip19.npubEncode(hex)}`);
+		} catch {
+			// skip invalid hex
+		}
+	}
+	for (const hex of parts.toPubkeys ?? []) {
+		try {
+			tokens.push(`to:${nip19.npubEncode(hex)}`);
+		} catch {
+			// skip invalid hex
+		}
+	}
+	for (const kind of parts.kinds ?? []) {
+		if (Number.isInteger(kind) && kind >= 0) {
+			tokens.push(`kind:${kind}`);
+		}
+	}
+	if (parts.sinceDate) {
+		tokens.push(`since:${parts.sinceDate}`);
+	}
+	if (parts.untilDate) {
+		tokens.push(`until:${parts.untilDate}`);
+	}
+	const keyword = (parts.keyword ?? '').trim();
+	if (keyword.length > 0) {
+		tokens.push(keyword);
+	}
+
+	return tokens.join(' ');
+}
+
+/**
+ * Extract the raw `since:`/`until:` date strings (`YYYY-MM-DD`) from a query,
+ * for round-tripping into `<input type="date">` without timestamp conversion.
+ */
+export function extractDateInputs(query: string): {
+	sinceDate: string | undefined;
+	untilDate: string | undefined;
+} {
+	return {
+		sinceDate: query.match(sinceRegexp)?.[1],
+		untilDate: query.match(untilRegexp)?.[1]
+	};
+}
+
 export function parseSearchQuery(
 	query: string,
 	mine = false
@@ -22,11 +112,6 @@ export function parseSearchQuery(
 	since: number | undefined;
 	until: number | undefined;
 } {
-	const fromRegexp = /from:(nostr:)?(npub1[a-z0-9]{6,})/g;
-	const toRegexp = /to:(nostr:)?(npub1[a-z0-9]{6,})/g;
-	const kindRegexp = /kind:(\d+)/g;
-	const sinceRegexp = /since:([0-9-]+)/;
-	const untilRegexp = /until:([0-9-]+)/;
 	const fromMatches = query.matchAll(fromRegexp);
 	const toMatches = query.matchAll(toRegexp);
 	const hashtagsMatches = query.matchAll(hashtagsRegexp);
@@ -35,11 +120,11 @@ export function parseSearchQuery(
 	const untilMatch = query.match(untilRegexp);
 
 	const fromPubkeys = [...fromMatches]
-		.map((match) => match[2])
-		.map((npub) => nip19.decode(npub).data as string);
+		.map((match) => decodeToPubkey(match[2]))
+		.filter((pubkey): pubkey is string => pubkey !== undefined);
 	const toPubkeys = [...toMatches]
-		.map((match) => match[2])
-		.map((npub) => nip19.decode(npub).data as string);
+		.map((match) => decodeToPubkey(match[2]))
+		.filter((pubkey): pubkey is string => pubkey !== undefined);
 	const hashtags = [...hashtagsMatches]
 		.map((match) => match.groups?.hashtag)
 		.filter((t): t is string => t !== undefined);

--- a/web/src/lib/Search.ts
+++ b/web/src/lib/Search.ts
@@ -141,7 +141,9 @@ export function parseSearchQuery(
 	if (untilMatch !== null) {
 		const date = new Date(untilMatch[1]);
 		if (!Number.isNaN(date.getTime())) {
-			until = Math.floor(date.getTime() / 1000) + date.getTimezoneOffset() * 60;
+			// Use the next day's 0:00 so the specified day is fully included.
+			until =
+				Math.floor(date.getTime() / 1000) + date.getTimezoneOffset() * 60 + 24 * 60 * 60;
 		}
 	}
 	console.debug('[search matches]', fromPubkeys, toPubkeys, hashtags, kinds, since, until);

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -203,7 +203,10 @@
 		"kindPresets": {
 			"notes": "Notes",
 			"reposts": "Reposts",
-			"reactions": "Reactions"
+			"reactions": "Reactions",
+			"channelMessage": "Channel messages",
+			"article": "Articles",
+			"poll": "Polls"
 		},
 		"scope": {
 			"label": "Scope",

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -192,7 +192,21 @@
 		"options": "Search options",
 		"notes": "Notes",
 		"users": "Users",
+		"fields": {
+			"from": "From (author)",
+			"to": "To (mention)",
+			"kinds": "Kinds",
+			"kindsCustom": "Other kind numbers",
+			"since": "Since",
+			"until": "Until"
+		},
+		"kindPresets": {
+			"notes": "Notes",
+			"reposts": "Reposts",
+			"reactions": "Reactions"
+		},
 		"scope": {
+			"label": "Scope",
 			"all": "All",
 			"nostr": "Exclude external SNS",
 			"following": "Following",

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -196,14 +196,13 @@
 			"from": "From (author)",
 			"to": "To (mention)",
 			"kinds": "Kinds",
-			"kindsCustom": "Other kind numbers",
+			"kindsCustom": "Other kind numbers (Enter to add)",
+			"pubkeyPlaceholder": "npub / nprofile (Enter to add)",
 			"since": "Since",
 			"until": "Until"
 		},
 		"kindPresets": {
 			"notes": "Notes",
-			"reposts": "Reposts",
-			"reactions": "Reactions",
 			"channelMessage": "Channel messages",
 			"article": "Articles",
 			"poll": "Polls"

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -192,17 +192,16 @@
 		"notes": "投稿",
 		"users": "ユーザー",
 		"fields": {
-			"from": "差出人 (著者)",
-			"to": "宛先 (メンション)",
+			"from": "投稿者 (from)",
+			"to": "メンション (to)",
 			"kinds": "種別 (kind)",
-			"kindsCustom": "その他の種別番号",
-			"since": "開始日",
-			"until": "終了日"
+			"kindsCustom": "その他の種別番号（Enter で追加）",
+			"pubkeyPlaceholder": "npub / nprofile（Enter で追加）",
+			"since": "開始日 (since)",
+			"until": "終了日 (until)"
 		},
 		"kindPresets": {
 			"notes": "投稿",
-			"reposts": "リポスト",
-			"reactions": "リアクション",
 			"channelMessage": "チャンネルメッセージ",
 			"article": "記事",
 			"poll": "投票"

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -191,7 +191,21 @@
 		"options": "検索オプション",
 		"notes": "投稿",
 		"users": "ユーザー",
+		"fields": {
+			"from": "差出人 (著者)",
+			"to": "宛先 (メンション)",
+			"kinds": "種別 (kind)",
+			"kindsCustom": "その他の種別番号",
+			"since": "開始日",
+			"until": "終了日"
+		},
+		"kindPresets": {
+			"notes": "投稿",
+			"reposts": "リポスト",
+			"reactions": "リアクション"
+		},
 		"scope": {
+			"label": "範囲",
 			"all": "すべて",
 			"nostr": "外部 SNS を除く",
 			"following": "フォロー",

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -202,7 +202,10 @@
 		"kindPresets": {
 			"notes": "投稿",
 			"reposts": "リポスト",
-			"reactions": "リアクション"
+			"reactions": "リアクション",
+			"channelMessage": "チャンネルメッセージ",
+			"article": "記事",
+			"poll": "投票"
 		},
 		"scope": {
 			"label": "範囲",

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import { unique } from '$lib/Array';
-	import { parseSearchQuery } from '$lib/Search';
+	import {
+		buildSearchQuery,
+		decodeToPubkey,
+		extractDateInputs,
+		parseSearchQuery
+	} from '$lib/Search';
 	import { developerMode } from '$lib/stores/Preference';
-	import type { Filter } from 'nostr-tools/filter';
-	import { ShortTextNote } from 'nostr-tools/kinds';
+	import { createTagsInput, melt, type Tag } from '@melt-ui/svelte';
+	import { nip19, type Filter } from 'nostr-tools';
+	import { Reaction, Repost, ShortTextNote } from 'nostr-tools/kinds';
+	import { writable } from 'svelte/store';
 	import { _ } from 'svelte-i18n';
 
 	interface Props {
@@ -13,14 +20,118 @@
 
 	let { query, scope = 'nostr' }: Props = $props();
 
-	let filter = $derived.by(() => {
-		const { keyword, kinds, fromPubkeys, toPubkeys, hashtags, since, until } = parseSearchQuery(
-			query,
-			scope === 'mine'
+	const kindPresets = [
+		{ kind: ShortTextNote, label: () => $_('search.kindPresets.notes') },
+		{ kind: Repost, label: () => $_('search.kindPresets.reposts') },
+		{ kind: Reaction, label: () => $_('search.kindPresets.reactions') }
+	];
+	const presetKinds = kindPresets.map((preset) => preset.kind);
+
+	// Tags Input external stores (id = hex pubkey / kind number, value = display).
+	const fromTags = writable<Tag[]>([]);
+	const toTags = writable<Tag[]>([]);
+	const customKindTags = writable<Tag[]>([]);
+
+	// Accept both npub and nprofile, store the hex pubkey, display the canonical npub.
+	const pubkeyAdd = (input: string): Tag => {
+		const pubkey = decodeToPubkey(input.trim());
+		if (pubkey === undefined) {
+			throw new Error('invalid npub/nprofile');
+		}
+		return { id: pubkey, value: nip19.npubEncode(pubkey) };
+	};
+	const kindAdd = (input: string): Tag => {
+		const kind = Number(input.trim());
+		if (!Number.isInteger(kind) || kind < 0 || presetKinds.includes(kind)) {
+			throw new Error('invalid kind');
+		}
+		return { id: String(kind), value: String(kind) };
+	};
+
+	const {
+		elements: { root: fromRoot, input: fromInput, tag: fromTag, deleteTrigger: fromDelete }
+	} = createTagsInput({ tags: fromTags, unique: true, editable: false, add: pubkeyAdd });
+	const {
+		elements: { root: toRoot, input: toInput, tag: toTag, deleteTrigger: toDelete }
+	} = createTagsInput({ tags: toTags, unique: true, editable: false, add: pubkeyAdd });
+	const {
+		elements: { root: kindRoot, input: kindInput, tag: kindTag, deleteTrigger: kindDelete }
+	} = createTagsInput({ tags: customKindTags, unique: true, editable: false, add: kindAdd });
+
+	let selectedPresets = $state<Record<number, boolean>>({});
+	let sinceDate = $state('');
+	let untilDate = $state('');
+	let keyword = $state('');
+
+	// Re-sync all fields whenever the incoming query changes (initial mount + navigation).
+	$effect(() => {
+		applyQuery(query);
+	});
+
+	function applyQuery(rawQuery: string): void {
+		const {
+			fromPubkeys,
+			toPubkeys,
+			hashtags,
+			kinds,
+			keyword: parsedKeyword
+		} = parseSearchQuery(rawQuery);
+		const { sinceDate: since, untilDate: until } = extractDateInputs(rawQuery);
+
+		fromTags.set(fromPubkeys.map((hex) => ({ id: hex, value: nip19.npubEncode(hex) })));
+		toTags.set(toPubkeys.map((hex) => ({ id: hex, value: nip19.npubEncode(hex) })));
+
+		const presets: Record<number, boolean> = {};
+		for (const kind of kinds) {
+			if (presetKinds.includes(kind)) {
+				presets[kind] = true;
+			}
+		}
+		selectedPresets = presets;
+		customKindTags.set(
+			unique(kinds.filter((kind) => !presetKinds.includes(kind))).map((kind) => ({
+				id: String(kind),
+				value: String(kind)
+			}))
 		);
+
+		sinceDate = since ?? '';
+		untilDate = until ?? '';
+		// Keep hashtags inline in the keyword field (hashtags have no dedicated UI).
+		keyword = [parsedKeyword, ...hashtags.map((hashtag) => `#${hashtag}`)].join(' ').trim();
+	}
+
+	let kinds = $derived(
+		unique([
+			...presetKinds.filter((kind) => selectedPresets[kind]),
+			...$customKindTags.map((tag) => Number(tag.value))
+		])
+	);
+
+	let q = $derived(
+		buildSearchQuery({
+			kinds,
+			fromPubkeys: $fromTags.map((tag) => tag.id),
+			toPubkeys: $toTags.map((tag) => tag.id),
+			sinceDate: sinceDate || undefined,
+			untilDate: untilDate || undefined,
+			keyword
+		})
+	);
+
+	let filter = $derived.by(() => {
+		const {
+			keyword: parsedKeyword,
+			kinds: parsedKinds,
+			fromPubkeys,
+			toPubkeys,
+			hashtags,
+			since,
+			until
+		} = parseSearchQuery(q, scope === 'mine');
 		if (
-			keyword.length === 0 &&
-			kinds.length === 0 &&
+			parsedKeyword.length === 0 &&
+			parsedKinds.length === 0 &&
 			fromPubkeys.length === 0 &&
 			toPubkeys.length === 0 &&
 			hashtags.length === 0 &&
@@ -30,8 +141,8 @@
 			return undefined;
 		}
 		return {
-			search: keyword.length > 0 ? keyword : undefined,
-			kinds: kinds.length > 0 ? kinds : [ShortTextNote],
+			search: parsedKeyword.length > 0 ? parsedKeyword : undefined,
+			kinds: parsedKinds.length > 0 ? parsedKinds : [ShortTextNote],
 			authors: fromPubkeys.length > 0 ? fromPubkeys : undefined,
 			'#p': toPubkeys.length > 0 ? toPubkeys : undefined,
 			'#t':
@@ -42,18 +153,89 @@
 			until
 		} satisfies Filter;
 	});
+
+	function shortNpub(npub: string): string {
+		return npub.length > 16 ? `${npub.slice(0, 10)}…${npub.slice(-4)}` : npub;
+	}
 </script>
 
 <form action="/search" class="card">
 	<div class="search-row">
-		<input type="search" name="q" bind:value={query} />
+		<input type="search" bind:value={keyword} placeholder={$_('search.search')} />
 		<input type="submit" value={$_('search.search')} />
 	</div>
+
+	<!-- Composed from the UI fields below; the keyword above is appended as-is. -->
+	<input type="hidden" name="q" value={q} />
 
 	<details class="search-options">
 		<summary>{$_('search.options')}</summary>
 
-		<div>
+		<div class="field">
+			<span class="label">{$_('search.fields.kinds')}</span>
+			<div class="presets">
+				{#each kindPresets as preset (preset.kind)}
+					<label class="preset">
+						<input type="checkbox" bind:checked={selectedPresets[preset.kind]} />
+						{preset.label()}
+					</label>
+				{/each}
+			</div>
+			<div use:melt={$kindRoot} class="tags-input">
+				{#each $customKindTags as tag (tag.id)}
+					<div use:melt={$kindTag(tag)} class="tag">
+						{tag.value}
+						<button type="button" use:melt={$kindDelete(tag)} class="delete">×</button>
+					</div>
+				{/each}
+				<input
+					use:melt={$kindInput}
+					type="text"
+					inputmode="numeric"
+					placeholder={$_('search.fields.kindsCustom')}
+				/>
+			</div>
+		</div>
+
+		<div class="date-row">
+			<label class="field">
+				<span class="label">{$_('search.fields.since')}</span>
+				<input type="date" bind:value={sinceDate} />
+			</label>
+			<label class="field">
+				<span class="label">{$_('search.fields.until')}</span>
+				<input type="date" bind:value={untilDate} />
+			</label>
+		</div>
+
+		<div class="field">
+			<span class="label">{$_('search.fields.from')}</span>
+			<div use:melt={$fromRoot} class="tags-input">
+				{#each $fromTags as tag (tag.id)}
+					<div use:melt={$fromTag(tag)} class="tag">
+						{shortNpub(tag.value)}
+						<button type="button" use:melt={$fromDelete(tag)} class="delete">×</button>
+					</div>
+				{/each}
+				<input use:melt={$fromInput} type="text" placeholder="npub / nprofile" />
+			</div>
+		</div>
+
+		<div class="field">
+			<span class="label">{$_('search.fields.to')}</span>
+			<div use:melt={$toRoot} class="tags-input">
+				{#each $toTags as tag (tag.id)}
+					<div use:melt={$toTag(tag)} class="tag">
+						{shortNpub(tag.value)}
+						<button type="button" use:melt={$toDelete(tag)} class="delete">×</button>
+					</div>
+				{/each}
+				<input use:melt={$toInput} type="text" placeholder="npub / nprofile" />
+			</div>
+		</div>
+
+		<div class="field">
+			<span class="label">{$_('search.scope.label')}</span>
 			<select name="scope" bind:value={scope}>
 				<option value="all">{$_('search.scope.all')}</option>
 				<option value="nostr">{$_('search.scope.nostr')}</option>
@@ -97,8 +279,79 @@
 		user-select: none;
 	}
 
-	details.search-options div {
-		margin: 0.5rem 0 0;
+	.field {
+		display: block;
+		margin: 0.75rem 0 0;
+	}
+
+	.field .label {
+		display: block;
+		font-size: 0.85rem;
+		color: var(--accent);
+		margin-bottom: 0.25rem;
+	}
+
+	.presets {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.preset {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.9rem;
+		cursor: pointer;
+	}
+
+	.date-row {
+		display: flex;
+		gap: 0.75rem;
+	}
+
+	.date-row .field {
+		flex: 1;
+	}
+
+	.tags-input {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		align-items: center;
+		padding: 0.25rem;
+		border: var(--default-border);
+		border-radius: var(--radius, 4px);
+	}
+
+	.tags-input input {
+		flex: 1;
+		min-width: 8rem;
+		border: none;
+		outline: none;
+		background: transparent;
+		padding: 0.2rem;
+	}
+
+	.tag {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.1rem 0.4rem;
+		background: var(--accent-surface, rgba(127, 127, 127, 0.15));
+		border-radius: 9999px;
+		font-size: 0.85rem;
+	}
+
+	.tag .delete {
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		color: inherit;
+		font-size: 1rem;
+		line-height: 1;
+		padding: 0;
 	}
 
 	hr.dev-divider {

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -44,7 +44,7 @@
 	};
 	const kindAdd = (input: string): Tag => {
 		const kind = Number(input.trim());
-		if (!Number.isInteger(kind) || kind < 0 || presetKinds.includes(kind)) {
+		if (!Number.isInteger(kind) || kind < 0) {
 			throw new Error('invalid kind');
 		}
 		return { id: String(kind), value: String(kind) };
@@ -86,6 +86,20 @@
 	// Re-sync all fields whenever the incoming query changes (initial mount + navigation).
 	$effect(() => {
 		applyQuery(query);
+	});
+
+	// Promote preset kinds typed into the custom field to their checkboxes.
+	$effect(() => {
+		const promoted = $customKindTags.filter((tag) => presetKinds.includes(Number(tag.value)));
+		if (promoted.length === 0) {
+			return;
+		}
+		for (const tag of promoted) {
+			selectedPresets[Number(tag.value)] = true;
+		}
+		customKindTags.update((tags) =>
+			tags.filter((tag) => !presetKinds.includes(Number(tag.value)))
+		);
 	});
 
 	function applyQuery(rawQuery: string): void {

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -57,6 +57,7 @@
 		unique: true,
 		editable: false,
 		addOnPaste: true,
+		blur: 'add',
 		add: pubkeyAdd
 	});
 	const {
@@ -66,6 +67,7 @@
 		unique: true,
 		editable: false,
 		addOnPaste: true,
+		blur: 'add',
 		add: pubkeyAdd
 	});
 	const {
@@ -75,6 +77,7 @@
 		unique: true,
 		editable: false,
 		addOnPaste: true,
+		blur: 'add',
 		add: kindAdd
 	});
 

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -192,16 +192,26 @@
 			until
 		} satisfies Filter;
 	});
+
+	let qInput: HTMLInputElement;
+
+	function handleSubmit(): void {
+		// Submit the fully composed query (keyword + options) under name="q".
+		qInput.value = q;
+	}
 </script>
 
-<form action="/search" class="card">
+<form action="/search" class="card" onsubmit={handleSubmit}>
 	<div class="search-row">
-		<input type="search" bind:value={keyword} placeholder={$_('search.search')} />
+		<input
+			type="search"
+			name="q"
+			bind:value={keyword}
+			bind:this={qInput}
+			placeholder={$_('search.search')}
+		/>
 		<input type="submit" value={$_('search.search')} />
 	</div>
-
-	<!-- Composed from the UI fields below; the keyword above is appended as-is. -->
-	<input type="hidden" name="q" value={q} />
 
 	<details class="search-options">
 		<summary>{$_('search.options')}</summary>
@@ -227,6 +237,7 @@
 					use:melt={$kindInput}
 					type="text"
 					inputmode="numeric"
+					autocomplete="off"
 					placeholder={$_('search.fields.kindsCustom')}
 				/>
 			</div>
@@ -255,6 +266,7 @@
 				<input
 					use:melt={$fromInput}
 					type="text"
+					autocomplete="off"
 					placeholder={$_('search.fields.pubkeyPlaceholder')}
 				/>
 			</div>
@@ -272,6 +284,7 @@
 				<input
 					use:melt={$toInput}
 					type="text"
+					autocomplete="off"
 					placeholder={$_('search.fields.pubkeyPlaceholder')}
 				/>
 			</div>

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -6,17 +6,11 @@
 		extractDateInputs,
 		parseSearchQuery
 	} from '$lib/Search';
+	import { alternativeName } from '$lib/Items';
 	import { developerMode } from '$lib/stores/Preference';
 	import { createTagsInput, melt, type Tag } from '@melt-ui/svelte';
 	import { nip19, type Filter } from 'nostr-tools';
-	import {
-		ChannelMessage,
-		LongFormArticle,
-		Poll,
-		Reaction,
-		Repost,
-		ShortTextNote
-	} from 'nostr-tools/kinds';
+	import { ChannelMessage, LongFormArticle, Poll, ShortTextNote } from 'nostr-tools/kinds';
 	import { writable } from 'svelte/store';
 	import { _ } from 'svelte-i18n';
 
@@ -29,8 +23,6 @@
 
 	const kindPresets = [
 		{ kind: ShortTextNote, label: () => $_('search.kindPresets.notes') },
-		{ kind: Repost, label: () => $_('search.kindPresets.reposts') },
-		{ kind: Reaction, label: () => $_('search.kindPresets.reactions') },
 		{ kind: ChannelMessage, label: () => $_('search.kindPresets.channelMessage') },
 		{ kind: LongFormArticle, label: () => $_('search.kindPresets.article') },
 		{ kind: Poll, label: () => $_('search.kindPresets.poll') }
@@ -60,13 +52,31 @@
 
 	const {
 		elements: { root: fromRoot, input: fromInput, tag: fromTag, deleteTrigger: fromDelete }
-	} = createTagsInput({ tags: fromTags, unique: true, editable: false, add: pubkeyAdd });
+	} = createTagsInput({
+		tags: fromTags,
+		unique: true,
+		editable: false,
+		addOnPaste: true,
+		add: pubkeyAdd
+	});
 	const {
 		elements: { root: toRoot, input: toInput, tag: toTag, deleteTrigger: toDelete }
-	} = createTagsInput({ tags: toTags, unique: true, editable: false, add: pubkeyAdd });
+	} = createTagsInput({
+		tags: toTags,
+		unique: true,
+		editable: false,
+		addOnPaste: true,
+		add: pubkeyAdd
+	});
 	const {
 		elements: { root: kindRoot, input: kindInput, tag: kindTag, deleteTrigger: kindDelete }
-	} = createTagsInput({ tags: customKindTags, unique: true, editable: false, add: kindAdd });
+	} = createTagsInput({
+		tags: customKindTags,
+		unique: true,
+		editable: false,
+		addOnPaste: true,
+		add: kindAdd
+	});
 
 	let selectedPresets = $state<Record<number, boolean>>({});
 	let sinceDate = $state('');
@@ -165,10 +175,6 @@
 			until
 		} satisfies Filter;
 	});
-
-	function shortNpub(npub: string): string {
-		return npub.length > 16 ? `${npub.slice(0, 10)}…${npub.slice(-4)}` : npub;
-	}
 </script>
 
 <form action="/search" class="card">
@@ -225,11 +231,15 @@
 			<div use:melt={$fromRoot} class="tags-input">
 				{#each $fromTags as tag (tag.id)}
 					<div use:melt={$fromTag(tag)} class="tag">
-						{shortNpub(tag.value)}
+						{alternativeName(tag.id)}
 						<button type="button" use:melt={$fromDelete(tag)} class="delete">×</button>
 					</div>
 				{/each}
-				<input use:melt={$fromInput} type="text" placeholder="npub / nprofile" />
+				<input
+					use:melt={$fromInput}
+					type="text"
+					placeholder={$_('search.fields.pubkeyPlaceholder')}
+				/>
 			</div>
 		</div>
 
@@ -238,11 +248,15 @@
 			<div use:melt={$toRoot} class="tags-input">
 				{#each $toTags as tag (tag.id)}
 					<div use:melt={$toTag(tag)} class="tag">
-						{shortNpub(tag.value)}
+						{alternativeName(tag.id)}
 						<button type="button" use:melt={$toDelete(tag)} class="delete">×</button>
 					</div>
 				{/each}
-				<input use:melt={$toInput} type="text" placeholder="npub / nprofile" />
+				<input
+					use:melt={$toInput}
+					type="text"
+					placeholder={$_('search.fields.pubkeyPlaceholder')}
+				/>
 			</div>
 		</div>
 

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -9,7 +9,14 @@
 	import { developerMode } from '$lib/stores/Preference';
 	import { createTagsInput, melt, type Tag } from '@melt-ui/svelte';
 	import { nip19, type Filter } from 'nostr-tools';
-	import { Reaction, Repost, ShortTextNote } from 'nostr-tools/kinds';
+	import {
+		ChannelMessage,
+		LongFormArticle,
+		Poll,
+		Reaction,
+		Repost,
+		ShortTextNote
+	} from 'nostr-tools/kinds';
 	import { writable } from 'svelte/store';
 	import { _ } from 'svelte-i18n';
 
@@ -23,7 +30,10 @@
 	const kindPresets = [
 		{ kind: ShortTextNote, label: () => $_('search.kindPresets.notes') },
 		{ kind: Repost, label: () => $_('search.kindPresets.reposts') },
-		{ kind: Reaction, label: () => $_('search.kindPresets.reactions') }
+		{ kind: Reaction, label: () => $_('search.kindPresets.reactions') },
+		{ kind: ChannelMessage, label: () => $_('search.kindPresets.channelMessage') },
+		{ kind: LongFormArticle, label: () => $_('search.kindPresets.article') },
+		{ kind: Poll, label: () => $_('search.kindPresets.poll') }
 	];
 	const presetKinds = kindPresets.map((preset) => preset.kind);
 
@@ -81,15 +91,17 @@
 		fromTags.set(fromPubkeys.map((hex) => ({ id: hex, value: nip19.npubEncode(hex) })));
 		toTags.set(toPubkeys.map((hex) => ({ id: hex, value: nip19.npubEncode(hex) })));
 
+		// Default to kind 1 (Notes) when no kind is specified, matching the search page.
+		const effectiveKinds = kinds.length === 0 ? [ShortTextNote] : kinds;
 		const presets: Record<number, boolean> = {};
-		for (const kind of kinds) {
+		for (const kind of effectiveKinds) {
 			if (presetKinds.includes(kind)) {
 				presets[kind] = true;
 			}
 		}
 		selectedPresets = presets;
 		customKindTags.set(
-			unique(kinds.filter((kind) => !presetKinds.includes(kind))).map((kind) => ({
+			unique(effectiveKinds.filter((kind) => !presetKinds.includes(kind))).map((kind) => ({
 				id: String(kind),
 				value: String(kind)
 			}))

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -147,16 +147,19 @@
 		])
 	);
 
-	let q = $derived(
-		buildSearchQuery({
-			kinds,
+	let q = $derived.by(() => {
+		// Omit kind:1 when only the default (Notes) is selected; the search page
+		// falls back to kind 1 when no kind is present, so results are unchanged.
+		const queryKinds = kinds.length === 1 && kinds[0] === ShortTextNote ? [] : kinds;
+		return buildSearchQuery({
+			kinds: queryKinds,
 			fromPubkeys: $fromTags.map((tag) => tag.id),
 			toPubkeys: $toTags.map((tag) => tag.id),
 			sinceDate: sinceDate || undefined,
 			untilDate: untilDate || undefined,
 			keyword
-		})
-	);
+		});
+	});
 
 	let filter = $derived.by(() => {
 		const {


### PR DESCRIPTION
Fix #886

Let users specify the from/to/kind/since/until search query options via form controls instead of typing the raw query syntax.

- Search.ts: add buildSearchQuery (inverse of parseSearchQuery), extractDateInputs, and decodeToPubkey. Extend parseSearchQuery to accept nprofile in addition to npub for from/to
- SearchForm.svelte: use Melt UI createTagsInput for from/to/custom kinds as chip inputs. Add kind preset checkboxes (notes/reposts/ reactions) and since/until date pickers. Feed the composed q into a hidden input, preserving the existing GET form flow
- hashtags have no dedicated UI; they are typed inline in the keyword field as before
- keep backward compatibility with raw query syntax; expand it back into the UI fields on revisit
- add search field labels to i18n (en/ja)
- Search.test.ts: cover round-trip and nprofile normalization