### PR TITLE
Show users without kind 0 metadata in followees, followers, and list members

### DIFF
--- a/web/src/lib/EventNavigation.ts
+++ b/web/src/lib/EventNavigation.ts
@@ -62,6 +62,9 @@ const resolveZapDestination = (nostrEvent: Nostr.Event): string | undefined => {
 	return target !== undefined ? `/${nip19.npubEncode(target)}` : undefined;
 };
 
+const resolveProfileDestination = (nostrEvent: Nostr.Event): string | undefined =>
+	nostrEvent.kind === 0 ? `/${nip19.npubEncode(nostrEvent.pubkey)}` : undefined;
+
 const resolveEventDestination = (nostrEvent: Nostr.Event): string => {
 	const eventId = [6, 7, 9735].includes(nostrEvent.kind)
 		? getTargetETag(nostrEvent.tags)
@@ -72,6 +75,7 @@ const resolveEventDestination = (nostrEvent: Nostr.Event): string => {
 const resolveDestination = (nostrEvent: Nostr.Event): string =>
 	resolveChannelDestination(nostrEvent) ??
 	resolveZapDestination(nostrEvent) ??
+	resolveProfileDestination(nostrEvent) ??
 	resolveEventDestination(nostrEvent);
 
 export async function navigateTo(

--- a/web/src/lib/Items.ts
+++ b/web/src/lib/Items.ts
@@ -91,12 +91,31 @@ export class ZapEventItem extends EventItem {
 export class Metadata implements Item {
 	public readonly content: MetadataContent | undefined;
 	private _zapUrl: URL | null | undefined;
+	private static readonly placeholderCache = new Map<pubkey, Metadata>();
 	constructor(public readonly event: Event) {
 		try {
 			this.content = JSON.parse(event.content);
 		} catch (error) {
 			console.warn('[invalid metadata item]', error, event);
 		}
+	}
+
+	// For pubkeys whose kind 0 is missing; getters fall back to npub and robohash
+	public static placeholder(pubkey: pubkey): Metadata {
+		let metadata = Metadata.placeholderCache.get(pubkey);
+		if (metadata === undefined) {
+			metadata = new Metadata({
+				id: pubkey,
+				pubkey,
+				kind: 0,
+				tags: [],
+				content: '{}',
+				created_at: 0,
+				sig: ''
+			});
+			Metadata.placeholderCache.set(pubkey, metadata);
+		}
+		return metadata;
 	}
 
 	public get id(): string {

--- a/web/src/lib/components/items/Profile.svelte
+++ b/web/src/lib/components/items/Profile.svelte
@@ -54,25 +54,30 @@
 		display: flex;
 		flex-direction: row;
 		gap: 12px;
+		min-width: 0;
 	}
 
 	.text {
-		width: 100%;
+		width: calc(100% - 60px);
+		min-width: 0;
 	}
 
 	.row {
 		display: flex;
 		flex-direction: row;
+		min-width: 0;
 	}
 
 	.display_name {
 		margin-right: 4px;
 		font-weight: 700;
+		flex-shrink: 1;
 	}
 
 	.name {
 		color: var(--accent-gray);
 		font-size: 15px;
+		flex-shrink: 2;
 	}
 
 	.display_name,
@@ -85,5 +90,6 @@
 
 	.follow {
 		margin-left: auto;
+		flex-shrink: 0;
 	}
 </style>

--- a/web/src/lib/components/items/Profile.svelte
+++ b/web/src/lib/components/items/Profile.svelte
@@ -28,10 +28,12 @@
 			<div class="display_name">
 				<EmojifiedContent content={metadata.displayName} tags={metadata.event.tags} />
 			</div>
-			<div class="name">
-				<span>@</span>
-				<EmojifiedContent content={metadata.name} tags={metadata.event.tags} />
-			</div>
+			{#if metadata.content?.name || metadata.content?.display_name || metadata.normalizedNip05}
+				<div class="name">
+					<span>@</span>
+					<EmojifiedContent content={metadata.name} tags={metadata.event.tags} />
+				</div>
+			{/if}
 			{#if !$rom}
 				<div class="follow">
 					<FollowButton pubkey={metadata.event.pubkey} />

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/members/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/members/+page.svelte
@@ -5,7 +5,7 @@
 	import { page } from '$app/state';
 	import { appName } from '$lib/Constants';
 	import { fetchListEvent, getListPubkeys, getListTitle } from '$lib/List';
-	import type { Metadata } from '$lib/Items';
+	import { Metadata } from '$lib/Items';
 	import { metadataReqEmit } from '$lib/timelines/MainTimeline';
 	import { metadataStore } from '$lib/cache/Events';
 	import { lastNoteReqEmit } from '$lib/LastNotes';
@@ -27,9 +27,7 @@
 	let title = $derived(listEvent === undefined ? '' : getListTitle(listEvent.tags));
 
 	let items = $derived(
-		pubkeys
-			.map((pubkey) => $metadataStore.get(pubkey))
-			.filter((metadata): metadata is Metadata => metadata !== undefined)
+		pubkeys.map((pubkey) => $metadataStore.get(pubkey) ?? Metadata.placeholder(pubkey))
 	);
 
 	afterNavigate(async () => {

--- a/web/src/routes/(app)/[slug=npub]/followees/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/followees/+page.svelte
@@ -9,7 +9,7 @@
 	import TimelineView from '../../TimelineView.svelte';
 	import { author, pubkey as authorPubkey } from '$lib/stores/Author';
 	import { appName } from '$lib/Constants';
-	import type { Metadata } from '$lib/Items';
+	import { Metadata } from '$lib/Items';
 	import type { LayoutData } from '../$types';
 	import { metadataReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
 	import { metadataStore } from '$lib/cache/Events';
@@ -28,9 +28,7 @@
 	let pubkeys: Pubkey[] = $state([]);
 
 	let items = $derived(
-		pubkeys
-			.map((pubkey) => $metadataStore.get(pubkey))
-			.filter((metadata): metadata is Metadata => metadata !== undefined)
+		pubkeys.map((pubkey) => $metadataStore.get(pubkey) ?? Metadata.placeholder(pubkey))
 	);
 
 	run(() => {

--- a/web/src/routes/(app)/[slug=npub]/followers/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/followers/+page.svelte
@@ -8,7 +8,7 @@
 	import { browser } from '$app/environment';
 	import TimelineView from '../../TimelineView.svelte';
 	import { appName } from '$lib/Constants';
-	import type { Metadata } from '$lib/Items';
+	import { Metadata } from '$lib/Items';
 	import type { LayoutData } from '../$types';
 	import { metadataReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
 	import { metadataStore } from '$lib/cache/Events';
@@ -25,9 +25,7 @@
 	let pubkeys = new SvelteSet<string>();
 
 	let items = $derived(
-		[...pubkeys]
-			.map((pubkey) => $metadataStore.get(pubkey))
-			.filter((metadata): metadata is Metadata => metadata !== undefined)
+		[...pubkeys].map((pubkey) => $metadataStore.get(pubkey) ?? Metadata.placeholder(pubkey))
 	);
 
 	run(() => {


### PR DESCRIPTION
Users whose kind 0 event is missing were filtered out of the followees, followers, and list members pages. Render them with a placeholder Metadata that falls back to a truncated npub and robohash icon, and navigate kind 0 items to the profile page instead of the thread page so placeholder rows do not lead to a not-found event page.