### PR TITLE
Reduce server-side logs and enable Workers Logs observability

### DIFF
--- a/web/src/lib/Api.ts
+++ b/web/src/lib/Api.ts
@@ -126,7 +126,6 @@ export class Api {
 }
 
 export const fetchEvent = async (id: string, relays: string[]): Promise<Event | undefined> => {
-	console.debug('[api request id]', id, relays);
 	const response = await fetch(`https://api.nostter.app/${nip19.neventEncode({ id, relays })}`, {
 		headers: {
 			'User-Agent': 'nostter'
@@ -136,16 +135,13 @@ export const fetchEvent = async (id: string, relays: string[]): Promise<Event | 
 		console.warn('[api event not found]', await response.text());
 		return undefined;
 	}
-	const event = (await response.json()) as Event;
-	console.debug('[api response]', event);
-	return event;
+	return (await response.json()) as Event;
 };
 
 export const fetchMetadata = async (
 	pubkey: string,
 	relays: string[]
 ): Promise<Event | undefined> => {
-	console.debug('[api request pubkey]', pubkey, relays);
 	const response = await fetch(
 		`https://api.nostter.app/${nip19.nprofileEncode({ pubkey, relays })}`,
 		{
@@ -158,7 +154,5 @@ export const fetchMetadata = async (
 		console.warn('[api metadata not found]', await response.text());
 		return undefined;
 	}
-	const event = (await response.json()) as Event;
-	console.debug('[api response]', event);
-	return event;
+	return (await response.json()) as Event;
 };

--- a/web/src/lib/User.ts
+++ b/web/src/lib/User.ts
@@ -3,8 +3,6 @@ import type * as Nostr from 'nostr-typedef';
 
 export class User {
 	static async decode(slug: string): Promise<{ pubkey: string | undefined; relays: string[] }> {
-		console.debug('[slug]', slug);
-
 		let pubkey: string | undefined = undefined;
 		let relays: string[] = [];
 
@@ -28,20 +26,17 @@ export class User {
 				}
 			} else {
 				const match = slug.match(/^(?:([\w-.]+)@)?([\w-.]+)$/);
-				console.debug('[NIP-05 match]', match);
 				if (match === null) {
 					throw new Error(`${slug} doesn't match NIP-05`);
 				}
 				const [, name = '_', domain] = match;
 				const url = `https://${domain}/.well-known/nostr.json?name=${name}`;
-				console.debug('[NIP-05 url]', url);
 				const response = await fetch(url);
 				if (!response.ok) {
 					console.error('[invalid NIP-05]', await response.text());
 					throw new Error('fetch failed');
 				}
 				const data = (await response.json()) as Nostr.Nip05.NostrAddress;
-				console.debug('[NIP-05]', data);
 				pubkey = Object.entries(data.names).find(
 					([key]) => key.toLowerCase() === name.toLowerCase()
 				)?.[1];
@@ -52,8 +47,6 @@ export class User {
 		} catch (error) {
 			console.error('[decode failed]', slug, error);
 		}
-
-		console.debug('[decoded]', slug, pubkey, relays);
 
 		return {
 			pubkey,

--- a/web/src/lib/cache/Events.ts
+++ b/web/src/lib/cache/Events.ts
@@ -23,7 +23,6 @@ export function storeMetadata(event: Nostr.Event): void {
 	const cache = $metadataStore.get(event.pubkey);
 	if (cache === undefined || cache.event.created_at < event.created_at) {
 		const metadata = new Metadata(event);
-		console.debug('[store metadata]', event, metadata.content?.name);
 		$metadataStore.set(metadata.event.pubkey, metadata);
 		metadataStore.set($metadataStore);
 

--- a/web/src/lib/components/ZapButton.svelte
+++ b/web/src/lib/components/ZapButton.svelte
@@ -18,7 +18,6 @@
 	let metadata = $derived($metadataStore.get(pubkey));
 	run(() => {
 		if (metadata === undefined) {
-			console.debug('[metadata undefined]', pubkey);
 			metadataReqEmit([pubkey]);
 		}
 	});

--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -272,7 +272,6 @@
 
 	// FIXME: Change trigger
 	openNoteDialog.subscribe(async (open) => {
-		console.log('[open]', open);
 		if (open) {
 			if ($quotes.length > 0) {
 				content =
@@ -300,8 +299,6 @@
 	});
 
 	intentContent.subscribe((value) => {
-		console.log('[content override]');
-
 		content = value;
 		value = '';
 	});

--- a/web/src/lib/server/Restriction.ts
+++ b/web/src/lib/server/Restriction.ts
@@ -9,9 +9,7 @@ export async function checkRestriction(
 		return;
 	}
 
-	console.time('[npub restriction]');
 	const restriction = await kv.get<Restriction>(pubkey, 'json');
-	console.timeEnd('[npub restriction]');
 	if (restriction !== null) {
 		console.error('[npub restriction]', restriction);
 		error(restriction.status, restriction.statusText);

--- a/web/src/lib/stores/Events.ts
+++ b/web/src/lib/stores/Events.ts
@@ -2,8 +2,6 @@ import { writable, type Writable } from 'svelte/store';
 import type { Event } from '../../routes/types';
 import type { EventItem } from '$lib/Items';
 
-console.log('[events store]');
-
 export const events: Writable<EventItem[]> = writable([]);
 export const eventsPool: Writable<EventItem[]> = writable([]);
 export const searchEvents: Writable<Event[]> = writable([]);

--- a/web/src/lib/stores/LastNotes.ts
+++ b/web/src/lib/stores/LastNotes.ts
@@ -2,8 +2,6 @@ import { kinds as Kind, type Event } from 'nostr-tools';
 import { get, writable } from 'svelte/store';
 import { followees } from './Author';
 
-console.log('[last notes store]');
-
 export const lastNotesMap = writable(new Map<string, Event>());
 export const saveLastNote = (event: Event) => {
 	if (event.kind !== Kind.ShortTextNote || !get(followees).includes(event.pubkey)) {

--- a/web/src/lib/stores/NoteDialog.ts
+++ b/web/src/lib/stores/NoteDialog.ts
@@ -2,8 +2,6 @@ import { writable, type Writable } from 'svelte/store';
 import type * as Nostr from 'nostr-typedef';
 import type { EventItem } from '$lib/Items';
 
-console.log('[note dialog store]');
-
 export const openNoteDialog = writable(false);
 export const replyTo: Writable<EventItem | undefined> = writable(undefined);
 export const quotes: Writable<Nostr.Event[]> = writable([]);

--- a/web/src/lib/stores/Preference.ts
+++ b/web/src/lib/stores/Preference.ts
@@ -3,8 +3,6 @@ import { WebStorage } from '$lib/WebStorage';
 import { writable, type Writable } from 'svelte/store';
 import { imageOptimizerServers } from '$lib/Constants';
 
-console.log('[preference store]');
-
 // Persistent in relay => $lib/Preferences.ts
 
 // Persistent in local

--- a/web/src/lib/stores/UserEvents.ts
+++ b/web/src/lib/stores/UserEvents.ts
@@ -2,8 +2,6 @@ import { writable, type Writable } from 'svelte/store';
 import type { User, UserEvent } from '../../routes/types';
 import { nip57, type Event } from 'nostr-tools';
 
-console.log('[user events store]');
-
 export const userEvents: Writable<Map<string, UserEvent>> = writable(new Map());
 function saveUserEvent(userEvent: UserEvent) {
 	userEvents.update((userEvents) => {

--- a/web/src/lib/stores/UserStatuses.ts
+++ b/web/src/lib/stores/UserStatuses.ts
@@ -1,7 +1,5 @@
 import type { Event } from 'nostr-tools';
 import { writable, type Writable } from 'svelte/store';
 
-console.log('[user statuses store]');
-
 export const userStatusesGeneral: Writable<Event[]> = writable([]);
 export const userStatusesMusic: Writable<Event[]> = writable([]);

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -68,12 +68,6 @@ export class HomeTimeline extends NewTimeline {
 	public filter = (event: Nostr.Event) =>
 		!get(excludeKinds).includes(event.kind) && isVisibleNotification(event.pubkey);
 
-	constructor() {
-		super();
-
-		console.debug('[home timeline initialize]');
-	}
-
 	//#endregion
 
 	//#region setIsTop

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -145,7 +145,6 @@ export async function metadataReqEmit(pubkeys: string[]): Promise<void> {
 		filterLimitItems
 	);
 	for (const pubkeys of groupedPubkeys) {
-		console.debug('[rx-nostr metadata REQ emit]', pubkeys);
 		metadataReq.emit({
 			kinds: [0],
 			authors: pubkeys

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -11,7 +11,6 @@
 	let editor = $state<NoteEditor>();
 
 	openNoteDialog.subscribe(async (open) => {
-		console.log('[note dialog open]', open);
 		if (open) {
 			dialog?.showModal();
 		}

--- a/web/src/routes/(app)/[slug=naddr]/+page.ts
+++ b/web/src/routes/(app)/[slug=naddr]/+page.ts
@@ -9,10 +9,8 @@ export const load: PageLoad<{
 	identifier: string;
 	relays: string[];
 }> = async ({ params }) => {
-	console.log('[naddr page load]', params.slug);
 	try {
 		const { data } = nip19.decode(params.slug);
-		console.log('[naddr decode]', data);
 		const pointer = data as nip19.AddressPointer;
 		return {
 			slug: params.slug,

--- a/web/src/routes/(app)/[slug=note]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=note]/+layout.server.ts
@@ -11,10 +11,8 @@ export const load: LayoutServerLoad<{
 	relays: string[];
 	event: Nostr.Event | undefined;
 }> = async ({ params, platform }) => {
-	console.debug('[thread page load]', params.slug);
 	try {
 		const { type, data } = nip19.decode(params.slug);
-		console.debug('[thread decode]', type, data);
 
 		let id: string;
 		let relays: string[] = [];

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/+layout.ts
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/+layout.ts
@@ -9,10 +9,8 @@ export const load: LayoutLoad<{
 	identifier: string;
 	relays: string[];
 }> = async ({ params }) => {
-	console.log('[list page load]', params.slug, params.naddr);
 	try {
 		const { type, data } = nip19.decode(params.naddr);
-		console.log('[list page naddr decode]', data);
 		const pointer = data as nip19.AddressPointer;
 
 		if (type !== 'naddr' || pointer.kind !== 30000) {

--- a/web/src/routes/(app)/[slug=npub]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=npub]/+layout.server.ts
@@ -18,22 +18,17 @@ type Data = {
 };
 
 export const load: LayoutServerLoad<Data> = async ({ params, platform }) => {
-	console.log('[npub page load]', params.slug);
-	console.time('[npub decode]');
 	const { pubkey, relays } = await User.decode(params.slug);
-	console.timeEnd('[npub decode]');
 	if (pubkey === undefined) {
 		error(404, 'Not Found');
 	}
 
 	await checkRestriction(pubkey, platform);
 
-	console.time('[metadata]');
 	const metadataEvent = await fetchMetadata(
 		pubkey,
 		relays.length > 0 ? relays : defaultRelays.filter(({ read }) => read).map(({ url }) => url)
 	);
-	console.timeEnd('[metadata]');
 
 	if (metadataEvent !== undefined) {
 		storeMetadata(metadataEvent);

--- a/web/src/routes/(app)/[slug=scheme]/+page.ts
+++ b/web/src/routes/(app)/[slug=scheme]/+page.ts
@@ -4,6 +4,5 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params }) => {
 	const slug = params.slug.replace(`${uriScheme}:`, '');
-	console.log('[uri scheme]', slug);
 	redirect(301, `/${slug}`);
 };

--- a/web/src/routes/(app)/relays/[url]/+layout.server.ts
+++ b/web/src/routes/(app)/relays/[url]/+layout.server.ts
@@ -3,8 +3,6 @@ import type { LayoutServerLoad } from './$types';
 import type * as Nostr from 'nostr-typedef';
 
 export const load: LayoutServerLoad = async ({ params }) => {
-	console.log('[relay page load]', params.url);
-
 	try {
 		const url = new URL(decodeURIComponent(params.url));
 		url.protocol = url.protocol === 'ws:' ? 'http:' : 'https:';
@@ -19,7 +17,6 @@ export const load: LayoutServerLoad = async ({ params }) => {
 		}
 
 		const nip11: Nostr.Nip11.RelayInfo = await response.json();
-		console.log('[relay page NIP-11]', nip11, response.url);
 		return {
 			name: nip11.name,
 			url: response.url,

--- a/web/src/routes/(app)/replay/home/+page.ts
+++ b/web/src/routes/(app)/replay/home/+page.ts
@@ -7,7 +7,6 @@ export const load: PageLoad<{
 }> = async ({ url }) => {
 	const since = url.searchParams.get('since');
 	const speed = Number(url.searchParams.get('speed'));
-	console.log('[replay page load]', since);
 	return {
 		since: since === null ? null : new Date(since),
 		speed: 0 < speed && speed <= 10 ? speed : speeds[0]

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -10,7 +10,6 @@ import type { LayoutLoad } from './$types';
 import { readRelays, writeRelays } from '$lib/stores/Author';
 
 export const load: LayoutLoad = async ({ url }) => {
-	console.debug('[layout load]');
 	let authenticated = false;
 	await initialize();
 	if (browser) {

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -4,6 +4,12 @@
 	"main": ".svelte-kit/cloudflare/_worker.js",
 	"compatibility_date": "2025-09-04",
 	"compatibility_flags": ["nodejs_als"],
+	"observability": {
+		"enabled": true,
+		"logs": {
+			"invocation_logs": false
+		}
+	},
 	"assets": {
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"


### PR DESCRIPTION
Enable observability in wrangler.jsonc with invocation logs disabled so that Workers Logs records only console output. Clean up logs executed during SSR so that successful requests emit nothing and only warnings and errors remain:

- Remove module-level store logs, page load logs, console.time measurements, and full event JSON dumps from server load functions
- Guard debug logs in shared code with the browser flag to keep the client console behavior unchanged