### PR TITLE
Fix own post images blurred by non-followee reactions

### DIFF
--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -13,7 +13,9 @@
 
 	const { href: src, pathname } = $derived(url);
 	const events = getContext<Nostr.Event[] | undefined>('events');
-	const blur = events !== undefined && !events.some((event) => $followees.includes(event.pubkey));
+	const blur = $derived(
+		events !== undefined && !events.some((event) => $followees.includes(event.pubkey))
+	);
 
 	const optimize = $derived(
 		$imageOptimization !== '' &&

--- a/web/src/lib/components/content/Video.svelte
+++ b/web/src/lib/components/content/Video.svelte
@@ -11,12 +11,14 @@
 	let { url }: Props = $props();
 
 	const events = getContext<Nostr.Event[] | undefined>('events');
-	let blur = $state(
+	const shouldBlur = $derived(
 		events !== undefined && !events.some((event) => $followees.includes(event.pubkey))
 	);
+	let revealed = $state(false);
+	const blur = $derived(shouldBlur && !revealed);
 
 	function show(): void {
-		blur = false;
+		revealed = true;
 	}
 </script>
 

--- a/web/src/lib/components/items/EventComponent.svelte
+++ b/web/src/lib/components/items/EventComponent.svelte
@@ -30,10 +30,9 @@
 
 	let { item, readonly, createdAtFormat = 'auto', full = false }: Props = $props();
 
-	$effect(() => {
-		const events = getContext<Nostr.Event[] | undefined>('events') ?? [];
-		setContext('events', [...events, item.event]);
-	});
+	const parentEvents = getContext<Nostr.Event[] | undefined>('events') ?? [];
+	// svelte-ignore state_referenced_locally
+	setContext('events', [...parentEvents, item.event]);
 </script>
 
 {#if item.event.kind === Kind.Metadata}


### PR DESCRIPTION
setContext('events', ...) ran inside $effect, so the ancestor-event chain was not yet populated when a reaction's deferred original-event subtree initialized. Img/Video then saw only the reaction sender (a non-followee) and blurred the user's own image.

Set the context synchronously during initialization so the chain is complete when descendants read it, and make the blur checks $derived so they react to followees loading.