### PR TITLE
Use outline:none to suppress focus-visible ring on a/button

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -247,7 +247,7 @@ button:focus,
 input:focus,
 select:focus,
 textarea:focus {
-	outline-width: 0;
+	outline: none;
 }
 
 legend {


### PR DESCRIPTION
outline-width:0 no longer hides the UA focus-visible ring because browsers draw it with outline-style:auto, which controls its own width and ignores the explicit width. Set outline:none so the ring is removed.