### PR TITLE
Avoid showing camera option in MediaPicker

### DIFF
--- a/web/src/lib/components/MediaPicker.svelte
+++ b/web/src/lib/components/MediaPicker.svelte
@@ -36,6 +36,6 @@
 	bind:this={input}
 	bind:files
 	{onchange}
-	accept="image/*,video/*,audio/*"
+	accept="image/png,image/jpeg,image/gif,image/webp,image/bmp,image/svg+xml,image/avif,image/heic,image/heif,video/mp4,video/webm,video/ogg,video/quicktime,audio/mpeg,audio/ogg,audio/wav,audio/webm,audio/mp4,audio/aac,audio/flac"
 	hidden
 />


### PR DESCRIPTION
Replace the image/* and video/* wildcards in the file input accept attribute with an explicit list of MIME types so that mobile browsers no longer offer the camera as a file source while still accepting image, video, and audio uploads.