### PR TITLE
Reduce client-side CPU usage on timelines

### DIFF
--- a/web/src/lib/components/Timeline.svelte
+++ b/web/src/lib/components/Timeline.svelte
@@ -37,6 +37,7 @@
 	}: Props = $props();
 
 	let isTop = $state(true);
+	let loadMoreAnchor = $state<HTMLElement>();
 
 	async function newer() {
 		const id = visibleEvents.at(0)?.id;
@@ -110,7 +111,22 @@
 			}, 1000);
 		}
 
-		return disposeTimelineScrollToTop;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting) && !timeline.loading) {
+					older();
+				}
+			},
+			{ rootMargin: '0px 0px 20% 0px' }
+		);
+		if (loadMoreAnchor !== undefined) {
+			observer.observe(loadMoreAnchor);
+		}
+
+		return () => {
+			observer.disconnect();
+			disposeTimelineScrollToTop?.();
+		};
 	});
 
 	$effect(() => {
@@ -130,18 +146,6 @@
 			untrack(() => {
 				isTop = false;
 				timeline.setIsTop(isTop);
-			});
-		}
-	});
-
-	$effect(() => {
-		if (
-			scrollY.current! > 0 &&
-			scrollY.current! + window.innerHeight * 1.2 >= document.documentElement.scrollHeight &&
-			!timeline.loading
-		) {
-			untrack(() => {
-				older();
 			});
 		}
 	});
@@ -189,6 +193,8 @@
 {#if showLoading && !timeline.oldest}
 	<div class="loading"><Loading /></div>
 {/if}
+
+<div bind:this={loadMoreAnchor}></div>
 
 <style>
 	div.scroll-to-top {

--- a/web/src/lib/components/shared/Foldable.svelte
+++ b/web/src/lib/components/shared/Foldable.svelte
@@ -17,28 +17,14 @@
 
 	const measure: Attachment<HTMLElement> = (element) => {
 		const maxHeight = maxHeightRem * parseFloat(getComputedStyle(element).fontSize);
-		let frame: number | undefined;
-		const update = () => {
-			frame = undefined;
-			overflowing = element.scrollHeight > maxHeight;
-		};
-		const schedule = () => {
-			if (frame === undefined) {
-				frame = requestAnimationFrame(update);
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				const blockSize = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+				overflowing = blockSize > maxHeight;
 			}
-		};
-
-		schedule();
-		element.addEventListener('load', schedule, true);
-		element.addEventListener('loadedmetadata', schedule, true);
-
-		return () => {
-			element.removeEventListener('load', schedule, true);
-			element.removeEventListener('loadedmetadata', schedule, true);
-			if (frame !== undefined) {
-				cancelAnimationFrame(frame);
-			}
-		};
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
 	};
 
 	async function toggle(): Promise<void> {
@@ -54,9 +40,10 @@
 	bind:this={container}
 	class:folded={enabled && overflowing && folded}
 	style:--fold-max-height="{maxHeightRem}rem"
-	{@attach measure}
 >
-	{@render children()}
+	<div class="fold-content" {@attach measure}>
+		{@render children()}
+	</div>
 	{#if enabled && overflowing}
 		<div class="view-more">
 			<button onclick={toggle} class="rounded-button small">

--- a/web/src/lib/components/shared/Foldable.svelte
+++ b/web/src/lib/components/shared/Foldable.svelte
@@ -15,20 +15,26 @@
 	let overflowing = $state(false);
 	let folded = $state(true);
 
-	const observe: Attachment<HTMLElement> = (element) => {
+	const measure: Attachment<HTMLElement> = (element) => {
 		const maxHeight = maxHeightRem * parseFloat(getComputedStyle(element).fontSize);
 		let frame: number | undefined;
-		const observer = new ResizeObserver(() => {
+		const update = () => {
+			frame = undefined;
+			overflowing = element.scrollHeight > maxHeight;
+		};
+		const schedule = () => {
 			if (frame === undefined) {
-				frame = requestAnimationFrame(() => {
-					frame = undefined;
-					overflowing = element.scrollHeight > maxHeight;
-				});
+				frame = requestAnimationFrame(update);
 			}
-		});
-		observer.observe(element);
+		};
+
+		schedule();
+		element.addEventListener('load', schedule, true);
+		element.addEventListener('loadedmetadata', schedule, true);
+
 		return () => {
-			observer.disconnect();
+			element.removeEventListener('load', schedule, true);
+			element.removeEventListener('loadedmetadata', schedule, true);
 			if (frame !== undefined) {
 				cancelAnimationFrame(frame);
 			}
@@ -48,7 +54,7 @@
 	bind:this={container}
 	class:folded={enabled && overflowing && folded}
 	style:--fold-max-height="{maxHeightRem}rem"
-	{@attach observe}
+	{@attach measure}
 >
 	{@render children()}
 	{#if enabled && overflowing}

--- a/web/src/lib/stores/Author.ts
+++ b/web/src/lib/stores/Author.ts
@@ -28,7 +28,46 @@ export const writeRelays: Writable<string[]> = writable(
 );
 export const rom = writable(false);
 
-export const isMutePubkey = (pubkey: string) => get(mutePubkeys).includes(pubkey);
+let mutePubkeysSetRef: string[] | undefined;
+let mutePubkeysSet = new Set<string>();
+const getMutePubkeysSet = (): Set<string> => {
+	const $mutePubkeys = get(mutePubkeys);
+	if ($mutePubkeys !== mutePubkeysSetRef) {
+		mutePubkeysSetRef = $mutePubkeys;
+		mutePubkeysSet = new Set($mutePubkeys);
+	}
+	return mutePubkeysSet;
+};
+
+let muteEventIdsSetRef: string[] | undefined;
+let muteEventIdsSet = new Set<string>();
+const getMuteEventIdsSet = (): Set<string> => {
+	const $muteEventIds = get(muteEventIds);
+	if ($muteEventIds !== muteEventIdsSetRef) {
+		muteEventIdsSetRef = $muteEventIds;
+		muteEventIdsSet = new Set($muteEventIds);
+	}
+	return muteEventIdsSet;
+};
+
+let muteWordsRegExpRef: string[] | undefined;
+let muteWordsRegExp: RegExp | undefined;
+const getMuteWordsRegExp = (): RegExp | undefined => {
+	const $muteWords = get(muteWords);
+	if ($muteWords !== muteWordsRegExpRef) {
+		muteWordsRegExpRef = $muteWords;
+		muteWordsRegExp =
+			$muteWords.length > 0
+				? new RegExp(
+						`(${$muteWords.map((word) => escapeStringRegexp(word)).join('|')})`,
+						'i'
+					)
+				: undefined;
+	}
+	return muteWordsRegExp;
+};
+
+export const isMutePubkey = (pubkey: string) => getMutePubkeysSet().has(pubkey);
 export const isMuteEvent = (event: Event) => {
 	// Avoid being muted if content contains muted words
 	if (event.pubkey === get(pubkey)) {
@@ -62,21 +101,13 @@ export const isMuteEvent = (event: Event) => {
 		}
 	}
 
-	const $muteWords = get(muteWords);
-	if (
-		$muteWords.length > 0 &&
-		new RegExp(`(${$muteWords.map((word) => escapeStringRegexp(word)).join('|')})`, 'i').test(
-			event.content
-		)
-	) {
+	const muteWordsPattern = getMuteWordsRegExp();
+	if (muteWordsPattern !== undefined && muteWordsPattern.test(event.content)) {
 		return true;
 	}
 
-	const ids = get(muteEventIds);
-	return (
-		ids.includes(event.id) ||
-		event.tags.some(([tagName, id]) => tagName === 'e' && ids.includes(id))
-	);
+	const ids = getMuteEventIdsSet();
+	return ids.has(event.id) || event.tags.some(([tagName, id]) => tagName === 'e' && ids.has(id));
 };
 
 export const updateRelays = (event: Event) => {


### PR DESCRIPTION
Drop the per-note ResizeObserver in Foldable in favor of a one-shot measurement that re-runs only when contained media load, so long notes no longer keep a live observer that forces a reflow on every layout change across the non-virtualized timeline.

Trigger older() from an IntersectionObserver sentinel in the home timeline instead of reading document.documentElement.scrollHeight in a scroll-reactive effect, removing the forced reflow on every scroll.

Memoize the mute-word RegExp and use Set lookups for muted pubkeys and event ids in isMuteEvent, keyed on the store array reference so they rebuild only when the mute lists change, cutting per-event filtering cost on every timeline.