### PR TITLE
Improve lists page UI

### DIFF
--- a/web/src/routes/(app)/[slug=npub]/(tabs)/lists/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/lists/+page.svelte
@@ -4,9 +4,7 @@
 	import { type Subscription, filter } from 'rxjs';
 	import type * as Nostr from 'nostr-typedef';
 	import { nip19 } from 'nostr-tools';
-	import IconList from '@tabler/icons-svelte-runes/icons/list';
-	import IconLock from '@tabler/icons-svelte-runes/icons/lock';
-	import IconUsers from '@tabler/icons-svelte-runes/icons/users';
+	import { IconList, IconLock, IconUsers } from '@tabler/icons-svelte-runes';
 	import { afterNavigate, beforeNavigate } from '$app/navigation';
 	import { metadataStore } from '$lib/cache/Events';
 	import { getSeenOnRelays, metadataReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
@@ -73,21 +71,24 @@
 							? await decryptListContent(event.pubkey, event.content)
 							: [[] as string[][]];
 
-					const publicPubkeys = filterTags('p', event.tags);
-					const privatePubkeys = filterTags('p', privateTags);
+					const pubkeys = new Set([
+						...filterTags('p', event.tags),
+						...filterTags('p', privateTags)
+					]);
 
 					// For legacy clients
-					if (publicPubkeys.length === 0 && privateTags.length === 0) {
+					if (pubkeys.size === 0) {
 						return;
 					}
-
-					const memberCount = new Set([...publicPubkeys, ...privatePubkeys]).size;
-					const isPrivate = event.pubkey === $pubkey && event.content !== '';
 
 					const identifier = findIdentifier(event.tags) ?? '';
 					const last = listItems.get(identifier);
 					if (last === undefined || last.event.created_at < event.created_at) {
-						listItems.set(identifier, { event, memberCount, isPrivate });
+						listItems.set(identifier, {
+							event,
+							memberCount: pubkeys.size,
+							isPrivate: privateTags.length > 0
+						});
 					}
 				},
 				complete: () => {
@@ -148,7 +149,7 @@
 
 <style>
 	.content {
-		min-height: 100vh;
+		min-height: 80vh;
 	}
 
 	ul {

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/lists/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/lists/+page.svelte
@@ -110,41 +110,47 @@
 
 <ProfileTabs tab="lists" {slug} />
 
-{#if listItems.size > 0}
-	<ul class="clear">
-		{#each [...listItems.values()].sort(reverseChronologicalItem) as { event, memberCount, isPrivate } (event.id)}
-			<li>
-				<a
-					class="card"
-					href="/{nip19.npubEncode(data.pubkey)}/lists/{nip19.naddrEncode({
-						kind: event.kind,
-						pubkey: event.pubkey,
-						identifier: findIdentifier(event.tags) ?? '',
-						relays: getSeenOnRelays(event.id)
-					})}"
-				>
-					<div class="title">
-						<IconList size={20} />
-						<span class="name">{getListTitle(event.tags)}</span>
-						{#if isPrivate}
-							<IconLock size={16} />
-						{/if}
-					</div>
-					<div class="members">
-						<IconUsers size={16} />
-						<span>{memberCount}</span>
-					</div>
-				</a>
-			</li>
-		{/each}
-	</ul>
-{:else if loading}
-	<Loading />
-{:else}
-	<p class="card">{$_('lists.none')}</p>
-{/if}
+<div class="content">
+	{#if listItems.size > 0}
+		<ul class="clear">
+			{#each [...listItems.values()].sort(reverseChronologicalItem) as { event, memberCount, isPrivate } (event.id)}
+				<li>
+					<a
+						class="card"
+						href="/{nip19.npubEncode(data.pubkey)}/lists/{nip19.naddrEncode({
+							kind: event.kind,
+							pubkey: event.pubkey,
+							identifier: findIdentifier(event.tags) ?? '',
+							relays: getSeenOnRelays(event.id)
+						})}"
+					>
+						<div class="title">
+							<IconList size={20} />
+							<span class="name">{getListTitle(event.tags)}</span>
+							{#if isPrivate}
+								<IconLock size={16} />
+							{/if}
+						</div>
+						<div class="members">
+							<IconUsers size={16} />
+							<span>{memberCount}</span>
+						</div>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{:else if loading}
+		<Loading />
+	{:else}
+		<p class="card">{$_('lists.none')}</p>
+	{/if}
+</div>
 
 <style>
+	.content {
+		min-height: 100vh;
+	}
+
 	ul {
 		display: flex;
 		flex-direction: column;

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/lists/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/lists/+page.svelte
@@ -4,13 +4,15 @@
 	import { type Subscription, filter } from 'rxjs';
 	import type * as Nostr from 'nostr-typedef';
 	import { nip19 } from 'nostr-tools';
+	import IconList from '@tabler/icons-svelte-runes/icons/list';
+	import IconLock from '@tabler/icons-svelte-runes/icons/lock';
+	import IconUsers from '@tabler/icons-svelte-runes/icons/users';
 	import { afterNavigate, beforeNavigate } from '$app/navigation';
 	import { metadataStore } from '$lib/cache/Events';
 	import { getSeenOnRelays, metadataReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
-	import { appName, reverseChronological } from '$lib/Constants';
-	import { isDecodable } from '$lib/Encryption';
-	import { findIdentifier } from '$lib/EventHelper';
-	import { getListTitle } from '$lib/List';
+	import { appName, reverseChronologicalItem } from '$lib/Constants';
+	import { filterTags, findIdentifier } from '$lib/EventHelper';
+	import { decryptListContent, getListTitle } from '$lib/List';
 	import type { LayoutProps } from '../$types';
 	import { pubkey } from '$lib/stores/Author';
 	import Loading from '$lib/components/Loading.svelte';
@@ -18,9 +20,15 @@
 	import { page } from '$app/state';
 	import ProfileTabs from '../ProfileTabs.svelte';
 
+	interface ListItem {
+		event: Nostr.Event;
+		memberCount: number;
+		isPrivate: boolean;
+	}
+
 	let { data }: LayoutProps = $props();
 
-	let listEvents = new SvelteMap<string, Nostr.Event>();
+	let listItems = new SvelteMap<string, ListItem>();
 	let loading = $state(true);
 	let subscription: Subscription | undefined;
 
@@ -33,7 +41,7 @@
 
 	afterNavigate(() => {
 		console.log('[lists page]', data.pubkey);
-		listEvents.clear();
+		listItems.clear();
 		loading = true;
 		metadataReqEmit([data.pubkey]);
 
@@ -60,20 +68,26 @@
 				next: async ({ event }) => {
 					console.debug('[lists event]', event);
 
+					const [privateTags] =
+						event.pubkey === $pubkey && event.content !== ''
+							? await decryptListContent(event.pubkey, event.content)
+							: [[] as string[][]];
+
+					const publicPubkeys = filterTags('p', event.tags);
+					const privatePubkeys = filterTags('p', privateTags);
+
 					// For legacy clients
-					if (
-						!event.tags.some(
-							([tagName, pubkey]) => tagName === 'p' && pubkey !== undefined
-						) &&
-						!(await isDecodable(event.pubkey, event.content))
-					) {
+					if (publicPubkeys.length === 0 && privateTags.length === 0) {
 						return;
 					}
 
+					const memberCount = new Set([...publicPubkeys, ...privatePubkeys]).size;
+					const isPrivate = event.pubkey === $pubkey && event.content !== '';
+
 					const identifier = findIdentifier(event.tags) ?? '';
-					const last = listEvents.get(identifier);
-					if (last === undefined || last.created_at < event.created_at) {
-						listEvents.set(identifier, event);
+					const last = listItems.get(identifier);
+					if (last === undefined || last.event.created_at < event.created_at) {
+						listItems.set(identifier, { event, memberCount, isPrivate });
 					}
 				},
 				complete: () => {
@@ -96,25 +110,78 @@
 
 <ProfileTabs tab="lists" {slug} />
 
-<ul>
-	{#each [...listEvents].map(([, event]) => event).sort(reverseChronological) as event}
-		<li class="card">
-			<a
-				href="/{nip19.npubEncode(data.pubkey)}/lists/{nip19.naddrEncode({
-					kind: event.kind,
-					pubkey: event.pubkey,
-					identifier: findIdentifier(event.tags) ?? '',
-					relays: getSeenOnRelays(event.id)
-				})}"
-			>
-				{getListTitle(event.tags)}
-			</a>
-		</li>
-	{:else}
-		{#if loading}
-			<Loading />
-		{:else}
-			<p class="card">{$_('lists.none')}</p>
-		{/if}
-	{/each}
-</ul>
+{#if listItems.size > 0}
+	<ul class="clear">
+		{#each [...listItems.values()].sort(reverseChronologicalItem) as { event, memberCount, isPrivate } (event.id)}
+			<li>
+				<a
+					class="card"
+					href="/{nip19.npubEncode(data.pubkey)}/lists/{nip19.naddrEncode({
+						kind: event.kind,
+						pubkey: event.pubkey,
+						identifier: findIdentifier(event.tags) ?? '',
+						relays: getSeenOnRelays(event.id)
+					})}"
+				>
+					<div class="title">
+						<IconList size={20} />
+						<span class="name">{getListTitle(event.tags)}</span>
+						{#if isPrivate}
+							<IconLock size={16} />
+						{/if}
+					</div>
+					<div class="members">
+						<IconUsers size={16} />
+						<span>{memberCount}</span>
+					</div>
+				</a>
+			</li>
+		{/each}
+	</ul>
+{:else if loading}
+	<Loading />
+{:else}
+	<p class="card">{$_('lists.none')}</p>
+{/if}
+
+<style>
+	ul {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin: 1rem 0;
+	}
+
+	a.card {
+		display: block;
+		color: inherit;
+		text-decoration: none;
+		transition: background-color 0.2s ease;
+	}
+
+	a.card:hover {
+		background-color: var(--accent-surface-low);
+	}
+
+	.title {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-weight: 600;
+	}
+
+	.title .name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.members {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-top: 0.5rem;
+		color: var(--accent-gray);
+		font-size: 0.875rem;
+	}
+</style>


### PR DESCRIPTION
Make each list card fully clickable and show a list icon, member count, and a lock icon for lists with private members. Remove default list bullets and add spacing and hover styles consistent with other pages.

Counting private members uses decryptListContent, which supports both NIP-04 and NIP-44, so private lists encrypted with NIP-44 by other clients are now displayed as well.