### PR TITLE
Stop the service worker from serving stale cached assets

### DIFF
--- a/web/src/service-worker.ts
+++ b/web/src/service-worker.ts
@@ -3,62 +3,19 @@
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
 
-import { build, files, version } from '$service-worker';
-
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
-console.debug('[service worker]');
-
-const CACHE = `cache-${version}`;
-
-const ASSETS = [...build, ...files];
-
-sw.addEventListener('install', (e) => {
-	console.debug('[service worker install]', CACHE, ASSETS);
-
-	async function addFilesToCache() {
-		const cache = await caches.open(CACHE);
-		await cache.addAll(ASSETS);
-	}
-
-	e.waitUntil(addFilesToCache());
+sw.addEventListener('install', () => {
+	sw.skipWaiting();
 });
 
-sw.addEventListener('activate', (e) => {
-	console.debug('[service worker activate]', CACHE);
-
-	async function deleteOldCaches() {
-		for (const key of await caches.keys()) {
-			if (key !== CACHE) {
-				console.debug('[service worker delete]', key);
+sw.addEventListener('activate', (event) => {
+	event.waitUntil(
+		(async () => {
+			for (const key of await caches.keys()) {
 				await caches.delete(key);
 			}
-		}
-	}
-
-	e.waitUntil(deleteOldCaches());
-});
-
-sw.addEventListener('fetch', (e) => {
-	const url = new URL(e.request.url);
-	if (e.request.method !== 'GET' || url.origin !== sw.origin) {
-		return;
-	}
-
-	async function respond() {
-		const cache = await caches.open(CACHE);
-
-		if (ASSETS.includes(url.pathname)) {
-			const response = await cache.match(url.pathname);
-
-			if (response) {
-				console.debug('[service worker cache]', url.pathname);
-				return response;
-			}
-		}
-
-		return await fetch(e.request);
-	}
-
-	e.respondWith(respond());
+			await sw.clients.claim();
+		})()
+	);
 });


### PR DESCRIPTION
The service worker cached build assets and, by default, never activated a new version until every controlled client was closed. iOS standalone PWAs are rarely fully closed, so the old worker kept serving stale chunks that no longer matched the freshly served HTML; module loading failed and the app never hydrated (every button dead) while the same build worked in a Safari tab.

Replace it with a worker that does not intercept fetches, so assets load straight from the browser cache just like a normal tab. On install it calls skipWaiting, and on activate it deletes all caches and claims clients, so already-broken PWAs recover automatically once the new worker is fetched.