### PR TITLE
Add developer option for seen-on relay icons and via on timeline

### DIFF
--- a/web/src/lib/Helper.ts
+++ b/web/src/lib/Helper.ts
@@ -3,6 +3,8 @@ export const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(r
 export const newUrl = (url: string): URL | undefined =>
 	URL.canParse(url) ? new URL(url) : undefined;
 
+export const hostname = (url: string): string => newUrl(url)?.hostname ?? url;
+
 export const fetchMinutes = (numberOfPubkeys: number): number => {
 	if (numberOfPubkeys < 10) {
 		return 24 * 60;

--- a/web/src/lib/SeenOnRelayIcon.ts
+++ b/web/src/lib/SeenOnRelayIcon.ts
@@ -1,0 +1,3 @@
+import { persistedStore } from '$lib/WebStorage';
+
+export const seenOnRelayIcon = persistedStore<boolean>('preference:seen-on-relay-icon', false);

--- a/web/src/lib/components/RelayIcon.svelte
+++ b/web/src/lib/components/RelayIcon.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
 	import { Nip11Registry } from 'rx-nostr';
+	import { hostname } from '$lib/Helper';
 
 	interface Props {
 		relay: string;
 	}
 
 	let { relay }: Props = $props();
-
-	function hostname(value: string): string {
-		try {
-			return new URL(value).hostname;
-		} catch {
-			return value;
-		}
-	}
 
 	let host = $derived(hostname(relay));
 	let initial = $derived(host.charAt(0).toUpperCase());
@@ -50,7 +43,7 @@
 		display: block;
 		width: 16px;
 		height: 16px;
-		border-radius: 2px;
+		border-radius: 50%;
 	}
 
 	img {

--- a/web/src/lib/components/RelayIcon.svelte
+++ b/web/src/lib/components/RelayIcon.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { Nip11Registry } from 'rx-nostr';
+
+	interface Props {
+		relay: string;
+	}
+
+	let { relay }: Props = $props();
+
+	function hostname(value: string): string {
+		try {
+			return new URL(value).hostname;
+		} catch {
+			return value;
+		}
+	}
+
+	let host = $derived(hostname(relay));
+	let initial = $derived(host.charAt(0).toUpperCase());
+
+	let triedFavicon = $state(false);
+	let failed = $state(false);
+
+	function favicon(): string {
+		return `https://${host}/favicon.ico`;
+	}
+
+	function onError(event: Event): void {
+		const img = event.currentTarget as HTMLImageElement;
+		if (!triedFavicon && img.src !== favicon()) {
+			triedFavicon = true;
+			img.src = favicon();
+		} else {
+			failed = true;
+		}
+	}
+</script>
+
+{#await Nip11Registry.getOrFetch(relay) then info}
+	{#if failed}
+		<span class="placeholder">{initial}</span>
+	{:else}
+		<img src={info.icon || favicon()} alt={host} onerror={onError} />
+	{/if}
+{/await}
+
+<style>
+	img,
+	.placeholder {
+		display: block;
+		width: 16px;
+		height: 16px;
+		border-radius: 2px;
+	}
+
+	img {
+		object-fit: cover;
+	}
+
+	.placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: var(--accent-gray);
+		color: white;
+		font-size: 10px;
+		line-height: 1;
+		text-transform: uppercase;
+	}
+</style>

--- a/web/src/lib/components/SeenOnRelayIcons.svelte
+++ b/web/src/lib/components/SeenOnRelayIcons.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { Nip11Registry } from 'rx-nostr';
+	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
+
+	interface Props {
+		id: string;
+	}
+
+	let { id }: Props = $props();
+
+	let relays = $derived(getSeenOnRelays(id) ?? []);
+
+	function hostname(relay: string): string {
+		try {
+			return new URL(relay).hostname;
+		} catch {
+			return relay;
+		}
+	}
+
+	function favicon(relay: string): string {
+		return `https://${hostname(relay)}/favicon.ico`;
+	}
+
+	function onError(event: Event, relay: string): void {
+		const img = event.currentTarget as HTMLImageElement;
+		const fallback = favicon(relay);
+		if (img.src !== fallback) {
+			img.src = fallback;
+		} else {
+			img.style.visibility = 'hidden';
+		}
+	}
+</script>
+
+<div class="relays">
+	{#each relays as relay (relay)}
+		<a href="/relays/{encodeURIComponent(relay)}" title={hostname(relay)}>
+			{#await Nip11Registry.getOrFetch(relay) then info}
+				<img
+					src={info.icon || favicon(relay)}
+					alt={hostname(relay)}
+					onerror={(event) => onError(event, relay)}
+				/>
+			{:catch}
+				<img
+					src={favicon(relay)}
+					alt={hostname(relay)}
+					onerror={(event) => onError(event, relay)}
+				/>
+			{/await}
+		</a>
+	{/each}
+</div>
+
+<style>
+	.relays {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	img {
+		display: block;
+		width: 16px;
+		height: 16px;
+		border-radius: 2px;
+		object-fit: cover;
+	}
+</style>

--- a/web/src/lib/components/SeenOnRelayIcons.svelte
+++ b/web/src/lib/components/SeenOnRelayIcons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Nip11Registry } from 'rx-nostr';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
+	import RelayIcon from './RelayIcon.svelte';
 
 	interface Props {
 		id: string;
@@ -17,38 +17,12 @@
 			return relay;
 		}
 	}
-
-	function favicon(relay: string): string {
-		return `https://${hostname(relay)}/favicon.ico`;
-	}
-
-	function onError(event: Event, relay: string): void {
-		const img = event.currentTarget as HTMLImageElement;
-		const fallback = favicon(relay);
-		if (img.src !== fallback) {
-			img.src = fallback;
-		} else {
-			img.style.visibility = 'hidden';
-		}
-	}
 </script>
 
 <div class="relays">
 	{#each relays as relay (relay)}
 		<a href="/relays/{encodeURIComponent(relay)}" title={hostname(relay)}>
-			{#await Nip11Registry.getOrFetch(relay) then info}
-				<img
-					src={info.icon || favicon(relay)}
-					alt={hostname(relay)}
-					onerror={(event) => onError(event, relay)}
-				/>
-			{:catch}
-				<img
-					src={favicon(relay)}
-					alt={hostname(relay)}
-					onerror={(event) => onError(event, relay)}
-				/>
-			{/await}
+			<RelayIcon {relay} />
 		</a>
 	{/each}
 </div>
@@ -59,13 +33,5 @@
 		flex-wrap: wrap;
 		align-items: center;
 		gap: 0.25rem;
-	}
-
-	img {
-		display: block;
-		width: 16px;
-		height: 16px;
-		border-radius: 2px;
-		object-fit: cover;
 	}
 </style>

--- a/web/src/lib/components/SeenOnRelayIcons.svelte
+++ b/web/src/lib/components/SeenOnRelayIcons.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
+	import { hostname } from '$lib/Helper';
 	import RelayIcon from './RelayIcon.svelte';
 
 	interface Props {
@@ -9,14 +10,6 @@
 	let { id }: Props = $props();
 
 	let relays = $derived(getSeenOnRelays(id) ?? []);
-
-	function hostname(relay: string): string {
-		try {
-			return new URL(relay).hostname;
-		} catch {
-			return relay;
-		}
-	}
 </script>
 
 <div class="relays">

--- a/web/src/lib/components/items/Note.svelte
+++ b/web/src/lib/components/items/Note.svelte
@@ -153,9 +153,9 @@
 					<Via tags={item.event.tags} />
 				</footer>
 			{:else if $seenOnRelayIcon}
-				<footer>
+				<footer class="relay-info">
 					<SeenOnRelayIcons id={item.event.id} />
-					<Via tags={item.event.tags} />
+					<div class="via"><Via tags={item.event.tags} /></div>
 				</footer>
 			{/if}
 		</section>
@@ -203,5 +203,16 @@
 
 	footer {
 		margin-top: 0.2rem;
+	}
+
+	footer.relay-info {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.25rem 0.5rem;
+	}
+
+	footer.relay-info .via {
+		margin-left: auto;
 	}
 </style>

--- a/web/src/lib/components/items/Note.svelte
+++ b/web/src/lib/components/items/Note.svelte
@@ -20,6 +20,8 @@
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import Foldable from '$lib/components/shared/Foldable.svelte';
 	import { _ } from 'svelte-i18n';
+	import SeenOnRelayIcons from '../SeenOnRelayIcons.svelte';
+	import { seenOnRelayIcon } from '$lib/SeenOnRelayIcon';
 
 	interface Props {
 		item: Item;
@@ -148,6 +150,11 @@
 			{#if full}
 				<footer>
 					<CreatedAt createdAt={item.event.created_at} format="full" />
+					<Via tags={item.event.tags} />
+				</footer>
+			{:else if $seenOnRelayIcon}
+				<footer>
+					<SeenOnRelayIcons id={item.event.id} />
 					<Via tags={item.event.tags} />
 				</footer>
 			{/if}

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -143,6 +143,7 @@
 		"enable_uri_scheme": "Enable",
 		"developer_mode": "Developer mode",
 		"developer_mode_description": "(Provide additional features, but they require knowledge of Nostr)",
+		"seen_on_relay_icon": "Show seen-on relays and via on timeline",
 		"mute": {
 			"mute": "Mute",
 			"pubkeys": "Users",

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -142,6 +142,7 @@
 		"enable_uri_scheme": "有効化",
 		"developer_mode": "開発者モード",
 		"developer_mode_description": "（追加の機能を提供しますが Nostr の知識が必要です）",
+		"seen_on_relay_icon": "タイムラインに seen on リレーと via を表示",
 		"mute": {
 			"mute": "ミュート",
 			"pubkeys": "ユーザー",

--- a/web/src/routes/(app)/preferences/+page.svelte
+++ b/web/src/routes/(app)/preferences/+page.svelte
@@ -107,10 +107,10 @@
 	<div><Backup /></div>
 	<div><DeveloperMode /></div>
 	{#if $developerMode}
+		<div><SeenOnRelayIcon /></div>
 		<div><WorkAsRemoteSigner /></div>
 		<div><RelayStates /></div>
 		<div><WebStorage /></div>
-		<div><SeenOnRelayIcon /></div>
 		<h3>{$_('preferences.trouble_shooting')}</h3>
 		<div><Reload /></div>
 		<div><ClearEventCacheAndReload /></div>

--- a/web/src/routes/(app)/preferences/+page.svelte
+++ b/web/src/routes/(app)/preferences/+page.svelte
@@ -21,6 +21,7 @@
 	import DeveloperMode from './DeveloperMode.svelte';
 	import WebStorage from './WebStorage.svelte';
 	import RelayStates from './RelayStates.svelte';
+	import SeenOnRelayIcon from './SeenOnRelayIcon.svelte';
 	import WalletConnect from './WalletConnect.svelte';
 	import Reload from './Reload.svelte';
 	import ClearEventCacheAndReload from './ClearEventCacheAndReload.svelte';
@@ -109,6 +110,7 @@
 		<div><WorkAsRemoteSigner /></div>
 		<div><RelayStates /></div>
 		<div><WebStorage /></div>
+		<div><SeenOnRelayIcon /></div>
 		<h3>{$_('preferences.trouble_shooting')}</h3>
 		<div><Reload /></div>
 		<div><ClearEventCacheAndReload /></div>

--- a/web/src/routes/(app)/preferences/SeenOnRelayIcon.svelte
+++ b/web/src/routes/(app)/preferences/SeenOnRelayIcon.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { seenOnRelayIcon } from '$lib/SeenOnRelayIcon';
+</script>
+
+<label>
+	<input type="checkbox" bind:checked={$seenOnRelayIcon} />
+	<span>{$_('preferences.seen_on_relay_icon')}</span>
+</label>


### PR DESCRIPTION
Add a persisted preference toggle in the developer section of preferences. When enabled, non-full Note views show NIP-11 relay icons (with favicon fallback) for the relays the event was seen on, together with the via tag.