### PR TITLE
Detect animated images by sniffing file headers

### DIFF
--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -25,14 +25,14 @@
 	let displaySrc = $derived(
 		optimize ? `${$imageOptimization}width=800,quality=60,format=webp/${src}` : src
 	);
-	let loaded = $derived(!optimize);
+	let loading = $derived(optimize);
 
 	const animated = $derived(/\.(gif|apng)$/i.test(pathname));
 	let playing = $state(false);
 	const frozen = $derived(animated && !$gifAutoplay && !playing);
 
-	let img: HTMLImageElement | undefined = $state();
-	let canvas: HTMLCanvasElement | undefined = $state();
+	let img = $state<HTMLImageElement>();
+	let canvas = $state<HTMLCanvasElement>();
 	let canvasDrawn = $state(false);
 
 	function freeze(): void {
@@ -69,13 +69,13 @@
 	<img
 		bind:this={img}
 		class:blur
-		class:loading={!loaded}
+		class:loading
 		class:frozen={frozen && canvasDrawn}
 		src={displaySrc}
 		alt={src}
 		loading="lazy"
 		onload={() => {
-			loaded = true;
+			loading = false;
 			if (frozen) {
 				freeze();
 			}
@@ -84,7 +84,7 @@
 			if (displaySrc !== src) {
 				displaySrc = src;
 			} else {
-				loaded = true;
+				loading = false;
 			}
 		}}
 	/>

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { followees } from '$lib/stores/Author';
+	import { isAnimatedImage } from '$lib/media/AnimatedImage';
 	import { gifAutoplay, imageOptimization } from '$lib/stores/Preference';
 	import type * as Nostr from 'nostr-typedef';
 	import { getContext } from 'svelte';
@@ -27,9 +28,23 @@
 	);
 	let loading = $derived(optimize);
 
-	const animated = $derived(/\.(gif|apng)$/i.test(pathname));
+	const presumedAnimated = $derived(/\.(gif|apng)$/i.test(pathname));
+	const detectable = $derived(/\.(gif|apng|png|webp|avif)$/i.test(pathname));
+	// Writable $derived: updated by detection, reset when url changes
+	let animated = $derived(presumedAnimated);
 	let playing = $state(false);
 	const frozen = $derived(animated && !$gifAutoplay && !playing);
+
+	$effect(() => {
+		if (!$gifAutoplay && detectable) {
+			const target = src;
+			isAnimatedImage(target).then((result) => {
+				if (src === target) {
+					animated = result ?? presumedAnimated;
+				}
+			});
+		}
+	});
 
 	let img = $state<HTMLImageElement>();
 	let canvas = $state<HTMLCanvasElement>();

--- a/web/src/lib/media/AnimatedImage.test.ts
+++ b/web/src/lib/media/AnimatedImage.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { isAnimatedGif, isAnimatedPng, isAnimatedWebp, isAnimatedAvif } from './AnimatedImage';
+
+function bytes(...parts: (string | number[])[]): Uint8Array {
+	const data: number[] = [];
+	for (const part of parts) {
+		if (typeof part === 'string') {
+			for (const character of part) {
+				data.push(character.charCodeAt(0));
+			}
+		} else {
+			data.push(...part);
+		}
+	}
+	return new Uint8Array(data);
+}
+
+const gifHeader = bytes('GIF89a', [0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+const gifFrame = bytes(
+	[0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00], // image descriptor
+	[0x02], // LZW minimum code size
+	[0x01, 0xaa, 0x00] // data sub-block and terminator
+);
+const gifNetscape = bytes([0x21, 0xff, 0x0b], 'NETSCAPE2.0', [0x03, 0x01, 0x00, 0x00, 0x00]);
+const gifTrailer = bytes([0x3b]);
+
+describe('isAnimatedGif', () => {
+	it('returns false for a single frame', () => {
+		expect(isAnimatedGif(bytes([...gifHeader, ...gifFrame, ...gifTrailer]))).toBe(false);
+	});
+
+	it('returns true for multiple frames', () => {
+		expect(isAnimatedGif(bytes([...gifHeader, ...gifFrame, ...gifFrame, ...gifTrailer]))).toBe(
+			true
+		);
+	});
+
+	it('returns true for the NETSCAPE loop extension', () => {
+		expect(isAnimatedGif(bytes([...gifHeader, ...gifNetscape, ...gifFrame]))).toBe(true);
+	});
+
+	it('skips the global color table', () => {
+		const header = bytes(
+			'GIF89a',
+			[0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00],
+			[0x00, 0x00, 0x00, 0x00, 0x00, 0x00] // global color table (2 entries)
+		);
+		expect(isAnimatedGif(bytes([...header, ...gifNetscape]))).toBe(true);
+	});
+
+	it('returns undefined for truncated data', () => {
+		const truncatedFrame = [
+			0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0xff
+		];
+		expect(isAnimatedGif(bytes([...gifHeader, ...truncatedFrame]))).toBeUndefined();
+	});
+
+	it('returns undefined for other formats', () => {
+		expect(isAnimatedGif(bytes('\x89PNG\r\n\x1a\n'))).toBeUndefined();
+		expect(isAnimatedGif(bytes())).toBeUndefined();
+	});
+});
+
+const pngSignature = bytes([0x89], 'PNG', [0x0d, 0x0a, 0x1a, 0x0a]);
+
+function pngChunk(type: string, dataLength: number): Uint8Array {
+	return bytes(
+		[0x00, 0x00, 0x00, dataLength],
+		type,
+		Array.from({ length: dataLength + 4 }, () => 0x00) // data and CRC
+	);
+}
+
+describe('isAnimatedPng', () => {
+	it('returns false when IDAT appears without acTL', () => {
+		expect(
+			isAnimatedPng(bytes([...pngSignature, ...pngChunk('IHDR', 13), ...pngChunk('IDAT', 4)]))
+		).toBe(false);
+	});
+
+	it('returns true when acTL appears before IDAT', () => {
+		expect(
+			isAnimatedPng(bytes([...pngSignature, ...pngChunk('IHDR', 13), ...pngChunk('acTL', 8)]))
+		).toBe(true);
+	});
+
+	it('returns undefined for truncated data', () => {
+		expect(isAnimatedPng(bytes([...pngSignature, ...pngChunk('IHDR', 13)]))).toBeUndefined();
+	});
+
+	it('returns undefined for other formats', () => {
+		expect(isAnimatedPng(bytes('GIF89a'))).toBeUndefined();
+		expect(isAnimatedPng(bytes())).toBeUndefined();
+	});
+});
+
+function webp(chunk: string, ...rest: number[][]): Uint8Array {
+	return bytes('RIFF', [0x00, 0x00, 0x00, 0x00], 'WEBP', chunk, ...rest);
+}
+
+describe('isAnimatedWebp', () => {
+	it('returns false for simple formats', () => {
+		expect(isAnimatedWebp(webp('VP8 '))).toBe(false);
+		expect(isAnimatedWebp(webp('VP8L'))).toBe(false);
+	});
+
+	it('returns the animation flag of VP8X', () => {
+		expect(isAnimatedWebp(webp('VP8X', [0x0a, 0x00, 0x00, 0x00], [0x02]))).toBe(true);
+		expect(isAnimatedWebp(webp('VP8X', [0x0a, 0x00, 0x00, 0x00], [0x10]))).toBe(false);
+	});
+
+	it('returns undefined for truncated data', () => {
+		expect(isAnimatedWebp(webp('VP8X', [0x0a, 0x00, 0x00, 0x00]))).toBeUndefined();
+	});
+
+	it('returns undefined for other formats', () => {
+		expect(isAnimatedWebp(bytes('GIF89a'))).toBeUndefined();
+		expect(isAnimatedWebp(bytes())).toBeUndefined();
+	});
+});
+
+function ftyp(major: string, ...compatible: string[]): Uint8Array {
+	const size = 16 + compatible.length * 4;
+	return bytes([0x00, 0x00, 0x00, size], 'ftyp', major, [0x00, 0x00, 0x00, 0x00], ...compatible);
+}
+
+describe('isAnimatedAvif', () => {
+	it('returns false for still images', () => {
+		expect(isAnimatedAvif(ftyp('avif', 'mif1', 'miaf'))).toBe(false);
+	});
+
+	it('returns true for the avis major brand', () => {
+		expect(isAnimatedAvif(ftyp('avis', 'avif', 'mif1'))).toBe(true);
+	});
+
+	it('returns true for the avis compatible brand', () => {
+		expect(isAnimatedAvif(ftyp('avif', 'avis', 'miaf'))).toBe(true);
+	});
+
+	it('returns undefined for truncated data', () => {
+		expect(isAnimatedAvif(ftyp('avif', 'mif1').subarray(0, 18))).toBeUndefined();
+	});
+
+	it('returns undefined for other formats', () => {
+		expect(isAnimatedAvif(bytes('GIF89a'))).toBeUndefined();
+		expect(isAnimatedAvif(bytes())).toBeUndefined();
+	});
+});

--- a/web/src/lib/media/AnimatedImage.ts
+++ b/web/src/lib/media/AnimatedImage.ts
@@ -1,0 +1,166 @@
+import { httpProxy } from '$lib/Constants';
+
+// Animation markers appear near the start of each container; 16 KB also covers
+// most GIF first frames so that static GIFs can reach a decisive block
+const headLength = 16384;
+
+const cache = new Map<string, Promise<boolean | undefined>>();
+
+// undefined means the animation could not be determined
+export function isAnimatedImage(url: string): Promise<boolean | undefined> {
+	let result = cache.get(url);
+	if (result === undefined) {
+		result = fetchHead(url)
+			.then(
+				(bytes) =>
+					isAnimatedGif(bytes) ??
+					isAnimatedPng(bytes) ??
+					isAnimatedWebp(bytes) ??
+					isAnimatedAvif(bytes)
+			)
+			.catch(() => undefined);
+		cache.set(url, result);
+	}
+	return result;
+}
+
+async function fetchHead(url: string): Promise<Uint8Array> {
+	try {
+		return await readHead(await fetch(url));
+	} catch {
+		return await readHead(await fetch(`${httpProxy}/?url=${encodeURIComponent(url)}`));
+	}
+}
+
+async function readHead(response: Response): Promise<Uint8Array> {
+	if (!response.ok || response.body === null) {
+		throw new Error(`Failed to fetch: ${response.status}`);
+	}
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let length = 0;
+	while (length < headLength) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		chunks.push(value);
+		length += value.length;
+	}
+	await reader.cancel();
+	const bytes = new Uint8Array(length);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return bytes;
+}
+
+export function isAnimatedGif(bytes: Uint8Array): boolean | undefined {
+	if (ascii(bytes, 0, 4) !== 'GIF8' || bytes.length < 13) {
+		return undefined;
+	}
+	let offset = 13 + colorTableLength(bytes[10]);
+	let frames = 0;
+	while (offset >= 0 && offset < bytes.length) {
+		const block = bytes[offset];
+		if (block === 0x3b) {
+			return frames >= 2;
+		} else if (block === 0x2c) {
+			frames++;
+			if (frames >= 2) {
+				return true;
+			}
+			if (offset + 10 > bytes.length) {
+				return undefined;
+			}
+			offset += 10 + colorTableLength(bytes[offset + 9]) + 1;
+			offset = skipSubBlocks(bytes, offset);
+		} else if (block === 0x21) {
+			if (ascii(bytes, offset + 3, 11) === 'NETSCAPE2.0') {
+				return true; // the loop extension is only used by animations
+			}
+			offset = skipSubBlocks(bytes, offset + 2);
+		} else {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+export function isAnimatedPng(bytes: Uint8Array): boolean | undefined {
+	if (ascii(bytes, 0, 8) !== '\x89PNG\r\n\x1a\n') {
+		return undefined;
+	}
+	let offset = 8;
+	while (offset + 8 <= bytes.length) {
+		const length = uint32(bytes, offset);
+		const type = ascii(bytes, offset + 4, 4);
+		if (type === 'acTL') {
+			return true;
+		}
+		if (type === 'IDAT') {
+			return false; // the animation control chunk must precede IDAT
+		}
+		offset += 12 + length;
+	}
+	return undefined;
+}
+
+export function isAnimatedWebp(bytes: Uint8Array): boolean | undefined {
+	if (ascii(bytes, 0, 4) !== 'RIFF' || ascii(bytes, 8, 4) !== 'WEBP') {
+		return undefined;
+	}
+	const chunk = ascii(bytes, 12, 4);
+	if (chunk === 'VP8 ' || chunk === 'VP8L') {
+		return false;
+	}
+	if (chunk === 'VP8X' && bytes.length > 20) {
+		return (bytes[20] & 0x02) !== 0;
+	}
+	return undefined;
+}
+
+export function isAnimatedAvif(bytes: Uint8Array): boolean | undefined {
+	if (ascii(bytes, 4, 4) !== 'ftyp') {
+		return undefined;
+	}
+	const size = uint32(bytes, 0);
+	if (size < 16 || size % 4 !== 0) {
+		return undefined;
+	}
+	const end = Math.min(size, bytes.length);
+	for (let offset = 8; offset + 4 <= end; offset += 4) {
+		if (ascii(bytes, offset, 4) === 'avis') {
+			return true; // the image sequence brand
+		}
+	}
+	return size <= bytes.length ? false : undefined;
+}
+
+function colorTableLength(packedField: number): number {
+	return (packedField & 0x80) !== 0 ? 3 * 2 ** ((packedField & 0x07) + 1) : 0;
+}
+
+function skipSubBlocks(bytes: Uint8Array, offset: number): number {
+	while (offset < bytes.length) {
+		const size = bytes[offset];
+		if (size === 0) {
+			return offset + 1;
+		}
+		offset += size + 1;
+	}
+	return -1;
+}
+
+function ascii(bytes: Uint8Array, offset: number, length: number): string {
+	return String.fromCharCode(...bytes.subarray(offset, offset + length));
+}
+
+function uint32(bytes: Uint8Array, offset: number): number {
+	return (
+		bytes[offset] * 0x1000000 +
+		((bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3])
+	);
+}


### PR DESCRIPTION
Extension-based detection froze static GIFs and missed APNG distributed
as .png, animated WebP and animated AVIF. When GIF autoplay is off,
fetch the first 16 KB of the image (falling back to the HTTP proxy when
CORS blocks the read) and inspect the container: NETSCAPE loop
extension or a second image descriptor for GIF, an acTL chunk before
IDAT for PNG, the VP8X animation flag for WebP and the avis brand for
AVIF. Results are cached per URL and fall back to the extension-based
presumption when undeterminable.