### PR TITLE
Migrate Cropper usage to svelte-easy-crop v5 callback API

### DIFF
--- a/web/src/routes/(app)/profile/+page.svelte
+++ b/web/src/routes/(app)/profile/+page.svelte
@@ -45,8 +45,8 @@
 		});
 	}
 
-	function onCropComplete({ detail }: { detail: { pixels: Pixels } }): void {
-		pixels = detail.pixels;
+	function onCropComplete(event: { pixels: Pixels }): void {
+		pixels = event.pixels;
 	}
 
 	function applyCrop(e: SubmitEvent): void {
@@ -167,7 +167,7 @@
 {#if $authorProfile}
 	<ModalDialog bind:open on:close={close}>
 		<div class="crop">
-			<Cropper image={url} aspect={1} maxZoom={10} on:cropcomplete={onCropComplete} />
+			<Cropper image={url} aspect={1} maxZoom={10} oncropcomplete={onCropComplete} />
 		</div>
 
 		<form class="apply" onsubmit={applyCrop}>


### PR DESCRIPTION
svelte-easy-crop v5 dropped createEventDispatcher in favor of runes callback props, so on:cropcomplete no longer fires and the payload is passed directly without a detail wrapper. Switch to the oncropcomplete prop and read pixels from the event so profile picture cropping keeps working.