### PR TITLE
Reflect channel history immediately with a parallel 5-minute window REQ

### DIFF
--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
@@ -20,6 +20,8 @@ import { Channel } from '$lib/Channel';
 import { referencesReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
 import type { ChannelMetadata } from '$lib/Types';
 
+const recentWindow = 5 * 60;
+
 function contentRelays(event: Event | undefined): string[] {
 	if (event === undefined) {
 		return [];
@@ -90,6 +92,10 @@ export class ChannelChat {
 		this.loading = true;
 
 		const until = this.messages.length > 0 ? this.messages[0].created_at : now();
+
+		this.#subscribeRecentWindow(until);
+
+		let olderCount = 0;
 		const collected: Event[] = [];
 		const { promise, resolve } = Promise.withResolvers<void>();
 		const req = createRxBackwardReq();
@@ -102,6 +108,9 @@ export class ChannelChat {
 			)
 			.subscribe({
 				next: ({ event }) => {
+					if (event.created_at < until) {
+						olderCount++;
+					}
 					if (!this.#seen.has(event.id)) {
 						collected.push(event);
 					}
@@ -115,7 +124,7 @@ export class ChannelChat {
 		req.over();
 		await promise;
 
-		if (collected.length === 0) {
+		if (olderCount === 0) {
 			this.reachedStart = true;
 		} else {
 			this.#prependHistory(collected);
@@ -167,6 +176,22 @@ export class ChannelChat {
 		req.emit({ kinds: [ChannelMessage], '#e': [this.#channelId], since: now() });
 	}
 
+	#subscribeRecentWindow(until: number): void {
+		const req = createRxBackwardReq();
+		rxNostr
+			.use(req, this.#useOptions)
+			.pipe(
+				tie,
+				uniq(),
+				tap(({ event }) => referencesReqEmit(event))
+			)
+			.subscribe(({ event }) => this.#insertOlder(event));
+		req.emit([
+			{ kinds: [ChannelMessage], '#e': [this.#channelId], since: until - recentWindow, until }
+		]);
+		req.over();
+	}
+
 	#appendLive(event: Event): void {
 		if (this.#seen.has(event.id)) {
 			return;
@@ -175,6 +200,17 @@ export class ChannelChat {
 		this.shift = false;
 		this.messages = [...this.messages, event];
 		this.liveSeq++;
+	}
+
+	#insertOlder(event: Event): void {
+		if (this.#seen.has(event.id)) {
+			return;
+		}
+		this.#seen.add(event.id);
+		const index = this.messages.findIndex((e) => e.created_at > event.created_at);
+		this.shift = true;
+		this.messages =
+			index < 0 ? [...this.messages, event] : this.messages.toSpliced(index, 0, event);
 	}
 
 	#prependHistory(events: Event[]): void {

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
@@ -21,6 +21,7 @@ import { referencesReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
 import type { ChannelMetadata } from '$lib/Types';
 
 const recentWindow = 5 * 60;
+const recentWindowCount = 3;
 
 function contentRelays(event: Event | undefined): string[] {
 	if (event === undefined) {
@@ -186,9 +187,13 @@ export class ChannelChat {
 				tap(({ event }) => referencesReqEmit(event))
 			)
 			.subscribe(({ event }) => this.#insertOlder(event));
-		req.emit([
-			{ kinds: [ChannelMessage], '#e': [this.#channelId], since: until - recentWindow, until }
-		]);
+		const filters = Array.from({ length: recentWindowCount }, (_, i) => ({
+			kinds: [ChannelMessage],
+			'#e': [this.#channelId],
+			since: until - recentWindow * (i + 1),
+			until: until - recentWindow * i
+		}));
+		req.emit(filters);
 		req.over();
 	}
 


### PR DESCRIPTION
Waiting for the limit-based backward REQ to complete (EOSE) delayed channel messages from showing. Issue a separate backward REQ covering the last 5 minutes (since = until - 5min) in parallel and insert its events as they arrive, without waiting for complete.

The existing limit:25 REQ still guarantees the minimum batch, but the end-of-history check now counts events older than `until` instead of unseen events, so the immediate window seeding `#seen` no longer falsely marks the start as reached.