### PR TITLE
Add search history to the search form

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -301,11 +301,6 @@ progress {
 	cursor: progress;
 }
 
-/* Specify the pointer cursor of trigger elements */
-[aria-controls] {
-	cursor: pointer;
-}
-
 /* Specify the unstyled cursor of disabled, not-editable, or otherwise inoperable elements */
 [aria-disabled='true'] {
 	cursor: default;

--- a/web/src/lib/SearchHistory.test.ts
+++ b/web/src/lib/SearchHistory.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { maxSearchHistory, pushSearchHistory, rankSearchHistory } from './SearchHistory';
+
+describe('pushSearchHistory', () => {
+	it('prepends the keyword as the most recent entry', () => {
+		expect(pushSearchHistory(['a'], 'b')).toStrictEqual(['b', 'a']);
+	});
+	it('trims surrounding whitespace', () => {
+		expect(pushSearchHistory([], '  hello  ')).toStrictEqual(['hello']);
+	});
+	it('ignores empty or whitespace-only keywords', () => {
+		expect(pushSearchHistory(['a'], '')).toStrictEqual(['a']);
+		expect(pushSearchHistory(['a'], '   ')).toStrictEqual(['a']);
+	});
+	it('keeps duplicates so frequency can be counted', () => {
+		expect(pushSearchHistory(['a'], 'a')).toStrictEqual(['a', 'a']);
+	});
+	it('caps the history at maxSearchHistory entries', () => {
+		const full = Array.from({ length: maxSearchHistory }, (_, i) => String(i));
+		const result = pushSearchHistory(full, 'new');
+		expect(result.length).toBe(maxSearchHistory);
+		expect(result[0]).toBe('new');
+		expect(result.at(-1)).toBe(String(maxSearchHistory - 2));
+	});
+});
+
+describe('rankSearchHistory', () => {
+	it('orders keywords by frequency descending', () => {
+		expect(rankSearchHistory(['a', 'b', 'a', 'c', 'a', 'b'])).toStrictEqual(['a', 'b', 'c']);
+	});
+	it('breaks ties by most recent (insertion) order', () => {
+		expect(rankSearchHistory(['recent', 'old'])).toStrictEqual(['recent', 'old']);
+	});
+	it('returns unique keywords', () => {
+		expect(rankSearchHistory(['a', 'a', 'a'])).toStrictEqual(['a']);
+	});
+	it('returns an empty array for empty history', () => {
+		expect(rankSearchHistory([])).toStrictEqual([]);
+	});
+});

--- a/web/src/lib/SearchHistory.ts
+++ b/web/src/lib/SearchHistory.ts
@@ -1,0 +1,17 @@
+export const maxSearchHistory = 100;
+
+export function pushSearchHistory(history: string[], keyword: string): string[] {
+	const trimmed = keyword.trim();
+	if (trimmed.length === 0) {
+		return history;
+	}
+	return [trimmed, ...history].slice(0, maxSearchHistory);
+}
+
+export function rankSearchHistory(history: string[]): string[] {
+	const counts = new Map<string, number>();
+	for (const keyword of history) {
+		counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
+	}
+	return [...counts].toSorted(([, x], [, y]) => y - x).map(([keyword]) => keyword);
+}

--- a/web/src/lib/SearchHistory.ts
+++ b/web/src/lib/SearchHistory.ts
@@ -1,7 +1,7 @@
 export const maxSearchHistory = 100;
 
-export function pushSearchHistory(history: string[], keyword: string): string[] {
-	const trimmed = keyword.trim();
+export function pushSearchHistory(history: string[], query: string): string[] {
+	const trimmed = query.trim();
 	if (trimmed.length === 0) {
 		return history;
 	}
@@ -10,8 +10,8 @@ export function pushSearchHistory(history: string[], keyword: string): string[] 
 
 export function rankSearchHistory(history: string[]): string[] {
 	const counts = new Map<string, number>();
-	for (const keyword of history) {
-		counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
+	for (const query of history) {
+		counts.set(query, (counts.get(query) ?? 0) + 1);
 	}
-	return [...counts].toSorted(([, x], [, y]) => y - x).map(([keyword]) => keyword);
+	return [...counts].toSorted(([, x], [, y]) => y - x).map(([query]) => query);
 }

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -213,6 +213,9 @@
 			"nostr": "Exclude external SNS",
 			"following": "Following",
 			"mine": "Mine"
+		},
+		"history": {
+			"clear": "Clear history"
 		}
 	},
 	"public_chat": {

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -212,6 +212,9 @@
 			"nostr": "外部 SNS を除く",
 			"following": "フォロー",
 			"mine": "自分"
+		},
+		"history": {
+			"clear": "履歴を消去"
 		}
 	},
 	"public_chat": {

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -9,10 +9,14 @@
 	import { alternativeName } from '$lib/Items';
 	import { developerMode } from '$lib/stores/Preference';
 	import { createTagsInput, melt, type Tag } from '@melt-ui/svelte';
+	import { Combobox } from 'melt/builders';
 	import { nip19, type Filter } from 'nostr-tools';
 	import { ChannelMessage, LongFormArticle, Poll, ShortTextNote } from 'nostr-tools/kinds';
 	import { writable } from 'svelte/store';
 	import { _ } from 'svelte-i18n';
+	import { persistedStore } from '$lib/WebStorage';
+	import { pushSearchHistory, rankSearchHistory } from '$lib/SearchHistory';
+	import { IconX, IconTrash } from '@tabler/icons-svelte-runes';
 
 	interface Props {
 		query: string;
@@ -81,10 +85,23 @@
 		add: kindAdd
 	});
 
+	const searchHistory = persistedStore<string[]>('search:history', []);
+	const combobox = new Combobox<string>();
+
 	let selectedPresets = $state<Record<number, boolean>>({});
 	let sinceDate = $state('');
 	let untilDate = $state('');
-	let keyword = $state('');
+	let keyword = $derived(combobox.inputValue);
+
+	let rankedHistory = $derived(rankSearchHistory($searchHistory));
+	let historySuggestions = $derived.by(() => {
+		const text = combobox.inputValue.trim().toLowerCase();
+		const list =
+			combobox.touched && text.length > 0
+				? rankedHistory.filter((item) => item.toLowerCase().includes(text))
+				: rankedHistory;
+		return list.slice(0, 10);
+	});
 
 	// Re-sync all fields whenever the incoming query changes (initial mount + navigation).
 	$effect(() => {
@@ -137,7 +154,9 @@
 		sinceDate = since ?? '';
 		untilDate = until ?? '';
 		// Keep hashtags inline in the keyword field (hashtags have no dedicated UI).
-		keyword = [parsedKeyword, ...hashtags.map((hashtag) => `#${hashtag}`)].join(' ').trim();
+		combobox.inputValue = [parsedKeyword, ...hashtags.map((hashtag) => `#${hashtag}`)]
+			.join(' ')
+			.trim();
 	}
 
 	let kinds = $derived(
@@ -201,20 +220,75 @@
 	function handleSubmit(): void {
 		// Submit the fully composed query (keyword + options) under name="q".
 		qInput.value = q;
+		searchHistory.update((history) => pushSearchHistory(history, keyword));
+	}
+
+	function onInputKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Enter') {
+			combobox.open = false;
+			return;
+		}
+		combobox.input.onkeydown(event);
+	}
+
+	function selectHistory(item: string): void {
+		combobox.inputValue = item;
+		combobox.open = false;
+		qInput.form?.requestSubmit();
+	}
+
+	function deleteHistory(item: string): void {
+		searchHistory.update((history) => history.filter((entry) => entry !== item));
 	}
 </script>
 
 <form action="/search" class="card" onsubmit={handleSubmit}>
 	<div class="search-row">
 		<input
+			{...combobox.input}
 			type="search"
 			name="q"
-			bind:value={keyword}
 			bind:this={qInput}
+			onkeydown={onInputKeydown}
 			placeholder={$_('search.search')}
 		/>
 		<input type="submit" value={$_('search.search')} />
 	</div>
+
+	{#if combobox.open && historySuggestions.length > 0}
+		<div {...combobox.content} class="history">
+			<ul>
+				{#each historySuggestions as item (item)}
+					<li
+						{...combobox.getOption(item, item, () => selectHistory(item))}
+						class="history-option"
+					>
+						<span class="history-keyword">{item}</span>
+						<button
+							type="button"
+							class="history-delete"
+							onpointerdown={(event) => event.preventDefault()}
+							onclick={(event) => {
+								event.stopPropagation();
+								deleteHistory(item);
+							}}
+						>
+							<IconX size={16} />
+						</button>
+					</li>
+				{/each}
+			</ul>
+			<button
+				type="button"
+				class="history-clear"
+				onpointerdown={(event) => event.preventDefault()}
+				onclick={() => searchHistory.set([])}
+			>
+				<IconTrash size={16} />
+				{$_('search.history.clear')}
+			</button>
+		</div>
+	{/if}
 
 	<details class="search-options">
 		<summary>{$_('search.options')}</summary>
@@ -325,6 +399,69 @@
 
 	.search-row input[type='submit'] {
 		flex-shrink: 0;
+	}
+
+	.history {
+		color: var(--surface-foreground);
+		background-color: var(--surface);
+		border: var(--default-border);
+		border-radius: var(--radius, 4px);
+		padding: 0.25rem;
+		max-height: 16rem;
+		overflow-y: auto;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	}
+
+	.history ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.history-option {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.4rem 0.5rem;
+		border-radius: var(--radius, 4px);
+		cursor: pointer;
+	}
+
+	.history-option[data-highlighted] {
+		background: var(--accent-surface, rgba(127, 127, 127, 0.15));
+	}
+
+	.history-keyword {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.history-delete {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		border: none;
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		padding: 0.1rem;
+	}
+
+	.history-clear {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		width: 100%;
+		border: none;
+		border-top: var(--default-border);
+		background: transparent;
+		color: var(--accent);
+		cursor: pointer;
+		padding: 0.4rem 0.5rem;
+		margin-top: 0.25rem;
+		font-size: 0.85rem;
 	}
 
 	details.search-options {

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -33,12 +33,10 @@
 	];
 	const presetKinds = kindPresets.map((preset) => preset.kind);
 
-	// Tags Input external stores (id = hex pubkey / kind number, value = display).
 	const fromTags = writable<Tag[]>([]);
 	const toTags = writable<Tag[]>([]);
 	const customKindTags = writable<Tag[]>([]);
 
-	// Accept both npub and nprofile, store the hex pubkey, display the canonical npub.
 	const pubkeyAdd = (input: string): Tag => {
 		const pubkey = decodeToPubkey(input.trim());
 		if (pubkey === undefined) {
@@ -103,12 +101,10 @@
 		return list.slice(0, 10);
 	});
 
-	// Re-sync all fields whenever the incoming query changes (initial mount + navigation).
 	$effect(() => {
 		applyQuery(query);
 	});
 
-	// Promote preset kinds typed into the custom field to their checkboxes.
 	$effect(() => {
 		const promoted = $customKindTags.filter((tag) => presetKinds.includes(Number(tag.value)));
 		if (promoted.length === 0) {
@@ -135,7 +131,6 @@
 		fromTags.set(fromPubkeys.map((hex) => ({ id: hex, value: nip19.npubEncode(hex) })));
 		toTags.set(toPubkeys.map((hex) => ({ id: hex, value: nip19.npubEncode(hex) })));
 
-		// Default to kind 1 (Notes) when no kind is specified, matching the search page.
 		const effectiveKinds = kinds.length === 0 ? [ShortTextNote] : kinds;
 		const presets: Record<number, boolean> = {};
 		for (const kind of effectiveKinds) {
@@ -153,7 +148,6 @@
 
 		sinceDate = since ?? '';
 		untilDate = until ?? '';
-		// Keep hashtags inline in the keyword field (hashtags have no dedicated UI).
 		combobox.inputValue = [parsedKeyword, ...hashtags.map((hashtag) => `#${hashtag}`)]
 			.join(' ')
 			.trim();
@@ -167,8 +161,6 @@
 	);
 
 	let q = $derived.by(() => {
-		// Omit kind:1 when only the default (Notes) is selected; the search page
-		// falls back to kind 1 when no kind is present, so results are unchanged.
 		const queryKinds = kinds.length === 1 && kinds[0] === ShortTextNote ? [] : kinds;
 		return buildSearchQuery({
 			kinds: queryKinds,
@@ -218,9 +210,8 @@
 	let qInput: HTMLInputElement;
 
 	function handleSubmit(): void {
-		// Submit the fully composed query (keyword + options) under name="q".
 		qInput.value = q;
-		searchHistory.update((history) => pushSearchHistory(history, keyword));
+		searchHistory.update((history) => pushSearchHistory(history, q));
 	}
 
 	function onInputKeydown(event: KeyboardEvent): void {
@@ -232,7 +223,7 @@
 	}
 
 	function selectHistory(item: string): void {
-		combobox.inputValue = item;
+		applyQuery(item);
 		combobox.open = false;
 		qInput.form?.requestSubmit();
 	}


### PR DESCRIPTION
Persist recent search keywords in localStorage and show them as a Combobox dropdown below the search input, ordered by recent usage frequency. Support deleting individual entries and clearing all.