### PR TITLE
Fix emoji picker failing to open on iOS Safari

### DIFF
--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -27,27 +27,51 @@
 
 	let emojiPicker: HTMLElement | undefined | null = $state();
 
+	let PickerConstructor = $state<typeof import('emoji-kitchen-mart').Picker>();
+
 	const popover = new Popover({
+		closeOnOutsideClick: (element): boolean => {
+			console.debug('[emoji picker outside]', element);
+			return true;
+		},
 		onOpenChange: (open) => {
 			console.debug('[emoji picker open]', open);
-			if (open) {
-				init();
-			} else {
-				clear();
-			}
 		}
 	});
 
 	const dispatch = createEventDispatcher();
 
-	async function init(): Promise<void> {
-		console.debug('[emoji picker click]', emojiPicker);
-		if (!emojiPicker || emojiPicker.firstChild !== null) {
+	$effect(() => {
+		if (PickerConstructor || !popover.open) {
 			return;
 		}
+		import('emoji-kitchen-mart').then(({ Picker }) => {
+			PickerConstructor = Picker;
+		});
+	});
 
-		emojiPickerOpen = true;
+	$effect(() => {
+		if (!emojiPicker) {
+			return;
+		}
+		if (popover.open) {
+			if (PickerConstructor && emojiPicker.firstChild === null) {
+				console.debug('[emoji picker click]', emojiPicker);
+				const picker = new PickerConstructor({
+					data,
+					onEmojiSelect,
+					custom: buildCustom()
+				});
+				// eslint-disable-next-line svelte/no-dom-manipulating, @typescript-eslint/no-explicit-any
+				emojiPicker.appendChild(picker as any);
+				emojiPickerOpen = true;
+			}
+		} else if (emojiPicker.firstChild !== null) {
+			clear();
+		}
+	});
 
+	function buildCustom() {
 		const customEmojis = $customEmojiTags.map(([, shortcode, url]) => {
 			return {
 				id: shortcode,
@@ -89,24 +113,7 @@
 				emojis: customEmojis
 			});
 		}
-
-		const { Picker } = await import('emoji-kitchen-mart');
-		if (!popover.open || !emojiPicker || emojiPicker.firstChild !== null) {
-			return;
-		}
-		const picker = new Picker({
-			data,
-			onEmojiSelect,
-			onClickOutside,
-			custom
-		});
-		// eslint-disable-next-line svelte/no-dom-manipulating, @typescript-eslint/no-explicit-any
-		emojiPicker.appendChild(picker as any);
-	}
-
-	function onClickOutside(event: PointerEvent) {
-		console.debug('[emoji picker outside]', event.target);
-		popover.open = false;
+		return custom;
 	}
 
 	function onEmojiSelect(emoji: BaseEmoji): void {

--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -29,15 +29,7 @@
 
 	let PickerConstructor = $state<typeof import('emoji-kitchen-mart').Picker>();
 
-	const popover = new Popover({
-		closeOnOutsideClick: (element): boolean => {
-			console.debug('[emoji picker outside]', element);
-			return true;
-		},
-		onOpenChange: (open) => {
-			console.debug('[emoji picker open]', open);
-		}
-	});
+	const popover = new Popover();
 
 	const dispatch = createEventDispatcher();
 
@@ -56,7 +48,6 @@
 		}
 		if (popover.open) {
 			if (PickerConstructor && emojiPicker.firstChild === null) {
-				console.debug('[emoji picker click]', emojiPicker);
 				const picker = new PickerConstructor({
 					data,
 					onEmojiSelect,
@@ -117,7 +108,6 @@
 	}
 
 	function onEmojiSelect(emoji: BaseEmoji): void {
-		console.debug('[emoji picker selected]', emoji);
 		dispatch('pick', emoji);
 		if (autoClose) {
 			popover.open = false;
@@ -125,7 +115,6 @@
 	}
 
 	function clear(): void {
-		console.debug('[emoji picker clear]');
 		emojiPicker?.firstChild?.remove();
 		emojiPickerOpen = false;
 	}


### PR DESCRIPTION
Drive picker creation through a reactive effect keyed on the melt Popover open state and a cached Picker constructor, instead of appending it after an awaited dynamic import inside the open handler. On iOS Safari the open state could flip during the await, so the post-import guard aborted the append and the picker never appeared. The reactive effect re-evaluates whenever the open state or the loaded constructor changes, so the picker is appended as soon as it is both open and ready, with no awaited gap on reopen.

Delegate outside-click dismissal to the melt Popover (closeOnOutsideClick) and stop passing onClickOutside to the picker, so the popover open state is owned solely by melt and no longer desynced by emoji-mart's document click listener.