### PR TITLE
Skip content-type fetch for URLs with known media extensions

### DIFF
--- a/web/src/lib/components/Content.svelte
+++ b/web/src/lib/components/Content.svelte
@@ -12,6 +12,7 @@
 	import { Spotify } from '$lib/Spotify';
 	import { Twitter } from '$lib/Twitter';
 	import { nicovideoRegexp } from '$lib/Constants';
+	import { mediaExtensionRegexp } from '$lib/media/MediaType';
 	import type * as Nostr from 'nostr-typedef';
 
 	interface Props {
@@ -70,7 +71,7 @@
 				<!-- Niconico -->
 			{:else if url.hostname === 'amzn.to' || url.hostname === 'amzn.asia' || /^(.+\.)*amazon\.co\.jp$/s.test(url.hostname)}
 				<!-- Amazon -->
-			{:else if /\.(apng|avif|gif|jpg|jpeg|png|webp|bmp|mp3|m4a|wav|mp4|ogg|webm|ogv|mov|mkv|avi|m4v)$/i.test(url.pathname)}
+			{:else if mediaExtensionRegexp.test(url.pathname)}
 				<!-- Media -->
 			{:else}
 				<Ogp {url} />

--- a/web/src/lib/components/content/Url.svelte
+++ b/web/src/lib/components/content/Url.svelte
@@ -1,7 +1,11 @@
 <script lang="ts" module>
 	import AsyncLock from 'async-lock';
 	import { httpProxy, nicovideoRegexp } from '$lib/Constants';
-	import { mediaKindFromPathname } from '$lib/media/MediaType';
+	import {
+		mediaKindFromContentType,
+		mediaKindFromPathname,
+		type MediaKind
+	} from '$lib/media/MediaType';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	declare global {
@@ -95,6 +99,27 @@
 	let preview = $state($enablePreview);
 </script>
 
+{#snippet showMore(link: URL)}
+	<ExternalLink {link} />
+	<button onclick={() => (preview = true)}>{$_('content.show')}</button>
+{/snippet}
+
+{#snippet media(link: URL, kind: MediaKind)}
+	{#if preview}
+		{#if kind === 'image'}
+			<div>
+				<Thumbnail url={link} urls={imageUrls} />
+			</div>
+		{:else if kind === 'audio'}
+			<audio src={link.href} controls></audio>
+		{:else}
+			<Video url={link} />
+		{/if}
+	{:else}
+		{@render showMore(link)}
+	{/if}
+{/snippet}
+
 {#if link === undefined}
 	<Text {text} />
 {:else if link.protocol === 'http:'}
@@ -113,8 +138,7 @@
 			</blockquote>
 		</div>
 	{:else}
-		<ExternalLink {link} />
-		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
+		{@render showMore(link)}
 	{/if}
 {:else if Spotify.isSpotifyUrl(link)}
 	{#if preview}
@@ -128,29 +152,8 @@
 	<Nicovideo {link} />
 {:else if link.hostname === 'amzn.to' || link.hostname === 'amzn.asia' || /^(.+\.)*amazon\.co\.jp$/s.test(link.hostname)}
 	<ExternalLink {link} />
-{:else if mediaKind === 'image'}
-	{#if preview}
-		<div>
-			<Thumbnail url={link} urls={imageUrls} />
-		</div>
-	{:else}
-		<ExternalLink {link} />
-		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
-	{/if}
-{:else if mediaKind === 'audio'}
-	{#if preview}
-		<audio src={link.href} controls></audio>
-	{:else}
-		<ExternalLink {link} />
-		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
-	{/if}
-{:else if mediaKind === 'video'}
-	{#if preview}
-		<Video url={link} />
-	{:else}
-		<ExternalLink {link} />
-		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
-	{/if}
+{:else if mediaKind !== undefined}
+	{@render media(link, mediaKind)}
 {:else}
 	{#await fetchContentType(link.href)}
 		{#if url !== undefined && text !== url}
@@ -161,33 +164,15 @@
 	{:then contentType}
 		{#if contentType === null}
 			<ExternalLink {link} />
-		{:else if contentType.startsWith('image/')}
-			{#if preview}
-				<div>
-					<Thumbnail url={link} urls={imageUrls} />
-				</div>
-			{:else}
-				<ExternalLink {link} />
-				<button onclick={() => (preview = true)}>{$_('content.show')}</button>
-			{/if}
-		{:else if contentType.startsWith('audio/')}
-			{#if preview}
-				<audio src={link.href} controls></audio>
-			{:else}
-				<ExternalLink {link} />
-				<button onclick={() => (preview = true)}>{$_('content.show')}</button>
-			{/if}
-		{:else if contentType.startsWith('video/')}
-			{#if preview}
-				<Video url={link} />
-			{:else}
-				<ExternalLink {link} />
-				<button onclick={() => (preview = true)}>{$_('content.show')}</button>
-			{/if}
-		{:else if url !== undefined && text !== url}
-			<ExternalLink {link}>{text}</ExternalLink>
 		{:else}
-			<ExternalLink {link} />
+			{@const kind = mediaKindFromContentType(contentType)}
+			{#if kind !== undefined}
+				{@render media(link, kind)}
+			{:else if url !== undefined && text !== url}
+				<ExternalLink {link}>{text}</ExternalLink>
+			{:else}
+				<ExternalLink {link} />
+			{/if}
 		{/if}
 	{:catch}
 		<ExternalLink {link} />

--- a/web/src/lib/components/content/Url.svelte
+++ b/web/src/lib/components/content/Url.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
 	import AsyncLock from 'async-lock';
 	import { httpProxy, nicovideoRegexp } from '$lib/Constants';
+	import { mediaKindFromPathname } from '$lib/media/MediaType';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	declare global {
@@ -69,7 +70,14 @@
 	let { text, url = undefined, urls = [] }: Props = $props();
 
 	let link = $derived(newUrl(url ?? text));
-	let imageUrls = $derived(urls.filter((url) => cache.get(url.href)?.startsWith('image/')));
+	let mediaKind = $derived(mediaKindFromPathname(link?.pathname ?? ''));
+	let imageUrls = $derived(
+		urls.filter(
+			(url) =>
+				mediaKindFromPathname(url.pathname) === 'image' ||
+				cache.get(url.href)?.startsWith('image/')
+		)
+	);
 
 	//#region Twitter Widget
 
@@ -120,6 +128,29 @@
 	<Nicovideo {link} />
 {:else if link.hostname === 'amzn.to' || link.hostname === 'amzn.asia' || /^(.+\.)*amazon\.co\.jp$/s.test(link.hostname)}
 	<ExternalLink {link} />
+{:else if mediaKind === 'image'}
+	{#if preview}
+		<div>
+			<Thumbnail url={link} urls={imageUrls} />
+		</div>
+	{:else}
+		<ExternalLink {link} />
+		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
+	{/if}
+{:else if mediaKind === 'audio'}
+	{#if preview}
+		<audio src={link.href} controls></audio>
+	{:else}
+		<ExternalLink {link} />
+		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
+	{/if}
+{:else if mediaKind === 'video'}
+	{#if preview}
+		<Video url={link} />
+	{:else}
+		<ExternalLink {link} />
+		<button onclick={() => (preview = true)}>{$_('content.show')}</button>
+	{/if}
 {:else}
 	{#await fetchContentType(link.href)}
 		{#if url !== undefined && text !== url}

--- a/web/src/lib/media/MediaType.test.ts
+++ b/web/src/lib/media/MediaType.test.ts
@@ -6,11 +6,16 @@ describe('mediaKindFromPathname', () => {
 		expect(mediaKindFromPathname('/photo.jpg')).toBe('image');
 		expect(mediaKindFromPathname('/photo.png')).toBe('image');
 		expect(mediaKindFromPathname('/photo.webp')).toBe('image');
+		expect(mediaKindFromPathname('/icon.svg')).toBe('image');
 	});
 
 	it('detects audio extensions', () => {
 		expect(mediaKindFromPathname('/sound.mp3')).toBe('audio');
 		expect(mediaKindFromPathname('/sound.ogg')).toBe('audio');
+		expect(mediaKindFromPathname('/sound.aac')).toBe('audio');
+		expect(mediaKindFromPathname('/sound.flac')).toBe('audio');
+		expect(mediaKindFromPathname('/sound.opus')).toBe('audio');
+		expect(mediaKindFromPathname('/sound.oga')).toBe('audio');
 	});
 
 	it('detects video extensions', () => {

--- a/web/src/lib/media/MediaType.test.ts
+++ b/web/src/lib/media/MediaType.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { mediaKindFromPathname } from './MediaType';
+
+describe('mediaKindFromPathname', () => {
+	it('detects image extensions', () => {
+		expect(mediaKindFromPathname('/photo.jpg')).toBe('image');
+		expect(mediaKindFromPathname('/photo.png')).toBe('image');
+		expect(mediaKindFromPathname('/photo.webp')).toBe('image');
+	});
+
+	it('detects audio extensions', () => {
+		expect(mediaKindFromPathname('/sound.mp3')).toBe('audio');
+		expect(mediaKindFromPathname('/sound.ogg')).toBe('audio');
+	});
+
+	it('detects video extensions', () => {
+		expect(mediaKindFromPathname('/clip.mp4')).toBe('video');
+		expect(mediaKindFromPathname('/clip.ogv')).toBe('video');
+	});
+
+	it('is case insensitive', () => {
+		expect(mediaKindFromPathname('/PHOTO.JPG')).toBe('image');
+	});
+
+	it('matches against the pathname without the query string', () => {
+		expect(mediaKindFromPathname(new URL('https://example.com/a.png?x=1').pathname)).toBe(
+			'image'
+		);
+	});
+
+	it('returns undefined for unknown or missing extensions', () => {
+		expect(mediaKindFromPathname('/article')).toBeUndefined();
+		expect(mediaKindFromPathname('/file.txt')).toBeUndefined();
+		expect(mediaKindFromPathname('')).toBeUndefined();
+	});
+});

--- a/web/src/lib/media/MediaType.test.ts
+++ b/web/src/lib/media/MediaType.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mediaKindFromPathname } from './MediaType';
+import { mediaKindFromContentType, mediaKindFromPathname } from './MediaType';
 
 describe('mediaKindFromPathname', () => {
 	it('detects image extensions', () => {
@@ -32,5 +32,19 @@ describe('mediaKindFromPathname', () => {
 		expect(mediaKindFromPathname('/article')).toBeUndefined();
 		expect(mediaKindFromPathname('/file.txt')).toBeUndefined();
 		expect(mediaKindFromPathname('')).toBeUndefined();
+	});
+});
+
+describe('mediaKindFromContentType', () => {
+	it('detects the kind from the content type', () => {
+		expect(mediaKindFromContentType('image/png')).toBe('image');
+		expect(mediaKindFromContentType('audio/mpeg')).toBe('audio');
+		expect(mediaKindFromContentType('video/mp4')).toBe('video');
+	});
+
+	it('returns undefined for non-media content types', () => {
+		expect(mediaKindFromContentType('text/html')).toBeUndefined();
+		expect(mediaKindFromContentType('application/json')).toBeUndefined();
+		expect(mediaKindFromContentType('')).toBeUndefined();
 	});
 });

--- a/web/src/lib/media/MediaType.ts
+++ b/web/src/lib/media/MediaType.ts
@@ -29,3 +29,16 @@ export function mediaKindFromPathname(pathname: string): MediaKind | undefined {
 	}
 	return undefined;
 }
+
+export function mediaKindFromContentType(contentType: string): MediaKind | undefined {
+	if (contentType.startsWith('image/')) {
+		return 'image';
+	}
+	if (contentType.startsWith('audio/')) {
+		return 'audio';
+	}
+	if (contentType.startsWith('video/')) {
+		return 'video';
+	}
+	return undefined;
+}

--- a/web/src/lib/media/MediaType.ts
+++ b/web/src/lib/media/MediaType.ts
@@ -1,5 +1,5 @@
-const imageExtensions = ['apng', 'avif', 'gif', 'jpg', 'jpeg', 'png', 'webp', 'bmp'];
-const audioExtensions = ['mp3', 'm4a', 'wav', 'ogg'];
+const imageExtensions = ['apng', 'avif', 'gif', 'jpg', 'jpeg', 'png', 'webp', 'bmp', 'svg'];
+const audioExtensions = ['mp3', 'm4a', 'wav', 'ogg', 'aac', 'flac', 'opus', 'oga'];
 const videoExtensions = ['mp4', 'webm', 'ogv', 'mov', 'mkv', 'avi', 'm4v'];
 
 const extensionRegexp = (extensions: string[]): RegExp =>

--- a/web/src/lib/media/MediaType.ts
+++ b/web/src/lib/media/MediaType.ts
@@ -1,0 +1,31 @@
+const imageExtensions = ['apng', 'avif', 'gif', 'jpg', 'jpeg', 'png', 'webp', 'bmp'];
+const audioExtensions = ['mp3', 'm4a', 'wav', 'ogg'];
+const videoExtensions = ['mp4', 'webm', 'ogv', 'mov', 'mkv', 'avi', 'm4v'];
+
+const extensionRegexp = (extensions: string[]): RegExp =>
+	new RegExp(`\\.(${extensions.join('|')})$`, 'i');
+
+const imageExtensionRegexp = extensionRegexp(imageExtensions);
+const audioExtensionRegexp = extensionRegexp(audioExtensions);
+const videoExtensionRegexp = extensionRegexp(videoExtensions);
+
+export const mediaExtensionRegexp = extensionRegexp([
+	...imageExtensions,
+	...audioExtensions,
+	...videoExtensions
+]);
+
+export type MediaKind = 'image' | 'audio' | 'video';
+
+export function mediaKindFromPathname(pathname: string): MediaKind | undefined {
+	if (imageExtensionRegexp.test(pathname)) {
+		return 'image';
+	}
+	if (audioExtensionRegexp.test(pathname)) {
+		return 'audio';
+	}
+	if (videoExtensionRegexp.test(pathname)) {
+		return 'video';
+	}
+	return undefined;
+}


### PR DESCRIPTION
Derive the media kind (image/audio/video) from the URL file extension in Url.svelte and render the player directly, avoiding a content-type HEAD request (and its httpProxy fallback) for media URLs. The shared extension list lives in a new media/MediaType module and is reused by Content.svelte's OGP exclusion. Extension-less URLs still fall back to fetchContentType.