### PR TITLE
Render SVG icons as block to fix action menu row height

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -287,6 +287,11 @@ img {
 	/* Remove border when inside `a` element in IE 8/9/10 */
 }
 
+svg {
+	/* Render icons as block to avoid the inline baseline descender gap */
+	display: block;
+}
+
 /* Add the correct vertical alignment in Chrome, Firefox, and Opera */
 progress {
 	vertical-align: baseline;

--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -145,7 +145,6 @@
 <style>
 	button:not(.editor-option) {
 		color: var(--accent-gray);
-		height: 20px;
 	}
 
 	[popover] {

--- a/web/src/lib/components/ProxyLink.svelte
+++ b/web/src/lib/components/ProxyLink.svelte
@@ -26,19 +26,22 @@
 		<span>{url.hostname}</span>
 	</a>
 {:else}
-	<span>
+	<span class="fallback">
 		<IconLink size="20" color="gray" />
 		<span>{tag.at(1) ?? '-'}</span>
 	</span>
 {/if}
 
 <style>
-	a {
+	a,
+	.fallback {
 		display: flex;
 		flex-direction: row;
+		align-items: center;
 	}
 
-	span {
+	a span,
+	.fallback span {
 		margin-left: 0.2rem;
 	}
 </style>

--- a/web/src/lib/components/ReactionButton.svelte
+++ b/web/src/lib/components/ReactionButton.svelte
@@ -53,7 +53,7 @@
 	}
 </script>
 
-<div>
+<div class="reaction">
 	<button
 		class="clear"
 		class:paw-pad={$preferencesStore.reactionEmoji.content === '🐾'}
@@ -113,6 +113,11 @@
 </div>
 
 <style>
+	.reaction {
+		display: flex;
+		align-items: center;
+	}
+
 	.hidden {
 		visibility: hidden;
 	}

--- a/web/src/lib/components/actions/ActionMenu.svelte
+++ b/web/src/lib/components/actions/ActionMenu.svelte
@@ -136,9 +136,13 @@
 		color: var(--accent-gray);
 	}
 
+	.action-menu > span {
+		display: flex;
+		align-items: center;
+	}
+
 	.action-menu :global(button.clear),
 	.action-menu :global(button) {
-		display: block;
 		padding: 10px;
 		margin: -10px;
 		height: auto;

--- a/web/src/lib/components/actions/ActionMenu.svelte
+++ b/web/src/lib/components/actions/ActionMenu.svelte
@@ -123,6 +123,7 @@
 	.action-menu {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
 
 		margin-top: 8px;
 	}
@@ -137,6 +138,7 @@
 
 	.action-menu :global(button.clear),
 	.action-menu :global(button) {
+		display: block;
 		padding: 10px;
 		margin: -10px;
 		height: auto;

--- a/web/src/lib/components/items/List.svelte
+++ b/web/src/lib/components/items/List.svelte
@@ -23,6 +23,9 @@
 
 <style>
 	h1 {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
 		height: 2rem;
 		font-size: 2rem;
 	}

--- a/web/src/lib/components/items/Note.svelte
+++ b/web/src/lib/components/items/Note.svelte
@@ -180,6 +180,12 @@
 		margin-top: 0.4rem;
 	}
 
+	.channel {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
 	.content-warning {
 		padding: 0.5em;
 		width: 100%;

--- a/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
@@ -254,6 +254,12 @@
 		margin-bottom: 2rem;
 	}
 
+	.edit-mode > label {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
 	button.edit,
 	input[type='submit'] {
 		background-color: transparent;

--- a/web/src/routes/(app)/preferences/Backup.svelte
+++ b/web/src/routes/(app)/preferences/Backup.svelte
@@ -104,6 +104,9 @@
 
 <style>
 	.trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
 		border-radius: 10px;
 	}
 

--- a/web/src/routes/(app)/preferences/WorkAsRemoteSigner.svelte
+++ b/web/src/routes/(app)/preferences/WorkAsRemoteSigner.svelte
@@ -47,4 +47,10 @@
 	p {
 		margin: 0.5rem 0;
 	}
+
+	button {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
 </style>


### PR DESCRIPTION
Icons are inline <svg>, so a baseline descender gap (~4px) was added to their line box, making .action-menu 24px tall instead of 20px.

Add a global `svg { display: block }` reset to remove the inline gap, and drop the now-redundant height hack in EmojiPicker. Block icons would stack under adjacent text, so flex the few icon+text containers that relied on inline svg (List heading, channel label in Note, ProxyLink fallback). Also block the action-menu trigger buttons so the ReactionButton/EmojiPicker wrappers collapse to the icon height.