### PR TITLE
Reduce style recalculation cost of note folding

### DIFF
--- a/web/src/lib/components/shared/ViewMore.svelte
+++ b/web/src/lib/components/shared/ViewMore.svelte
@@ -4,12 +4,17 @@
 
 	interface Props {
 		onclick?: () => void | Promise<void>;
+		onfold?: (folded: boolean) => void;
 	}
 
-	let { onclick = toggle }: Props = $props();
+	let { onclick = toggle, onfold }: Props = $props();
 
 	let element = $state<HTMLDivElement>();
 	let folded = $state(true);
+
+	$effect(() => {
+		onfold?.(folded);
+	});
 
 	async function toggle(): Promise<void> {
 		folded = !folded;
@@ -34,7 +39,7 @@
 </div>
 
 <style>
-	:global(*:has(> .folded)) {
+	:global(.folded-container) {
 		max-height: var(--fold-max-height, 20rem);
 		overflow: hidden;
 		position: relative;

--- a/web/src/lib/components/shared/ViewMoreAttachment.svelte.ts
+++ b/web/src/lib/components/shared/ViewMoreAttachment.svelte.ts
@@ -5,22 +5,42 @@ import ViewMore from './ViewMore.svelte';
 export function fold(maxHeightRem = 20): Attachment<HTMLElement> {
 	return (element) => {
 		element.style.setProperty('--fold-max-height', `${maxHeightRem}rem`);
+		const maxHeight = maxHeightRem * parseFloat(getComputedStyle(element).fontSize);
 		let component: ReturnType<typeof mount> | undefined;
-		const observer = new ResizeObserver(async () => {
-			const maxHeight = maxHeightRem * parseFloat(getComputedStyle(element).fontSize);
+		let frame: number | undefined;
+
+		const update = async (): Promise<void> => {
+			frame = undefined;
 			if (element.scrollHeight > maxHeight) {
 				if (component === undefined) {
-					component = mount(ViewMore, { target: element });
+					component = mount(ViewMore, {
+						target: element,
+						props: {
+							onfold: (folded: boolean) =>
+								element.classList.toggle('folded-container', folded)
+						}
+					});
+					element.classList.add('folded-container');
 				}
 			} else if (component !== undefined) {
 				await unmount(component);
 				component = undefined;
+				element.classList.remove('folded-container');
+			}
+		};
+
+		const observer = new ResizeObserver(() => {
+			if (frame === undefined) {
+				frame = requestAnimationFrame(update);
 			}
 		});
 		observer.observe(element);
 
 		return () => {
 			observer.disconnect();
+			if (frame !== undefined) {
+				cancelAnimationFrame(frame);
+			}
 			if (component !== undefined) {
 				unmount(component);
 			}

--- a/web/src/lib/components/shared/ViewMoreAttachment.svelte.ts
+++ b/web/src/lib/components/shared/ViewMoreAttachment.svelte.ts
@@ -44,6 +44,7 @@ export function fold(maxHeightRem = 20): Attachment<HTMLElement> {
 			if (component !== undefined) {
 				unmount(component);
 			}
+			element.classList.remove('folded-container');
 		};
 	};
 }


### PR DESCRIPTION
The fold attachment attached a ResizeObserver per note whose callback read getComputedStyle() and scrollHeight on every resize, and ViewMore applied max-height via a universal :has() selector, both of which made the timeline noticeably slower.

- Replace the global *:has(> .folded) rule with an explicit folded-container class toggled on the observed element
- Compute the pixel threshold once when the attachment is created
- Coalesce ResizeObserver callbacks with requestAnimationFrame