### PR TITLE
Migrate wrangler config from Cloudflare Pages to Workers

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,6 +1,11 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "nostter",
-	"pages_build_output_dir": ".svelte-kit/cloudflare",
-	"compatibility_date": "2025-09-04"
+	"main": ".svelte-kit/cloudflare/_worker.js",
+	"compatibility_date": "2025-09-04",
+	"compatibility_flags": ["nodejs_als"],
+	"assets": {
+		"binding": "ASSETS",
+		"directory": ".svelte-kit/cloudflare"
+	}
 }


### PR DESCRIPTION
Replace pages_build_output_dir with main and assets so the SvelteKit Cloudflare adapter builds for Workers with Static Assets. Add the nodejs_als compatibility flag required by SvelteKit.