### PR TITLE
Redirect unauthenticated users from login-required pages to top

### DIFF
--- a/web/src/routes/(app)/+layout.ts
+++ b/web/src/routes/(app)/+layout.ts
@@ -1,0 +1,19 @@
+import { redirect } from '@sveltejs/kit';
+import { browser } from '$app/environment';
+import type { LayoutLoad } from './$types';
+
+const protectedPaths = [
+	'/home',
+	'/notifications',
+	'/preferences',
+	'/profile',
+	'/post',
+	'/replay/home'
+];
+
+export const load: LayoutLoad = async ({ parent, url }) => {
+	const data = await parent();
+	if (browser && !data.authenticated && protectedPaths.some((p) => url.pathname.startsWith(p))) {
+		redirect(307, '/');
+	}
+};


### PR DESCRIPTION
When session restoration fails (for example iOS Safari PWA losing the stored login from localStorage), login-required pages under (app) left the user on a broken screen: a logged-out header and a timeline stuck loading. Add a layout guard that redirects unauthenticated visitors of protected paths to the top page, which already shows the login screen.