### PR TITLE
Create gallery Swiper lazily and destroy it on unmount

### DIFF
--- a/web/src/lib/components/content/Thumbnail.svelte
+++ b/web/src/lib/components/content/Thumbnail.svelte
@@ -4,7 +4,7 @@
 	import { IconX } from '@tabler/icons-svelte-runes';
 	import Swiper from 'swiper';
 	import { Navigation, Zoom } from 'swiper/modules';
-	import { onMount } from 'svelte';
+	import { onDestroy } from 'svelte';
 
 	interface Props {
 		url: URL;
@@ -18,23 +18,25 @@
 	const dialog = new Dialog({
 		closeOnOutsideClick: false,
 		onOpenChange: (open) => {
-			const index = urls.findIndex((u) => u.href === url.href);
-			if (open && swiper !== undefined) {
-				swiper.activeIndex = index >= 0 ? index : 0;
+			if (!open) {
+				return;
 			}
+			if (swiper === undefined) {
+				swiper = new Swiper(`.swiper-${id}`, {
+					zoom: true,
+					modules: [Navigation, Zoom],
+					navigation: {
+						nextEl: '.swiper-button-next',
+						prevEl: '.swiper-button-prev'
+					}
+				});
+			}
+			const index = urls.findIndex((u) => u.href === url.href);
+			swiper.activeIndex = index >= 0 ? index : 0;
 		}
 	});
 
-	onMount(() => {
-		swiper = new Swiper(`.swiper-${id}`, {
-			zoom: true,
-			modules: [Navigation, Zoom],
-			navigation: {
-				nextEl: '.swiper-button-next',
-				prevEl: '.swiper-button-prev'
-			}
-		});
-	});
+	onDestroy(() => swiper?.destroy());
 
 	function close(e: MouseEvent): void {
 		const target = e.target as HTMLElement;


### PR DESCRIPTION
Every content image rendered a Thumbnail that created a Swiper instance in onMount, even while the gallery dialog stayed closed, and never destroyed it. On the non-virtualized home/public timeline, auto refresh churns notes in and out, leaking a Swiper per image. The accumulated instances keep observers, listeners and timers alive and retain compositing layers, so style recalculation and layerization grow over time while the timeline is just left open.

Initialize the Swiper only when the dialog opens, and destroy it on component unmount.