### PR TITLE
Fix seen-on relay reactivity and split seen-on/via options

### DIFF
--- a/web/src/lib/RxNostrTie.ts
+++ b/web/src/lib/RxNostrTie.ts
@@ -1,5 +1,6 @@
 import type { EventPacket } from 'rx-nostr';
 import { map, pipe, type OperatorFunction } from 'rxjs';
+import { SvelteSet } from 'svelte/reactivity';
 
 export function createTie<P extends EventPacket>(): [
 	OperatorFunction<P, P & { seenOn: Set<string>; isNew: boolean }>,
@@ -10,7 +11,7 @@ export function createTie<P extends EventPacket>(): [
 	return [
 		pipe(
 			map((packet) => {
-				const seenOn = memo.get(packet.event.id) ?? new Set<string>();
+				const seenOn = memo.get(packet.event.id) ?? new SvelteSet<string>();
 				const isNew = seenOn.size <= 0;
 
 				if (!memo.get(packet.event.id)?.has(packet.from)) {

--- a/web/src/lib/ShowVia.ts
+++ b/web/src/lib/ShowVia.ts
@@ -1,0 +1,3 @@
+import { persistedStore } from '$lib/WebStorage';
+
+export const showVia = persistedStore<boolean>('preference:show-via', false);

--- a/web/src/lib/components/items/Note.svelte
+++ b/web/src/lib/components/items/Note.svelte
@@ -22,6 +22,7 @@
 	import { _ } from 'svelte-i18n';
 	import SeenOnRelayIcons from '../SeenOnRelayIcons.svelte';
 	import { seenOnRelayIcon } from '$lib/SeenOnRelayIcon';
+	import { showVia } from '$lib/ShowVia';
 
 	interface Props {
 		item: Item;
@@ -150,12 +151,19 @@
 			{#if full}
 				<footer>
 					<CreatedAt createdAt={item.event.created_at} format="full" />
-					<Via tags={item.event.tags} />
+					<div class="relay-info">
+						<SeenOnRelayIcons id={item.event.id} />
+						<div class="via"><Via tags={item.event.tags} /></div>
+					</div>
 				</footer>
-			{:else if $seenOnRelayIcon}
+			{:else if $seenOnRelayIcon || $showVia}
 				<footer class="relay-info">
-					<SeenOnRelayIcons id={item.event.id} />
-					<div class="via"><Via tags={item.event.tags} /></div>
+					{#if $seenOnRelayIcon}
+						<SeenOnRelayIcons id={item.event.id} />
+					{/if}
+					{#if $showVia}
+						<div class="via"><Via tags={item.event.tags} /></div>
+					{/if}
 				</footer>
 			{/if}
 		</section>
@@ -205,14 +213,18 @@
 		margin-top: 0.2rem;
 	}
 
-	footer.relay-info {
+	.relay-info {
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
 		gap: 0.25rem 0.5rem;
 	}
 
-	footer.relay-info .via {
+	footer.relay-info {
+		margin-top: 0.5rem;
+	}
+
+	.relay-info .via {
 		margin-left: auto;
 	}
 </style>

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -143,7 +143,8 @@
 		"enable_uri_scheme": "Enable",
 		"developer_mode": "Developer mode",
 		"developer_mode_description": "(Provide additional features, but they require knowledge of Nostr)",
-		"seen_on_relay_icon": "Show seen-on relays and via on timeline",
+		"seen_on_relay_icon": "Show seen-on relays on timeline",
+		"show_via": "Show via on timeline",
 		"mute": {
 			"mute": "Mute",
 			"pubkeys": "Users",

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -142,7 +142,8 @@
 		"enable_uri_scheme": "有効化",
 		"developer_mode": "開発者モード",
 		"developer_mode_description": "（追加の機能を提供しますが Nostr の知識が必要です）",
-		"seen_on_relay_icon": "タイムラインに seen on リレーと via を表示",
+		"seen_on_relay_icon": "タイムラインに seen on リレーを表示",
+		"show_via": "タイムラインに via を表示",
 		"mute": {
 			"mute": "ミュート",
 			"pubkeys": "ユーザー",

--- a/web/src/routes/(app)/preferences/+page.svelte
+++ b/web/src/routes/(app)/preferences/+page.svelte
@@ -22,6 +22,7 @@
 	import WebStorage from './WebStorage.svelte';
 	import RelayStates from './RelayStates.svelte';
 	import SeenOnRelayIcon from './SeenOnRelayIcon.svelte';
+	import ShowVia from './ShowVia.svelte';
 	import WalletConnect from './WalletConnect.svelte';
 	import Reload from './Reload.svelte';
 	import ClearEventCacheAndReload from './ClearEventCacheAndReload.svelte';
@@ -108,6 +109,7 @@
 	<div><DeveloperMode /></div>
 	{#if $developerMode}
 		<div><SeenOnRelayIcon /></div>
+		<div><ShowVia /></div>
 		<div><WorkAsRemoteSigner /></div>
 		<div><RelayStates /></div>
 		<div><WebStorage /></div>

--- a/web/src/routes/(app)/preferences/ShowVia.svelte
+++ b/web/src/routes/(app)/preferences/ShowVia.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { showVia } from '$lib/ShowVia';
+</script>
+
+<label>
+	<input type="checkbox" bind:checked={$showVia} />
+	<span>{$_('preferences.show_via')}</span>
+</label>


### PR DESCRIPTION
Use a reactive SvelteSet for seen-on relays so the icons update as more relays deliver an event instead of freezing on the first one. Split the timeline toggle into separate seen-on and via options, always show relay icons and via in the full view, and add spacing between the footer and the action buttons.