### PR TITLE
Extract OGP fetching into $lib/ogp module with unit tests

### DIFF
--- a/web/src/lib/components/content/Ogp.svelte
+++ b/web/src/lib/components/content/Ogp.svelte
@@ -1,134 +1,18 @@
 <script lang="ts" module>
 	import { SvelteMap } from 'svelte/reactivity';
+	import type { Ogp } from '$lib/ogp';
 
-	type Data = {
-		title?: string;
-		image?: string;
-	};
-
-	const cache = new SvelteMap<string, Data | undefined>();
+	const cache = new SvelteMap<string, Ogp | undefined>();
 </script>
 
 <script lang="ts">
-	import { httpProxy } from '$lib/Constants';
+	import { fetchOgp } from '$lib/ogp';
 
 	interface Props {
 		url: URL;
 	}
 
 	let { url }: Props = $props();
-
-	async function fetchOgp(url: URL, proxy: boolean): Promise<boolean> {
-		console.debug('[OGP url]', url.href, proxy);
-		cache.set(url.href, undefined);
-
-		return await new Promise((resolve) => {
-			fetch(
-				proxy ? `${httpProxy}/?url=${encodeURIComponent(url.href)}` : url,
-				proxy ? { headers: { Accept: 'application/json' } } : undefined
-			)
-				.then(async (response) => {
-					const contentType = response.headers.get('Content-Type');
-					if (proxy) {
-						if (
-							!response.ok ||
-							response.status < 200 ||
-							300 <= response.status ||
-							contentType === null ||
-							!contentType.includes('application/json')
-						) {
-							console.debug(
-								'[OGP error]',
-								url.href,
-								response.ok,
-								response.status,
-								...response.headers
-							);
-							resolve(false);
-							return;
-						}
-						const ogp: Record<string, string> = await response.json();
-						console.debug('[OGP]', url.href, ogp);
-						cache.set(url.href, {
-							title: ogp['og:title'] ?? ogp['title'],
-							image: ogp['og:image']
-						});
-						resolve(true);
-						return;
-					}
-					if (
-						!response.ok ||
-						response.status < 200 ||
-						300 <= response.status ||
-						contentType === null ||
-						!contentType.includes('text/html')
-					) {
-						console.debug(
-							'[OGP error]',
-							url.href,
-							response.ok,
-							response.status,
-							...response.headers
-						);
-						resolve(false);
-						return;
-					}
-					const html = await response.text();
-
-					// Workaround for Chromium bug
-					// <meta name="text-scale" content="scale" /> cause STATUS_ACCESS_VIOLATION
-					if (html.includes('text-scale')) {
-						console.debug('[OGP workaround]', url.href);
-						resolve(true);
-						return;
-					}
-
-					const domParser = new DOMParser();
-					const dom = domParser.parseFromString(html, 'text/html');
-					const metaTags = [...dom.head.children].filter(
-						(element) => element.tagName === 'META'
-					);
-					if (
-						!/charset=utf-8/i.test(contentType) &&
-						!metaTags.some(
-							(element) => element.getAttribute('charset')?.toLowerCase() === 'utf-8'
-						)
-					) {
-						console.debug(
-							'[OGP charset is not utf-8]',
-							url.href,
-							metaTags.find((element) => element.getAttribute('charset') !== null)
-						);
-						resolve(true);
-						return;
-					}
-					const ogp = Object.fromEntries(
-						metaTags
-							.filter(
-								(element) =>
-									element.getAttribute('property')?.startsWith('og:') &&
-									element.getAttribute('content')
-							)
-							.map((element) => {
-								return [
-									element.getAttribute('property')!,
-									element.getAttribute('content')!
-								];
-							})
-					);
-					console.debug('[OGP]', url.href, dom.title, ogp);
-					cache.set(url.href, {
-						title: ogp['og:title'] ?? dom.title,
-						image: ogp['og:image']
-					});
-					resolve(true);
-				})
-				.catch((error) => {
-					console.debug('[OGP network/CORS error]', url.href, error);
-					resolve(false);
-				});
-		});
-	}
 
 	function error(event: Event): void {
 		const img = event.target as HTMLImageElement;
@@ -138,13 +22,11 @@
 	let data = $derived(cache.get(url.href));
 
 	$effect(() => {
-		if (!cache.has(url.href)) {
-			fetchOgp(url, true).then((success) => {
-				if (!success) {
-					fetchOgp(url, false);
-				}
-			});
+		if (cache.has(url.href)) {
+			return;
 		}
+		cache.set(url.href, undefined);
+		fetchOgp(url).then((ogp) => cache.set(url.href, ogp));
 	});
 </script>
 

--- a/web/src/lib/ogp.test.ts
+++ b/web/src/lib/ogp.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchOgp, fetchOgpViaProxy } from './ogp';
+
+function jsonResponse(body: Record<string, string>, init?: { ok?: boolean; contentType?: string }) {
+	return {
+		ok: init?.ok ?? true,
+		status: init?.ok === false ? 500 : 200,
+		headers: new Headers({ 'Content-Type': init?.contentType ?? 'application/json' }),
+		json: async () => body,
+		text: async () => JSON.stringify(body)
+	} as unknown as Response;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('fetchOgpViaProxy', () => {
+	it('maps og:title and og:image', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				jsonResponse({ 'og:title': 'Title', 'og:image': 'https://example.com/i.png' })
+			)
+		);
+		expect(await fetchOgpViaProxy(new URL('https://example.com'))).toStrictEqual({
+			title: 'Title',
+			image: 'https://example.com/i.png'
+		});
+	});
+
+	it('falls back to title when og:title is missing', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonResponse({ title: 'Fallback' }))
+		);
+		expect(await fetchOgpViaProxy(new URL('https://example.com'))).toStrictEqual({
+			title: 'Fallback',
+			image: undefined
+		});
+	});
+
+	it('sends Accept: application/json to the proxy', async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ title: 'x' }));
+		vi.stubGlobal('fetch', fetchMock);
+		await fetchOgpViaProxy(new URL('https://example.com'));
+		const [, init] = fetchMock.mock.calls[0] as unknown as [unknown, RequestInit?];
+		expect(new Headers(init?.headers).get('Accept')).toBe('application/json');
+	});
+
+	it('returns undefined when response is not ok', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonResponse({}, { ok: false }))
+		);
+		expect(await fetchOgpViaProxy(new URL('https://example.com'))).toBeUndefined();
+	});
+
+	it('returns undefined when content type is not json', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonResponse({}, { contentType: 'text/html' }))
+		);
+		expect(await fetchOgpViaProxy(new URL('https://example.com'))).toBeUndefined();
+	});
+
+	it('returns undefined on network error', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				throw new TypeError('Failed to fetch');
+			})
+		);
+		expect(await fetchOgpViaProxy(new URL('https://example.com'))).toBeUndefined();
+	});
+});
+
+describe('fetchOgp', () => {
+	it('falls back to a direct fetch when the proxy yields nothing', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({}, { ok: false }))
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers({ 'Content-Type': 'text/plain' }),
+				text: async () => 'not html'
+			} as unknown as Response);
+		vi.stubGlobal('fetch', fetchMock);
+
+		expect(await fetchOgp(new URL('https://example.com'))).toBeUndefined();
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not fetch directly when the proxy succeeds', async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ 'og:title': 'Title' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		expect(await fetchOgp(new URL('https://example.com'))).toStrictEqual({
+			title: 'Title',
+			image: undefined
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web/src/lib/ogp.ts
+++ b/web/src/lib/ogp.ts
@@ -1,0 +1,97 @@
+import { httpProxy } from '$lib/Constants';
+
+export type Ogp = {
+	title?: string;
+	image?: string;
+};
+
+export async function fetchOgp(url: URL): Promise<Ogp | undefined> {
+	return (await fetchOgpViaProxy(url)) ?? (await fetchOgpDirect(url));
+}
+
+export async function fetchOgpViaProxy(url: URL): Promise<Ogp | undefined> {
+	console.debug('[ogp proxy]', url.href);
+
+	let response: Response;
+	try {
+		response = await fetch(`${httpProxy}/?url=${encodeURIComponent(url.href)}`, {
+			headers: { Accept: 'application/json' }
+		});
+	} catch (error) {
+		console.debug('[ogp proxy error]', url.href, error);
+		return undefined;
+	}
+
+	const contentType = response.headers.get('Content-Type');
+	if (!response.ok || !contentType?.includes('application/json')) {
+		console.debug('[ogp proxy error]', url.href, response.status, contentType);
+		return undefined;
+	}
+
+	const ogp: Record<string, string> = await response.json();
+	console.debug('[ogp proxy]', url.href, ogp);
+	return {
+		title: ogp['og:title'] ?? ogp['title'],
+		image: ogp['og:image']
+	};
+}
+
+export async function fetchOgpDirect(url: URL): Promise<Ogp | undefined> {
+	console.debug('[ogp direct]', url.href);
+
+	let response: Response;
+	try {
+		response = await fetch(url);
+	} catch (error) {
+		console.debug('[ogp direct error]', url.href, error);
+		return undefined;
+	}
+
+	const contentType = response.headers.get('Content-Type');
+	if (!response.ok || !contentType?.includes('text/html')) {
+		console.debug('[ogp direct error]', url.href, response.status, contentType);
+		return undefined;
+	}
+
+	const html = await response.text();
+
+	// Workaround for Chromium bug
+	// <meta name="text-scale" content="scale" /> cause STATUS_ACCESS_VIOLATION
+	if (html.includes('text-scale')) {
+		console.debug('[ogp direct workaround]', url.href);
+		return undefined;
+	}
+
+	return parseOgp(html, contentType);
+}
+
+export function parseOgp(html: string, contentType: string): Ogp | undefined {
+	const dom = new DOMParser().parseFromString(html, 'text/html');
+	const metaTags = [...dom.head.children].filter((element) => element.tagName === 'META');
+
+	if (
+		!/charset=utf-8/i.test(contentType) &&
+		!metaTags.some((element) => element.getAttribute('charset')?.toLowerCase() === 'utf-8')
+	) {
+		console.debug(
+			'[ogp charset is not utf-8]',
+			metaTags.find((element) => element.getAttribute('charset') !== null)
+		);
+		return undefined;
+	}
+
+	const ogp = Object.fromEntries(
+		metaTags
+			.filter(
+				(element) =>
+					element.getAttribute('property')?.startsWith('og:') &&
+					element.getAttribute('content')
+			)
+			.map((element) => [element.getAttribute('property')!, element.getAttribute('content')!])
+	);
+	console.debug('[ogp direct]', dom.title, ogp);
+	return {
+		title: ogp['og:title'] ?? dom.title,
+		image: ogp['og:image']
+	};
+}


### PR DESCRIPTION
Move the proxy/direct fetch and HTML parsing out of Ogp.svelte into a testable $lib/ogp module. Replace the Promise-constructor wrapper with async/await, unify the response validation, and let the component handle only caching and rendering. Add ogp.test.ts covering the proxy JSON path with a mocked fetch.