### PR TITLE
Replace svelte-remote-image with inline image fallback

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,7 +28,6 @@
 				"svelte-easy-crop": "^3.0.0",
 				"svelte-i18n": "^4.0.0",
 				"svelte-persisted-store": "^0.12.0",
-				"svelte-remote-image": "^0.4.4",
 				"swiper": "^12.1.4",
 				"twitter-text": "^3.1.0",
 				"virtua": "^0.49.1"
@@ -9232,15 +9231,6 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.48.0 || ^4 || ^5"
-			}
-		},
-		"node_modules/svelte-remote-image": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/svelte-remote-image/-/svelte-remote-image-0.4.6.tgz",
-			"integrity": "sha512-cIXe+7XeYi65iem4xC+PpFXlliuHy9b8Cbz6SB6AjjFV75CaIVL2goOy5B3p0CZnM/4fvYn0HwRJTLWsYBqH0A==",
-			"license": "MIT",
-			"peerDependencies": {
-				"svelte": "^4.0.0 || ^5.0.0"
 			}
 		},
 		"node_modules/svelte/node_modules/aria-query": {

--- a/web/package.json
+++ b/web/package.json
@@ -69,7 +69,6 @@
 		"svelte-easy-crop": "^3.0.0",
 		"svelte-i18n": "^4.0.0",
 		"svelte-persisted-store": "^0.12.0",
-		"svelte-remote-image": "^0.4.4",
 		"swiper": "^12.1.4",
 		"twitter-text": "^3.1.0",
 		"virtua": "^0.49.1"

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -4,7 +4,6 @@
 	import type * as Nostr from 'nostr-typedef';
 	import { getContext } from 'svelte';
 	import { _ } from 'svelte-i18n';
-	import { Img, type ImgSrc } from 'svelte-remote-image';
 
 	interface Props {
 		url: URL;
@@ -16,25 +15,42 @@
 	const events = getContext<Nostr.Event[] | undefined>('events');
 	const blur = events !== undefined && !events.some((event) => $followees.includes(event.pubkey));
 
-	let imageSrc: ImgSrc = $derived({
-		img: `${$imageOptimization}width=800,quality=60,format=webp/${src}`,
-		fallback: [src]
-	});
+	const optimize = $derived(
+		$imageOptimization !== '' &&
+			/\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) &&
+			!src.startsWith($imageOptimization)
+	);
+
+	// Writable $derived: reassigned on error/load, reset when url or preference changes
+	let displaySrc = $derived(
+		optimize ? `${$imageOptimization}width=800,quality=60,format=webp/${src}` : src
+	);
+	let loaded = $derived(!optimize);
 </script>
 
 <span class="img-wrapper">
-	{#if $imageOptimization && /\.(avif|jpg|jpeg|png|webp)$/i.test(pathname) && !src.startsWith($imageOptimization)}
-		<Img class="global-content-image{blur ? ' blur' : ''}" src={imageSrc} alt={src} />
-	{:else}
-		<img class="global-content-image" class:blur {src} alt={src} />
-	{/if}
+	<img
+		class:blur
+		class:loading={!loaded}
+		src={displaySrc}
+		alt={src}
+		loading="lazy"
+		onload={() => (loaded = true)}
+		onerror={() => {
+			if (displaySrc !== src) {
+				displaySrc = src;
+			} else {
+				loaded = true;
+			}
+		}}
+	/>
 	{#if blur}
 		<button>{$_('content.show')}</button>
 	{/if}
 </span>
 
 <style>
-	.img-wrapper :global(.global-content-image) {
+	img {
 		max-width: calc(100% - 1.5em);
 		max-height: 20em;
 		margin: 0.5em;
@@ -43,9 +59,12 @@
 		vertical-align: middle;
 	}
 
-	.img-wrapper :global(.global-content-image.blur),
 	img.blur {
 		filter: blur(8px);
+	}
+
+	img.loading {
+		opacity: 0;
 	}
 
 	.img-wrapper {


### PR DESCRIPTION
The library was only used to fall back to the original URL when the optimized image fails to load. Implement the fallback, lazy loading and hide-until-load behavior directly in Img.svelte and drop the dependency.