### PR TITLE
Use Cloudflare KV binding for npub restriction check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,3 @@ jobs:
       - run: npm ci
       - run: npx playwright install
       - run: npm run test:e2e
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,8 +1,5 @@
 # Server
 BROWSER=chrome
-CLOUDFLARE_API_TOKEN=
-CLOUDFLARE_ACCOUNT_ID=
-CLOUDFLARE_KV_NAMESPACE_ID=
 
 # Client
 # @see src/vite-env.d.ts

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,6 +34,7 @@
 			},
 			"devDependencies": {
 				"@beyonk/gdpr-cookie-consent-banner": "^16.0.2",
+				"@cloudflare/workers-types": "^4.20260528.1",
 				"@eslint/compat": "^2.0.4",
 				"@eslint/js": "^9.39.4",
 				"@melt-ui/pp": "^0.3.2",
@@ -225,9 +226,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260603.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260603.1.tgz",
-			"integrity": "sha512-TLeVHoBbcYv35S5TdRWUoj3IJ56BhHtrsuci+O7ithU8yz7ttNdCk6rAl1QUSGNVEWSIp54bWOuV/xmX1zu79g==",
+			"version": "4.20260528.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260528.1.tgz",
+			"integrity": "sha512-sTNOEN+8DvAOdE7MG3I/TbRGrjZnfbf0aqyTR4wzVi2GEpHTG9DzaK0MSA0z0JS2LmTUSSWimj4mB4cJaYk9rQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0"
 		},

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
 	},
 	"devDependencies": {
 		"@beyonk/gdpr-cookie-consent-banner": "^16.0.2",
+		"@cloudflare/workers-types": "^4.20260528.1",
 		"@eslint/compat": "^2.0.4",
 		"@eslint/js": "^9.39.4",
 		"@melt-ui/pp": "^0.3.2",

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -1,3 +1,5 @@
+import type { KVNamespace } from '@cloudflare/workers-types';
+
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
@@ -5,7 +7,11 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
-		// interface Platform {}
+		interface Platform {
+			env?: {
+				RESTRICTION?: KVNamespace;
+			};
+		}
 	}
 }
 

--- a/web/src/lib/server/Restriction.ts
+++ b/web/src/lib/server/Restriction.ts
@@ -1,26 +1,18 @@
-import {
-	CLOUDFLARE_ACCOUNT_ID,
-	CLOUDFLARE_API_TOKEN,
-	CLOUDFLARE_KV_NAMESPACE_ID
-} from '$env/static/private';
 import { error } from '@sveltejs/kit';
 
-export async function checkRestriction(pubkey: string): Promise<void> {
-	console.time('[npub restriction]');
-
-	if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_API_TOKEN || !CLOUDFLARE_KV_NAMESPACE_ID) {
+export async function checkRestriction(
+	pubkey: string,
+	platform: App.Platform | undefined
+): Promise<void> {
+	const kv = platform?.env?.RESTRICTION;
+	if (kv === undefined) {
 		return;
 	}
 
-	const url = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces/${CLOUDFLARE_KV_NAMESPACE_ID}/values/${pubkey}`;
-	const response = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`
-		}
-	});
+	console.time('[npub restriction]');
+	const restriction = await kv.get<Restriction>(pubkey, 'json');
 	console.timeEnd('[npub restriction]');
-	if (response.ok) {
-		const restriction = (await response.json()) as Restriction;
+	if (restriction !== null) {
 		console.error('[npub restriction]', restriction);
 		error(restriction.status, restriction.statusText);
 	}

--- a/web/src/routes/(app)/[slug=note]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=note]/+layout.server.ts
@@ -10,7 +10,7 @@ export const load: LayoutServerLoad<{
 	eventId: string;
 	relays: string[];
 	event: Nostr.Event | undefined;
-}> = async ({ params }) => {
+}> = async ({ params, platform }) => {
 	console.debug('[thread page load]', params.slug);
 	try {
 		const { type, data } = nip19.decode(params.slug);
@@ -42,7 +42,7 @@ export const load: LayoutServerLoad<{
 		);
 
 		if (event !== undefined) {
-			await checkRestriction(event.pubkey);
+			await checkRestriction(event.pubkey, platform);
 		}
 
 		return {

--- a/web/src/routes/(app)/[slug=npub]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=npub]/+layout.server.ts
@@ -17,7 +17,7 @@ type Data = {
 	image?: string;
 };
 
-export const load: LayoutServerLoad<Data> = async ({ params }) => {
+export const load: LayoutServerLoad<Data> = async ({ params, platform }) => {
 	console.log('[npub page load]', params.slug);
 	console.time('[npub decode]');
 	const { pubkey, relays } = await User.decode(params.slug);
@@ -26,7 +26,7 @@ export const load: LayoutServerLoad<Data> = async ({ params }) => {
 		error(404, 'Not Found');
 	}
 
-	await checkRestriction(pubkey);
+	await checkRestriction(pubkey, platform);
 
 	console.time('[metadata]');
 	const metadataEvent = await fetchMetadata(

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -7,5 +7,12 @@
 	"assets": {
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"
-	}
+	},
+	"kv_namespaces": [
+		{
+			"binding": "RESTRICTION",
+			// Placeholder. Replace with the actual KV namespace ID when deploying.
+			"id": "00000000000000000000000000000000"
+		}
+	]
 }


### PR DESCRIPTION
Replace the Cloudflare REST API lookup with a KV namespace binding accessed via platform.env. This avoids the HTTPS round-trip and API rate limits on the SSR path, and removes the need for the CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN and
CLOUDFLARE_KV_NAMESPACE_ID environment variables.

The namespace ID in wrangler.jsonc is a placeholder to be replaced with the actual ID when deploying.