### PR TITLE
Show login progress in a status bar at the bottom of the screen

### DIFF
--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -9,6 +9,7 @@ import { rxNostr } from './timelines/MainTimeline';
 import { now } from 'rx-nostr';
 import type { User } from '../routes/types';
 import { remoteSigner } from './RemoteSigner';
+import { setLoginStatus, clearLoginStatus } from './stores/LoginStatus';
 
 export class Login {
 	public async saveBasicInfo(name: string): Promise<void> {
@@ -57,6 +58,7 @@ export class Login {
 		console.time('NIP-07');
 
 		loginType.set('NIP-07');
+		setLoginStatus('getting_pubkey');
 
 		try {
 			pubkey.set(await Signer.getPublicKey());
@@ -69,6 +71,7 @@ export class Login {
 			console.error('[NIP-07 getPublicKey()]', error);
 			console.timeEnd('NIP-07');
 			loginType.set(undefined);
+			setLoginStatus('failed', 'error');
 			return;
 		}
 
@@ -84,6 +87,7 @@ export class Login {
 		console.time('NIP-46');
 
 		loginType.set('NIP-46');
+		setLoginStatus('connecting_bunker');
 
 		try {
 			await Signer.establishBunkerConnection(bunker);
@@ -92,6 +96,7 @@ export class Login {
 			console.error('Failed to connect to NIP-46 bunker');
 			await Signer.abolishBunkerConnection();
 			loginType.set(undefined);
+			setLoginStatus('bunker_failed', 'error');
 			return false;
 		}
 
@@ -109,6 +114,7 @@ export class Login {
 		const { type, data: seckey } = nip19.decode(key);
 		if (type !== 'nsec') {
 			console.error('Invalid nsec');
+			setLoginStatus('invalid_key', 'error');
 			return;
 		}
 
@@ -126,6 +132,7 @@ export class Login {
 		console.debug(type, data);
 		if (type !== 'npub' || typeof data !== 'string') {
 			console.error(`Invalid npub: ${key}`);
+			setLoginStatus('invalid_key', 'error');
 			return;
 		}
 
@@ -140,6 +147,7 @@ export class Login {
 
 	private async fetchAuthor() {
 		console.time('fetch author');
+		setLoginStatus('fetching_profile');
 
 		const $author = new Author(get(pubkey));
 
@@ -150,6 +158,7 @@ export class Login {
 		console.timeEnd('fetch author');
 
 		author.set($author);
+		clearLoginStatus();
 
 		remoteSigner.subscribeIfEnabled();
 	}

--- a/web/src/lib/components/LoginStatus.svelte
+++ b/web/src/lib/components/LoginStatus.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { loginStatus } from '$lib/stores/LoginStatus';
+</script>
+
+{#if $loginStatus !== null}
+	<div class="login-status login-status-{$loginStatus.level}" role="status" aria-live="polite">
+		{$_(`login.status.${$loginStatus.key}`)}
+	</div>
+{/if}
+
+<style>
+	.login-status {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		padding: 0.5rem 0.75rem;
+		border-top: var(--default-border);
+		background: var(--surface);
+		color: var(--foreground);
+		font-size: 0.875rem;
+		text-align: center;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.login-status-success {
+		color: var(--green);
+	}
+
+	.login-status-error {
+		color: var(--red);
+	}
+</style>

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -45,7 +45,18 @@
 		"login": "Login",
 		"hero-message": "Freedom is Here",
 		"hero-message-sub": "All you need is name. No e-mail address, no account suspension, open SNS. Play with Emoji Kitchen.",
-		"failed": "Failed to login."
+		"failed": "Failed to login.",
+		"status": {
+			"checking": "Checking saved login information",
+			"waiting_extension": "Waiting for browser extension",
+			"extension_not_found": "Browser extension was not found",
+			"getting_pubkey": "Getting public key",
+			"connecting_bunker": "Connecting to remote signer",
+			"bunker_failed": "Failed to connect to remote signer",
+			"invalid_key": "Invalid key format",
+			"fetching_profile": "Fetching profile",
+			"failed": "Failed to login"
+		}
 	},
 	"logout": {
 		"logout": "Logout",

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -45,7 +45,18 @@
 		"login": "ログイン",
 		"hero-message": "すべての自由が、ここに。",
 		"hero-message-sub": "必要なのは名前だけ。メールアドレスも要らない、凍結もない、オープンなSNS。絵文字キッチンで遊ぼう。",
-		"failed": "ログインできませんでした。"
+		"failed": "ログインできませんでした。",
+		"status": {
+			"checking": "保存済みのログイン情報を確認しています",
+			"waiting_extension": "拡張機能を待っています",
+			"extension_not_found": "拡張機能が見つかりませんでした",
+			"getting_pubkey": "公開鍵を取得しています",
+			"connecting_bunker": "リモート署名に接続しています",
+			"bunker_failed": "リモート署名に接続できませんでした",
+			"invalid_key": "鍵の形式が正しくありません",
+			"fetching_profile": "プロフィールを取得しています",
+			"failed": "ログインに失敗しました"
+		}
 	},
 	"logout": {
 		"logout": "ログアウト",

--- a/web/src/lib/stores/LoginStatus.ts
+++ b/web/src/lib/stores/LoginStatus.ts
@@ -1,0 +1,18 @@
+import { writable } from 'svelte/store';
+
+export type LoginStatusLevel = 'info' | 'success' | 'error';
+
+export type LoginStatus = {
+	key: string;
+	level: LoginStatusLevel;
+};
+
+export const loginStatus = writable<LoginStatus | null>(null);
+
+export function setLoginStatus(key: string, level: LoginStatusLevel = 'info'): void {
+	loginStatus.set({ key, level });
+}
+
+export function clearLoginStatus(): void {
+	loginStatus.set(null);
+}

--- a/web/src/routes/(app)/Login.svelte
+++ b/web/src/routes/(app)/Login.svelte
@@ -9,6 +9,7 @@
 	import { afterNavigate, goto } from '$app/navigation';
 	import { authorProfile } from '$lib/stores/Author';
 	import { WebStorage } from '$lib/WebStorage';
+	import { setLoginStatus } from '$lib/stores/LoginStatus';
 	import ModalDialog from '$lib/components/ModalDialog.svelte';
 	import NostterLogo from '$lib/components/logo/NostterLogo.svelte';
 
@@ -47,6 +48,7 @@
 			}
 		} catch (error) {
 			console.error('[NIP-07 login failed]', error);
+			setLoginStatus('failed', 'error');
 			resetLoginProgress();
 		}
 	}
@@ -71,6 +73,7 @@
 			}
 		} catch (error) {
 			console.error('[NIP-46 login failed]', error);
+			setLoginStatus('failed', 'error');
 			failedToLogin = true;
 			resetLoginProgress();
 		}
@@ -95,6 +98,7 @@
 			}
 		} catch (error) {
 			console.error('[key login failed]', error);
+			setLoginStatus('failed', 'error');
 			resetLoginProgress();
 		}
 	}
@@ -123,6 +127,7 @@
 			await goto('/public');
 		} catch (error) {
 			console.error('[register failed]', error);
+			setLoginStatus('failed', 'error');
 			registering = false;
 			loginType.set(undefined);
 		}
@@ -140,6 +145,7 @@
 	async function gotoHome(): Promise<boolean> {
 		if ($authorProfile === undefined) {
 			console.error('[login failed]');
+			setLoginStatus('failed', 'error');
 			return false;
 		}
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { appName } from '$lib/Constants';
 	import '../app.css';
 	import Toaster from '$lib/components/Toaster.svelte';
+	import LoginStatus from '$lib/components/LoginStatus.svelte';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
@@ -51,4 +52,5 @@
 </svelte:head>
 
 <Toaster />
+<LoginStatus />
 {@render children?.()}

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -8,6 +8,7 @@ import { rxNostr } from '$lib/timelines/MainTimeline';
 import { appName, defaultRelays, localizedRelays } from '$lib/Constants';
 import type { LayoutLoad } from './$types';
 import { readRelays, writeRelays } from '$lib/stores/Author';
+import { setLoginStatus } from '$lib/stores/LoginStatus';
 
 export const load: LayoutLoad = async ({ url }) => {
 	let authenticated = false;
@@ -49,13 +50,17 @@ async function tryLogin(): Promise<boolean> {
 		return false;
 	}
 
+	setLoginStatus('checking');
+
 	const login = new Login();
 	if (savedLogin === 'NIP-07') {
+		setLoginStatus('waiting_extension');
 		const { waitNostr } = await import('nip07-awaiter');
 		const nostr = await waitNostr(10000);
 		console.debug('[NIP-07]', nostr);
 		if (nostr === undefined) {
 			console.error('Browser Extension was not found');
+			setLoginStatus('extension_not_found', 'error');
 			return false;
 		}
 		await login.withNip07();
@@ -70,6 +75,7 @@ async function tryLogin(): Promise<boolean> {
 		await login.withNpub(savedLogin);
 	} else {
 		console.error('[login logic error]');
+		setLoginStatus('failed', 'error');
 		return false;
 	}
 


### PR DESCRIPTION
Add a global one-line login status bar (i18n login.status.*) shown at the bottom of the screen, kept separate from console logs, so login failures can be investigated without DevTools. Progress and errors are reported from auto-login (+layout.ts), Login.ts, and Login.svelte, and the status is cleared on successful author set so failures keep their last message.