### PR TITLE
Fix emoji picker not reopening after close

### DIFF
--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -91,6 +91,9 @@
 		}
 
 		const { Picker } = await import('emoji-kitchen-mart');
+		if (!popover.open || !emojiPicker || emojiPicker.firstChild !== null) {
+			return;
+		}
 		const picker = new Picker({
 			data,
 			onEmojiSelect,
@@ -103,14 +106,14 @@
 
 	function onClickOutside(event: PointerEvent) {
 		console.debug('[emoji picker outside]', event.target);
-		clear();
+		popover.open = false;
 	}
 
 	function onEmojiSelect(emoji: BaseEmoji): void {
 		console.debug('[emoji picker selected]', emoji);
 		dispatch('pick', emoji);
 		if (autoClose) {
-			clear();
+			popover.open = false;
 		}
 	}
 


### PR DESCRIPTION
Route emoji picker close through the melt Popover state instead of calling clear() directly from onClickOutside and onEmojiSelect. The direct clear() removed the picker DOM and reset emojiPickerOpen but left the Popover's internal open state stuck at true, so the next trigger click only toggled it closed and the picker failed to reappear.

Also guard the async picker init: bail out if the popover was closed during the dynamic import to avoid leaving a stale child element.