### PR TITLE
Add timeout to NIP-46 bunker connection

### DIFF
--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -14,6 +14,7 @@ export const filterLimit = 500;
 export const maxFilters = 10;
 export const timelineBufferMs = 1500;
 export const timeout = 5000;
+export const nip46ConnectTimeout = 10000;
 
 export const hexRegexp = /^[0-9a-f]{64}$/;
 export const addressRegexp = /^[0-9]+:[0-9a-f]{64}:.*$/;

--- a/web/src/lib/Signer.ts
+++ b/web/src/lib/Signer.ts
@@ -11,6 +11,7 @@ import { BunkerSigner, parseBunkerInput } from 'nostr-tools/nip46';
 import { generateSecretKey } from 'nostr-tools/pure';
 import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
 import { WebStorage } from './WebStorage';
+import { nip46ConnectTimeout } from './Constants';
 import type * as Nostr from 'nostr-typedef';
 
 declare const window: {
@@ -35,13 +36,34 @@ export class Signer {
 			storage.set('login:bunker:client-seckey', bytesToHex(clientSeckey));
 		}
 
+		let authRequested = false;
 		bunkerSigner = BunkerSigner.fromBunker(clientSeckey, bunkerPointer, {
-			onauth: (url) => open(url, '_blank')
+			onauth: (url) => {
+				authRequested = true;
+				open(url, '_blank');
+			}
 		});
 		console.debug('[NIP-46 client pubkey]', getPublicKey(clientSeckey));
-		await bunkerSigner.connect();
-		console.debug('[NIP-46 connected]');
-		nip46CachedPublicKey = await bunkerSigner.getPublicKey();
+
+		const signer = bunkerSigner;
+		const { promise: timeout, reject: rejectOnTimeout } = Promise.withResolvers<never>();
+		const timer = setTimeout(() => {
+			if (!authRequested) {
+				rejectOnTimeout(new Error('NIP-46 connection timed out'));
+			}
+		}, nip46ConnectTimeout);
+		try {
+			await Promise.race([
+				(async () => {
+					await signer.connect();
+					console.debug('[NIP-46 connected]');
+					nip46CachedPublicKey = await signer.getPublicKey();
+				})(),
+				timeout
+			]);
+		} finally {
+			clearTimeout(timer);
+		}
 		console.debug('[NIP-46 user pubkey]', nip46CachedPublicKey);
 	}
 


### PR DESCRIPTION
Restoring a NIP-46 login on reload could hang the splash screen forever when the bunker did not respond, because connect() and getPublicKey() wait indefinitely for a reply. Add a 10s timeout (skipped once the bunker requests authorization) so a stuck reconnect rejects and falls back to the login screen instead of freezing the app.