### PR TITLE
Request OGP as JSON from httpProxy with Accept: application/json

### DIFF
--- a/web/src/lib/components/content/Ogp.svelte
+++ b/web/src/lib/components/content/Ogp.svelte
@@ -23,9 +23,39 @@
 		cache.set(url.href, undefined);
 
 		return await new Promise((resolve) => {
-			fetch(proxy ? `${httpProxy}/?url=${encodeURIComponent(url.href)}` : url)
+			fetch(
+				proxy ? `${httpProxy}/?url=${encodeURIComponent(url.href)}` : url,
+				proxy ? { headers: { Accept: 'application/json' } } : undefined
+			)
 				.then(async (response) => {
 					const contentType = response.headers.get('Content-Type');
+					if (proxy) {
+						if (
+							!response.ok ||
+							response.status < 200 ||
+							300 <= response.status ||
+							contentType === null ||
+							!contentType.includes('application/json')
+						) {
+							console.debug(
+								'[OGP error]',
+								url.href,
+								response.ok,
+								response.status,
+								...response.headers
+							);
+							resolve(false);
+							return;
+						}
+						const ogp: Record<string, string> = await response.json();
+						console.debug('[OGP]', url.href, ogp);
+						cache.set(url.href, {
+							title: ogp['og:title'] ?? ogp['title'],
+							image: ogp['og:image']
+						});
+						resolve(true);
+						return;
+					}
 					if (
 						!response.ok ||
 						response.status < 200 ||


### PR DESCRIPTION
The proxy parses OGP server-side and returns it as JSON when the request sends Accept: application/json, so fetch it that way for proxied requests and read og:title/title/og:image from the JSON instead of parsing HTML. The direct (non-proxy) fallback keeps parsing HTML with DOMParser.