### PR TITLE
Recover from invalid third-party CSS during lightningcss minify

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
 	build: {
 		target: 'esnext'
 	},
+	css: {
+		lightningcss: {
+			errorRecovery: true
+		}
+	},
 	plugins: [sveltekit(), visualizer({ emitFile: true, template: 'markdown' })],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']


### PR DESCRIPTION
Vite 8 switches the default CSS minifier to lightningcss, which is stricter than the previous esbuild minifier and aborts the production build on the invalid selector in
@beyonk/gdpr-cookie-consent-banner/banner.css. Enable lightningcss errorRecovery so the invalid rule is dropped with a warning instead of failing the build.