### PR TITLE
Reduce expected error logs during SSR

### DIFF
--- a/web/src/lib/Api.ts
+++ b/web/src/lib/Api.ts
@@ -132,7 +132,9 @@ export const fetchEvent = async (id: string, relays: string[]): Promise<Event | 
 		}
 	});
 	if (!response.ok) {
-		console.warn('[api event not found]', await response.text());
+		if (response.status !== 404) {
+			console.error('[api event error]', response.status, await response.text());
+		}
 		return undefined;
 	}
 	return (await response.json()) as Event;
@@ -151,7 +153,9 @@ export const fetchMetadata = async (
 		}
 	);
 	if (!response.ok) {
-		console.warn('[api metadata not found]', await response.text());
+		if (response.status !== 404) {
+			console.error('[api metadata error]', response.status, await response.text());
+		}
 		return undefined;
 	}
 	return (await response.json()) as Event;

--- a/web/src/lib/User.ts
+++ b/web/src/lib/User.ts
@@ -33,7 +33,6 @@ export class User {
 				const url = `https://${domain}/.well-known/nostr.json?name=${name}`;
 				const response = await fetch(url);
 				if (!response.ok) {
-					console.error('[invalid NIP-05]', await response.text());
 					throw new Error('fetch failed');
 				}
 				const data = (await response.json()) as Nostr.Nip05.NostrAddress;
@@ -44,8 +43,8 @@ export class User {
 					relays = data.relays?.[pubkey] ?? [];
 				}
 			}
-		} catch (error) {
-			console.error('[decode failed]', slug, error);
+		} catch {
+			// Fall through with pubkey undefined
 		}
 
 		return {

--- a/web/src/lib/server/Restriction.ts
+++ b/web/src/lib/server/Restriction.ts
@@ -11,7 +11,7 @@ export async function checkRestriction(
 
 	const restriction = await kv.get<Restriction>(pubkey, 'json');
 	if (restriction !== null) {
-		console.error('[npub restriction]', restriction);
+		console.warn('[npub restriction]', restriction);
 		error(restriction.status, restriction.statusText);
 	}
 }

--- a/web/src/routes/(app)/[slug=naddr]/+page.ts
+++ b/web/src/routes/(app)/[slug=naddr]/+page.ts
@@ -19,8 +19,7 @@ export const load: PageLoad<{
 			identifier: pointer.identifier,
 			relays: pointer.relays ?? []
 		};
-	} catch (e) {
-		console.error('[naddr page decode error]', e);
+	} catch {
 		error(404, 'Not Found');
 	}
 };

--- a/web/src/routes/(app)/[slug=note]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=note]/+layout.server.ts
@@ -48,8 +48,7 @@ export const load: LayoutServerLoad<{
 			relays,
 			event
 		};
-	} catch (e) {
-		console.error('[thread page decode error]', e);
+	} catch {
 		error(404, 'Not Found');
 	}
 };

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/+layout.ts
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/+layout.ts
@@ -24,8 +24,7 @@ export const load: LayoutLoad<{
 			identifier: pointer.identifier,
 			relays: pointer.relays ?? []
 		};
-	} catch (e) {
-		console.error('[list page naddr decode error]', e);
+	} catch {
 		error(404, 'Not Found');
 	}
 };

--- a/web/src/routes/(app)/relays/[url]/+layout.server.ts
+++ b/web/src/routes/(app)/relays/[url]/+layout.server.ts
@@ -25,8 +25,7 @@ export const load: LayoutServerLoad = async ({ params }) => {
 			description: nip11.description,
 			icon: nip11.icon
 		};
-	} catch (e) {
-		console.error('[relay page error]', e);
+	} catch {
 		error(404, 'Not Found');
 	}
 };


### PR DESCRIPTION
Remove error logs for invalid slugs and unreachable relays that only reflect bad external input and already result in 404 responses. Log non-404 API failures as errors while silencing expected 404s, and downgrade the npub restriction log to a warning since it records an intentional block rather than a failure.