### PR TITLE
Remove focus outline from emoji picker popover

### DIFF
--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -150,6 +150,10 @@
 		background-color: transparent;
 	}
 
+	[popover]:focus {
+		outline: none;
+	}
+
 	main {
 		border: var(--default-border);
 		border-radius: var(--radius);


### PR DESCRIPTION
The melt Popover content element is programmatically focused on open, which showed the browser default focus ring around the whole picker.