### PR TITLE
Move profile status above badges with section labels

### DIFF
--- a/web/src/lib/components/Badges.svelte
+++ b/web/src/lib/components/Badges.svelte
@@ -160,36 +160,45 @@
 			)
 			.map((address) => badgeDefinitions.get(address)!)
 	);
+
+	let visible = $derived(awardedDefinitions.length > 0 || pubkey === $authorPubkey);
 </script>
 
-<ul class="badges">
-	{#each awardedDefinitions as event (event.id)}
-		{@const name = event.tags.find(([tagName]) => tagName === 'name')?.at(1)}
-		{@const thumb = event.tags.find(([tagName]) => tagName === 'thumb')?.at(1)}
-		{@const image = event.tags.find(([tagName]) => tagName === 'image')?.at(1)}
-		{@const npub = nip19.npubEncode(event.pubkey)}
-		<li>
-			<a
-				href="https://yakitofu.org/badge/{npub}:{findIdentifier(event.tags) ?? ''}"
-				target="_blank"
-				rel="noreferrer"
-			>
-				<img src={thumb ? thumb : image} alt={name} title={name} />
-			</a>
-		</li>
-	{:else}
-		{#if pubkey === $authorPubkey}
+{#if visible}
+	<h3 class="section-label">{$_('badge.title')}</h3>
+	<ul class="badges">
+		{#each awardedDefinitions as event (event.id)}
+			{@const name = event.tags.find(([tagName]) => tagName === 'name')?.at(1)}
+			{@const thumb = event.tags.find(([tagName]) => tagName === 'thumb')?.at(1)}
+			{@const image = event.tags.find(([tagName]) => tagName === 'image')?.at(1)}
+			{@const npub = nip19.npubEncode(event.pubkey)}
+			<li>
+				<a
+					href="https://yakitofu.org/badge/{npub}:{findIdentifier(event.tags) ?? ''}"
+					target="_blank"
+					rel="noreferrer"
+				>
+					<img src={thumb ? thumb : image} alt={name} title={name} />
+				</a>
+			</li>
+		{:else}
 			<li>
 				<span>{$_('badge.none')}</span>
 				<ExternalLink link={new URL('https://yakitofu.org/')}>
 					{$_('badge.create')}
 				</ExternalLink>
 			</li>
-		{/if}
-	{/each}
-</ul>
+		{/each}
+	</ul>
+{/if}
 
 <style>
+	.section-label {
+		margin: 1rem 0 0.5rem;
+		font-size: 0.95rem;
+		font-weight: 700;
+	}
+
 	.badges {
 		list-style: none;
 		padding: 0;

--- a/web/src/lib/components/UserStatusFull.svelte
+++ b/web/src/lib/components/UserStatusFull.svelte
@@ -20,6 +20,11 @@
 	let generalLink = $state<URL>();
 	let musicLink = $state<URL>();
 
+	let isAuthor = $derived(pubkey === $authorPubkey);
+	let hasGeneral = $derived(generalEvent !== undefined && generalEvent.content !== '');
+	let hasMusic = $derived(musicEvent !== undefined && musicEvent.content !== '');
+	let visible = $derived(hasGeneral || hasMusic || isAuthor);
+
 	$effect(() => {
 		const statuses = $userStatusesMap.get(pubkey) ?? [];
 		statuses.sort(chronological);
@@ -53,41 +58,50 @@
 	</span>
 {/snippet}
 
-<section>
-	{#if generalEvent !== undefined && generalEvent.content !== ''}
-		<div class="general">
-			<span><IconUser size="14" /></span>
-			{#if generalLink !== undefined}
-				<ExternalLink link={generalLink}>
+{#if visible}
+	<h3 class="section-label">{$_('user_status.title')}</h3>
+	<section>
+		{#if hasGeneral && generalEvent !== undefined}
+			<div class="general">
+				<span><IconUser size="14" /></span>
+				{#if generalLink !== undefined}
+					<ExternalLink link={generalLink}>
+						{@render content(generalEvent)}
+					</ExternalLink>
+				{:else}
 					{@render content(generalEvent)}
-				</ExternalLink>
-			{:else}
-				{@render content(generalEvent)}
-			{/if}
-		</div>
-	{/if}
-	{#if musicEvent !== undefined && musicEvent.content !== ''}
-		<div class="music">
-			<span><IconMusic size="14" /></span>
-			{#if musicLink !== undefined}
-				<ExternalLink link={musicLink}>
+				{/if}
+			</div>
+		{/if}
+		{#if hasMusic && musicEvent !== undefined}
+			<div class="music">
+				<span><IconMusic size="14" /></span>
+				{#if musicLink !== undefined}
+					<ExternalLink link={musicLink}>
+						{@render content(musicEvent)}
+					</ExternalLink>
+				{:else}
 					{@render content(musicEvent)}
+				{/if}
+			</div>
+		{/if}
+		{#if isAuthor}
+			<div>
+				<ExternalLink link={new URL('https://nostatus.vercel.app/')}>
+					{$_('user_status.edit')}
 				</ExternalLink>
-			{:else}
-				{@render content(musicEvent)}
-			{/if}
-		</div>
-	{/if}
-	{#if pubkey === $authorPubkey}
-		<div>
-			<ExternalLink link={new URL('https://nostatus.vercel.app/')}>
-				{$_('user_status.edit')}
-			</ExternalLink>
-		</div>
-	{/if}
-</section>
+			</div>
+		{/if}
+	</section>
+{/if}
 
 <style>
+	.section-label {
+		margin: 1rem 0 0.5rem;
+		font-size: 0.95rem;
+		font-weight: 700;
+	}
+
 	div {
 		color: var(--accent-gray);
 

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -335,6 +335,7 @@
 		"message": "Not found or something wrong."
 	},
 	"badge": {
+		"title": "Badges",
 		"accept": "Accept",
 		"accepted": "Accepted",
 		"none": "No badge yet.",
@@ -427,6 +428,7 @@
 		"copy": "Copy Bunker URL"
 	},
 	"user_status": {
+		"title": "Status",
 		"edit": "Edit status"
 	},
 	"pinned-notes": {

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -334,6 +334,7 @@
 		"message": "ページが見つからなかったかエラーが発生しました。"
 	},
 	"badge": {
+		"title": "バッジ",
 		"accept": "受け取る",
 		"accepted": "受取り済",
 		"none": "まだバッジはありません。",
@@ -426,6 +427,7 @@
 		"copy": "Bunker URL をコピー"
 	},
 	"user_status": {
+		"title": "ステータス",
 		"edit": "ステータスを編集"
 	},
 	"pinned-notes": {

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/Profile.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/Profile.svelte
@@ -141,12 +141,6 @@
 			{/if}
 		</div>
 
-		{#if pubkey !== undefined}
-			<div class="user-status">
-				<UserStatusEditor {pubkey} />
-			</div>
-		{/if}
-
 		{#if metadata !== undefined}
 			<NostrAddress {metadata} />
 		{/if}
@@ -180,6 +174,11 @@
 			{$_('pages.followers')}: <a href={`/${slug}/followers`}>{$_('pages.followers_see')}</a>
 		</div>
 	</div>
+
+	{#if pubkey !== undefined}
+		<UserStatusEditor {pubkey} />
+	{/if}
+
 	<Badges {pubkey} {relays} />
 
 	{#if $developerMode}


### PR DESCRIPTION
Group the status (NIP-38) and badges (NIP-58) sections together below the follow info, each with a section label. The labels are hidden when there is no content to show (for example another user's profile without a status or badges).