### PR TITLE
Fix svelte-check type errors

### DIFF
--- a/web/src/gdpr-cookie-consent-banner.d.ts
+++ b/web/src/gdpr-cookie-consent-banner.d.ts
@@ -1,0 +1,4 @@
+declare module '@beyonk/gdpr-cookie-consent-banner' {
+	import { SvelteComponent } from 'svelte';
+	export default class GdprBanner extends SvelteComponent {}
+}

--- a/web/src/lib/components/Gdpr.svelte
+++ b/web/src/lib/components/Gdpr.svelte
@@ -1,3 +1,11 @@
+<script lang="ts" module>
+	declare global {
+		interface Window {
+			dataLayer: unknown[];
+		}
+	}
+</script>
+
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
 	import '@beyonk/gdpr-cookie-consent-banner/banner.css';
@@ -22,8 +30,8 @@
 		console.debug('[analytics init]');
 
 		window.dataLayer = window.dataLayer || [];
-		function gtag() {
-			window.dataLayer.push(arguments);
+		function gtag(...args: unknown[]) {
+			window.dataLayer.push(args);
 		}
 		gtag('js', new Date());
 


### PR DESCRIPTION
- Declare window.dataLayer and type the gtag wrapper in Gdpr.svelte
- Add an ambient module declaration for @beyonk/gdpr-cookie-consent-banner