### PR TITLE
Make timeline event dedup O(1) to reduce CPU on long sessions

### DIFF
--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -211,13 +211,13 @@ export class HomeTimeline extends NewTimeline {
 					not: true
 				}
 			),
-			filter(({ event }) => !this.eventsStore.some((e) => e.id === event.id)),
+			filter(({ event }) => !this.hasEvent(event.id)),
 			tap(({ event }) => referencesReqEmit(event)),
 			share()
 		);
 		timeline$.subscribe(({ event }) => {
 			const lastId = this.eventsStore.at(0)?.id;
-			this.eventsStore.unshift(event);
+			this.unshiftEvent(event);
 			this.latestId = event.id;
 			if (this.autoUpdate && this.#isTop && this.eventsForView.at(0)?.id === lastId) {
 				this.eventsForView = [event, ...this.eventsForView].slice(0, maxTimelineLength);
@@ -384,7 +384,7 @@ export class HomeTimeline extends NewTimeline {
 			.pipe(
 				tie,
 				uniq(),
-				filter(({ event }) => !this.eventsStore.some((e) => e.id === event.id)),
+				filter(({ event }) => !this.hasEvent(event.id)),
 				tap(({ event }) => {
 					referencesReqEmit(event);
 					authorActionReqEmit(event);
@@ -400,10 +400,10 @@ export class HomeTimeline extends NewTimeline {
 						(e) => e.created_at < event.created_at
 					);
 					if (index < 0) {
-						this.eventsStore.push(event);
+						this.pushEvents(event);
 						this.eventsForView = [...this.eventsForView, event];
 					} else {
-						this.eventsStore.splice(index, 0, event);
+						this.insertEventAt(index, event);
 						const indexForView = this.eventsForView.findIndex(
 							(e) => e.created_at < event.created_at
 						);
@@ -427,7 +427,7 @@ export class HomeTimeline extends NewTimeline {
 					userStatusReqEmit([...pubkeys]);
 					if (count < minTimelineLength) {
 						const events = await this.#fetchEnough(minTimelineLength - count);
-						this.eventsStore.push(...events);
+						this.pushEvents(...events);
 						this.eventsForView = [...this.eventsForView, ...events];
 						count += events.length;
 						console.debug(
@@ -476,7 +476,7 @@ export class HomeTimeline extends NewTimeline {
 					const filteredEvents = events
 						.toSorted(reverseChronological)
 						.slice(0, limit * 2)
-						.filter((event) => !this.eventsStore.some((e) => e.id === event.id))
+						.filter((event) => !this.hasEvent(event.id))
 						.slice(0, limit);
 					const pubkeys = new Set<string>(filteredEvents.map((e) => e.pubkey));
 					userStatusReqEmit([...pubkeys]);
@@ -499,7 +499,7 @@ export class HomeTimeline extends NewTimeline {
 			.pipe(
 				tie,
 				uniq(),
-				filter(({ event }) => !this.eventsStore.some((e) => e.id === event.id)),
+				filter(({ event }) => !this.hasEvent(event.id)),
 				tap(({ event }) => {
 					referencesReqEmit(event);
 					authorActionReqEmit(event);
@@ -515,10 +515,10 @@ export class HomeTimeline extends NewTimeline {
 						(e) => e.created_at < event.created_at
 					);
 					if (index < 0) {
-						this.eventsStore.push(event);
+						this.pushEvents(event);
 						this.eventsForView = [...this.eventsForView, event];
 					} else {
-						this.eventsStore.splice(index, 0, event);
+						this.insertEventAt(index, event);
 						const indexForView = this.eventsForView.findIndex(
 							(e) => e.created_at < event.created_at
 						);

--- a/web/src/lib/timelines/PublicTimeline.ts
+++ b/web/src/lib/timelines/PublicTimeline.ts
@@ -47,7 +47,7 @@ export class PublicTimeline extends NewTimeline {
 			)
 			.subscribe(({ event }) => {
 				const lastId = this.eventsStore.at(0)?.id;
-				this.eventsStore.unshift(event);
+				this.unshiftEvent(event);
 				this.latestId = event.id;
 				if (this.autoUpdate && this.#isTop && this.eventsForView.at(0)?.id === lastId) {
 					this.eventsForView = [event, ...this.eventsForView].slice(0, maxTimelineLength);
@@ -104,10 +104,10 @@ export class PublicTimeline extends NewTimeline {
 						(e) => e.created_at < event.created_at
 					);
 					if (index < 0) {
-						this.eventsStore.push(event);
+						this.pushEvents(event);
 						this.eventsForView = [...this.eventsForView, event];
 					} else {
-						this.eventsStore.splice(index, 0, event);
+						this.insertEventAt(index, event);
 						const indexForView = this.eventsForView.findIndex(
 							(e) => e.created_at < event.created_at
 						);
@@ -130,7 +130,7 @@ export class PublicTimeline extends NewTimeline {
 					console.debug('[public timeline older complete]', count);
 					if (count < minTimelineLength) {
 						const events = await this.fetchEnough(minTimelineLength - count);
-						this.eventsStore.push(...events);
+						this.pushEvents(...events);
 						this.eventsForView = [...this.eventsForView, ...events];
 						count += events.length;
 						console.debug(
@@ -188,7 +188,7 @@ export class PublicTimeline extends NewTimeline {
 	}
 
 	#fine(event: Nostr.Event): boolean {
-		if (this.eventsStore.some((e) => e.id === event.id)) {
+		if (this.hasEvent(event.id)) {
 			return false;
 		}
 

--- a/web/src/lib/timelines/Timeline.svelte.ts
+++ b/web/src/lib/timelines/Timeline.svelte.ts
@@ -39,8 +39,8 @@ export abstract class NewTimeline {
 	}
 
 	protected pushEvents(...events: Nostr.Event[]): void {
+		this.eventsStore.push(...events);
 		for (const event of events) {
-			this.eventsStore.push(event);
 			this.eventIdSet.add(event.id);
 		}
 	}

--- a/web/src/lib/timelines/Timeline.svelte.ts
+++ b/web/src/lib/timelines/Timeline.svelte.ts
@@ -25,8 +25,30 @@ export abstract class NewTimeline {
 	//#region Events
 
 	protected readonly eventsStore: Nostr.Event[] = [];
+	protected readonly eventIdSet = new Set<string>();
 	protected eventsForView = $state.raw<Nostr.Event[]>([]);
 	public readonly events = $derived(this.eventsForView);
+
+	protected hasEvent(id: string): boolean {
+		return this.eventIdSet.has(id);
+	}
+
+	protected unshiftEvent(event: Nostr.Event): void {
+		this.eventsStore.unshift(event);
+		this.eventIdSet.add(event.id);
+	}
+
+	protected pushEvents(...events: Nostr.Event[]): void {
+		for (const event of events) {
+			this.eventsStore.push(event);
+			this.eventIdSet.add(event.id);
+		}
+	}
+
+	protected insertEventAt(index: number, event: Nostr.Event): void {
+		this.eventsStore.splice(index, 0, event);
+		this.eventIdSet.add(event.id);
+	}
 
 	protected latestId = $state<string | undefined>();
 	public readonly latest = $derived(this.latestId === this.eventsForView.at(0)?.id);
@@ -96,6 +118,7 @@ export abstract class NewTimeline {
 
 	public clear(): void {
 		this.eventsStore.splice(0);
+		this.eventIdSet.clear();
 		this.eventsForView = [];
 		this.latestId = undefined;
 		this._oldest = false;


### PR DESCRIPTION
The home timeline appends every received event to eventsStore without a bound, and each incoming event was deduplicated with a linear eventsStore.some() scan. While the timeline stays open the store keeps growing, so per-event work becomes O(n) and CPU usage climbs over time.

Track event ids in a Set on the base timeline and route all inserts through helper methods, turning the dedup checks into O(1) lookups. Apply the same change to the public timeline, which shares the hot path.