### PR TITLE
Add GIF autoplay preference

### DIFF
--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { followees } from '$lib/stores/Author';
-	import { imageOptimization } from '$lib/stores/Preference';
+	import { gifAutoplay, imageOptimization } from '$lib/stores/Preference';
 	import type * as Nostr from 'nostr-typedef';
 	import { getContext } from 'svelte';
 	import { _ } from 'svelte-i18n';
@@ -26,16 +26,60 @@
 		optimize ? `${$imageOptimization}width=800,quality=60,format=webp/${src}` : src
 	);
 	let loaded = $derived(!optimize);
+
+	const animated = $derived(/\.(gif|apng)$/i.test(pathname));
+	let playing = $state(false);
+	const frozen = $derived(animated && !$gifAutoplay && !playing);
+
+	let img: HTMLImageElement | undefined = $state();
+	let canvas: HTMLCanvasElement | undefined = $state();
+	let canvasDrawn = $state(false);
+
+	function freeze(): void {
+		if (img === undefined || canvas === undefined || !img.complete || img.naturalWidth === 0) {
+			return;
+		}
+		canvas.width = img.naturalWidth;
+		canvas.height = img.naturalHeight;
+		// drawImage renders the first frame; the canvas gets tainted but pixels are never read back
+		canvas.getContext('2d')?.drawImage(img, 0, 0);
+		canvasDrawn = true;
+	}
+
+	// Fallback for images already complete before onload fires (cache) and for preference toggles
+	$effect(() => {
+		if (frozen) {
+			if (!canvasDrawn) {
+				freeze();
+			}
+		} else {
+			canvasDrawn = false;
+		}
+	});
+
+	function play(event: MouseEvent): void {
+		// Do not bubble to the gallery dialog trigger in Thumbnail.svelte
+		event.preventDefault();
+		event.stopPropagation();
+		playing = true;
+	}
 </script>
 
 <span class="img-wrapper">
 	<img
+		bind:this={img}
 		class:blur
 		class:loading={!loaded}
+		class:frozen={frozen && canvasDrawn}
 		src={displaySrc}
 		alt={src}
 		loading="lazy"
-		onload={() => (loaded = true)}
+		onload={() => {
+			loaded = true;
+			if (frozen) {
+				freeze();
+			}
+		}}
 		onerror={() => {
 			if (displaySrc !== src) {
 				displaySrc = src;
@@ -44,13 +88,20 @@
 			}
 		}}
 	/>
+	{#if frozen}
+		<canvas bind:this={canvas} class:blur class:pending={!canvasDrawn}></canvas>
+		{#if canvasDrawn}
+			<button class="gif-badge" onclick={play}>GIF</button>
+		{/if}
+	{/if}
 	{#if blur}
 		<button>{$_('content.show')}</button>
 	{/if}
 </span>
 
 <style>
-	img {
+	img,
+	canvas {
 		max-width: calc(100% - 1.5em);
 		max-height: 20em;
 		margin: 0.5em;
@@ -59,7 +110,8 @@
 		vertical-align: middle;
 	}
 
-	img.blur {
+	img.blur,
+	canvas.blur {
 		filter: blur(8px);
 	}
 
@@ -67,11 +119,16 @@
 		opacity: 0;
 	}
 
+	img.frozen,
+	canvas.pending {
+		display: none;
+	}
+
 	.img-wrapper {
 		position: relative;
 	}
 
-	button {
+	button:not(.gif-badge) {
 		position: absolute;
 		top: 50%;
 		left: 50%;
@@ -80,5 +137,18 @@
 
 	button:hover {
 		opacity: inherit;
+	}
+
+	button.gif-badge {
+		position: absolute;
+		left: 1em;
+		bottom: 1em;
+		padding: 0.1em 0.5em;
+		font-weight: bold;
+		color: white;
+		background: rgb(0 0 0 / 0.6);
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
 	}
 </style>

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -95,7 +95,7 @@
 		{/if}
 	{/if}
 	{#if blur}
-		<button>{$_('content.show')}</button>
+		<button class="show">{$_('content.show')}</button>
 	{/if}
 </span>
 
@@ -107,7 +107,6 @@
 		margin: 0.5em;
 		border: 1px solid lightgray;
 		border-radius: 5px;
-		vertical-align: middle;
 	}
 
 	img.blur,
@@ -125,14 +124,24 @@
 	}
 
 	.img-wrapper {
-		position: relative;
+		display: inline-grid;
+		place-items: center;
+		vertical-align: middle;
 	}
 
-	button:not(.gif-badge) {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
+	/* Stack all children in the same cell so buttons overlay the image */
+	.img-wrapper > * {
+		grid-area: 1 / 1;
+	}
+
+	/* Blur's filter creates a stacking context that would otherwise paint over the buttons */
+	.img-wrapper > button {
+		z-index: 1;
+	}
+
+	/* Paint above the blur filter's stacking context */
+	.img-wrapper > button {
+		z-index: 1;
 	}
 
 	button:hover {
@@ -140,9 +149,9 @@
 	}
 
 	button.gif-badge {
-		position: absolute;
-		left: 1em;
-		bottom: 1em;
+		align-self: end;
+		justify-self: start;
+		margin: 1em;
 		padding: 0.1em 0.5em;
 		font-weight: bold;
 		color: white;

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -121,6 +121,7 @@
 		},
 		"auto_refresh": "Auto refresh",
 		"media_preview": "Media preview",
+		"gif_autoplay": "GIF autoplay",
 		"image_optimization": "Image size reduction",
 		"image_optimization_none": "None",
 		"media_uploader": {

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -120,6 +120,7 @@
 		},
 		"auto_refresh": "自動更新",
 		"media_preview": "メディアプレビュー",
+		"gif_autoplay": "GIF アニメーションの自動再生",
 		"image_optimization": "画像軽量化",
 		"image_optimization_none": "なし",
 		"media_uploader": {

--- a/web/src/lib/stores/Preference.ts
+++ b/web/src/lib/stores/Preference.ts
@@ -29,6 +29,10 @@ export const enablePreview = writable(
 	browser ? new WebStorage(localStorage).get('preference:preview') !== 'false' : true
 );
 
+export const gifAutoplay = writable(
+	browser ? new WebStorage(localStorage).get('preference:gif-autoplay') !== 'false' : true
+);
+
 export const imageOptimization = writable(browser ? getImageOptimization() : '');
 
 function getImageOptimization(): string {

--- a/web/src/routes/(app)/preferences/+page.svelte
+++ b/web/src/routes/(app)/preferences/+page.svelte
@@ -16,6 +16,7 @@
 	import Theme from './Theme.svelte';
 	import UriScheme from './UriScheme.svelte';
 	import EnablePreview from './EnablePreview.svelte';
+	import GifAutoplay from './GifAutoplay.svelte';
 	import DeveloperMode from './DeveloperMode.svelte';
 	import WebStorage from './WebStorage.svelte';
 	import RelayStates from './RelayStates.svelte';
@@ -94,6 +95,7 @@
 	<div><Language /></div>
 	<div><AutoRefresh /></div>
 	<div><EnablePreview /></div>
+	<div><GifAutoplay /></div>
 	<div><NotificationVisibility /></div>
 	<div><ImageOptimization /></div>
 	<div><Notification /></div>

--- a/web/src/routes/(app)/preferences/GifAutoplay.svelte
+++ b/web/src/routes/(app)/preferences/GifAutoplay.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { browser } from '$app/environment';
+	import { WebStorage } from '$lib/WebStorage';
+	import { gifAutoplay } from '$lib/stores/Preference';
+
+	if (browser) {
+		gifAutoplay.subscribe((value) => {
+			const storage = new WebStorage(localStorage);
+			storage.set('preference:gif-autoplay', JSON.stringify(value));
+		});
+	}
+</script>
+
+<label>
+	<input type="checkbox" bind:checked={$gifAutoplay} />
+	<span>{$_('preferences.gif_autoplay')}</span>
+</label>


### PR DESCRIPTION
Fix #1888 #1924 #2099 (@akazdayo @ikuradon Thanks!)

Add a device preference to control autoplay of animated GIFs in note content. When disabled, GIF and APNG images are shown as a still first frame drawn on a canvas with a GIF badge; clicking the badge plays the animation in place. Defaults to autoplay to keep the current behavior.