### PR TITLE
Cache followees' replaceable events in IndexedDB

### DIFF
--- a/web/src/lib/Contacts.ts
+++ b/web/src/lib/Contacts.ts
@@ -4,6 +4,7 @@ import { Api } from './Api';
 import { filterTags } from './EventHelper';
 import { followees, originalFollowees, pubkey } from './stores/Author';
 import { sendEvent } from './RxNostrHelper';
+import { pruneFolloweeReplaceableEventsCache } from './cache/Events';
 
 export class Contacts {
 	private readonly api: Api;
@@ -42,4 +43,5 @@ export function updateFolloweesStore(tags: string[][]): void {
 	pubkeys.add(get(pubkey)); // Add myself
 	followees.set([...pubkeys]);
 	console.log('[contacts]', pubkeys.size);
+	pruneFolloweeReplaceableEventsCache([...pubkeys]);
 }

--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -1,11 +1,12 @@
 import { get } from 'svelte/store';
-import { author, authorProfile, loginType, pubkey, rom } from './stores/Author';
+import { author, authorProfile, followees, loginType, pubkey, rom } from './stores/Author';
 import { Signer } from './Signer';
 import { Author } from './Author';
 import { getPublicKey, nip19 } from 'nostr-tools';
 import { robohash } from './Items';
 import { WebStorage } from './WebStorage';
 import { rxNostr } from './timelines/MainTimeline';
+import { loadFolloweesMetadataCache } from './cache/Events';
 import { now } from 'rx-nostr';
 import type { User } from '../routes/types';
 import { remoteSigner } from './RemoteSigner';
@@ -156,6 +157,8 @@ export class Login {
 
 		await $author.fetchEvents();
 		console.timeEnd('fetch author');
+
+		await loadFolloweesMetadataCache(get(followees));
 
 		author.set($author);
 		clearLoginStatus();

--- a/web/src/lib/RelayList.ts
+++ b/web/src/lib/RelayList.ts
@@ -1,14 +1,17 @@
 import { createRxBackwardReq, latestEach, uniq } from 'rx-nostr';
+import { kinds as Kind } from 'nostr-tools';
 import type * as Nostr from 'nostr-typedef';
 import type { pubkey } from './Types';
 import { rxNostr, tie } from './timelines/MainTimeline';
+import { cacheFolloweeReplaceableEvent, followeeEventCache } from './cache/Events';
 
 export class RelayList {
 	static async fetchEvents(pubkeys: pubkey[]): Promise<Map<pubkey, Nostr.Event>> {
-		const eventsMap = new Map<pubkey, Nostr.Event>();
 		if (pubkeys.length === 0) {
-			return eventsMap;
+			return new Map();
 		}
+
+		const eventsMap = await followeeEventCache.getLatest(Kind.RelayList, pubkeys);
 
 		return new Promise((resolve) => {
 			const req = createRxBackwardReq();
@@ -20,12 +23,14 @@ export class RelayList {
 					latestEach(({ event }) => event.pubkey)
 				)
 				.subscribe({
-					next: (packet) => {
-						console.debug('[rx-nostr kind 10002 next]', pubkeys, packet);
-						eventsMap.set(packet.event.pubkey, packet.event);
+					next: ({ event }) => {
+						const current = eventsMap.get(event.pubkey);
+						if (current === undefined || current.created_at < event.created_at) {
+							eventsMap.set(event.pubkey, event);
+						}
+						cacheFolloweeReplaceableEvent(event);
 					},
 					complete: () => {
-						console.debug('[rx-nostr kind 10002 complete]', pubkeys);
 						resolve(eventsMap);
 					},
 					error: (error) => {
@@ -33,7 +38,7 @@ export class RelayList {
 						resolve(eventsMap);
 					}
 				});
-			req.emit([{ kinds: [10002], authors: pubkeys }]);
+			req.emit([{ kinds: [Kind.RelayList], authors: pubkeys }]);
 			req.over();
 		});
 	}

--- a/web/src/lib/author/MuteAutomatically.ts
+++ b/web/src/lib/author/MuteAutomatically.ts
@@ -1,10 +1,12 @@
 import { get, writable } from 'svelte/store';
 import { createRxBackwardReq, latestEach, uniq } from 'rx-nostr';
+import { kinds as Kind } from 'nostr-tools';
 import type * as Nostr from 'nostr-typedef';
 import { chunk } from '$lib/Array';
 import { filterLimit, maxFilters } from '$lib/Constants';
 import { rxNostr, tie } from '$lib/timelines/MainTimeline';
 import { followees } from '$lib/stores/Author';
+import { cacheFolloweeReplaceableEvent, followeeEventCache } from '$lib/cache/Events';
 
 export const followeesOfFollowees = writable<Set<string>>(new Set());
 
@@ -33,6 +35,19 @@ export function contactsOfFolloweesReqEmit(): void {
 
 	loaded = true;
 
+	const $followees = get(followees);
+	followeesOfFollowees.set(new Set($followees)); // For UX
+
+	followeeEventCache.getLatest(Kind.Contacts, $followees).then((cached) => {
+		if (cached.size === 0) {
+			return;
+		}
+		for (const [pubkey, event] of cached) {
+			$contactsOfFollowees.set(pubkey, event);
+		}
+		contactsOfFollowees.set($contactsOfFollowees);
+	});
+
 	const req = createRxBackwardReq();
 	rxNostr
 		.use(req)
@@ -45,15 +60,17 @@ export function contactsOfFolloweesReqEmit(): void {
 			next: ({ event }) => {
 				console.debug('[followees contacts]', event);
 				$contactsOfFollowees.set(event.pubkey, event);
+				cacheFolloweeReplaceableEvent(event);
 			},
 			complete: () => {
 				contactsOfFollowees.set($contactsOfFollowees);
 			}
 		});
 
-	const $followees = get(followees);
-	followeesOfFollowees.set(new Set($followees)); // For UX
-	const filters = chunk($followees, filterLimit).map((authors) => ({ kinds: [3], authors }));
+	const filters = chunk($followees, filterLimit).map((authors) => ({
+		kinds: [Kind.Contacts],
+		authors
+	}));
 	for (const chunkedFilters of chunk(filters, maxFilters)) {
 		req.emit(chunkedFilters);
 		req.over();

--- a/web/src/lib/cache/Events.ts
+++ b/web/src/lib/cache/Events.ts
@@ -66,3 +66,10 @@ export async function loadFolloweesMetadataCache(pubkeys: string[]): Promise<voi
 	}
 	metadataStore.set($metadataStore);
 }
+
+export async function pruneFolloweeReplaceableEventsCache(pubkeys: string[]): Promise<void> {
+	if (pubkeys.length <= 1) {
+		return;
+	}
+	await followeeEventCache.pruneExcept(pubkeys);
+}

--- a/web/src/lib/cache/Events.ts
+++ b/web/src/lib/cache/Events.ts
@@ -5,7 +5,7 @@ import type { id, pubkey } from '$lib/Types';
 import { EventItem, Metadata } from '$lib/Items';
 import { ToastNotification } from '$lib/ToastNotification';
 import { replaceableKinds } from '$lib/Constants';
-import { followees } from '$lib/stores/Author';
+import { followeesSet } from '$lib/stores/Author';
 import { db, EventCache, FolloweeReplaceableEventCache } from './db';
 
 export const metadataStore = writable(new Map<pubkey, Metadata>());
@@ -47,9 +47,6 @@ export function storeEventItem(event: Nostr.Event): void {
 
 export const eventCache = new EventCache(db);
 export const followeeEventCache = new FolloweeReplaceableEventCache(db);
-
-let followeesSet = new Set<string>();
-followees.subscribe(($followees) => (followeesSet = new Set($followees)));
 
 export function cacheFolloweeReplaceableEvent(event: Nostr.Event): void {
 	if (!replaceableKinds.includes(event.kind) || !followeesSet.has(event.pubkey)) {

--- a/web/src/lib/cache/Events.ts
+++ b/web/src/lib/cache/Events.ts
@@ -1,9 +1,12 @@
 import { get, writable, type Writable } from 'svelte/store';
+import { kinds as Kind } from 'nostr-tools';
 import type * as Nostr from 'nostr-typedef';
 import type { id, pubkey } from '$lib/Types';
 import { EventItem, Metadata } from '$lib/Items';
 import { ToastNotification } from '$lib/ToastNotification';
-import { db, EventCache } from './db';
+import { replaceableKinds } from '$lib/Constants';
+import { followees } from '$lib/stores/Author';
+import { db, EventCache, FolloweeReplaceableEventCache } from './db';
 
 export const metadataStore = writable(new Map<pubkey, Metadata>());
 export const eventItemStore = writable(new Map<id, EventItem>());
@@ -29,6 +32,8 @@ export function storeMetadata(event: Nostr.Event): void {
 		const toast = new ToastNotification();
 		toast.dequeue(metadata);
 	}
+
+	cacheFolloweeReplaceableEvent(event);
 }
 
 export function storeEventItem(event: Nostr.Event): void {
@@ -41,3 +46,26 @@ export function storeEventItem(event: Nostr.Event): void {
 }
 
 export const eventCache = new EventCache(db);
+export const followeeEventCache = new FolloweeReplaceableEventCache(db);
+
+let followeesSet = new Set<string>();
+followees.subscribe(($followees) => (followeesSet = new Set($followees)));
+
+export function cacheFolloweeReplaceableEvent(event: Nostr.Event): void {
+	if (!replaceableKinds.includes(event.kind) || !followeesSet.has(event.pubkey)) {
+		return;
+	}
+	followeeEventCache.put(event);
+}
+
+export async function loadFolloweesMetadataCache(pubkeys: string[]): Promise<void> {
+	const eventsMap = await followeeEventCache.getLatest(Kind.Metadata, pubkeys);
+	const $metadataStore = get(metadataStore);
+	for (const [pubkey, event] of eventsMap) {
+		const cache = $metadataStore.get(pubkey);
+		if (cache === undefined || cache.event.created_at < event.created_at) {
+			$metadataStore.set(pubkey, new Metadata(event));
+		}
+	}
+	metadataStore.set($metadataStore);
+}

--- a/web/src/lib/cache/db.test.ts
+++ b/web/src/lib/cache/db.test.ts
@@ -219,4 +219,34 @@ describe('FolloweeReplaceableEventCache', () => {
 			expect(map.get(pubkey1)?.kind).toBe(3);
 		});
 	});
+
+	describe('pruneExcept', () => {
+		it('should delete events whose pubkey is not in the list', async () => {
+			await cache.put(
+				mockEvent({ id: '1'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 1000 })
+			);
+			await cache.put(
+				mockEvent({ id: '2'.repeat(64), kind: 0, pubkey: pubkey2, created_at: 2000 })
+			);
+
+			await cache.pruneExcept([pubkey1]);
+
+			expect(await testDb.followeeReplaceableEvents.get([0, pubkey1])).toBeDefined();
+			expect(await testDb.followeeReplaceableEvents.get([0, pubkey2])).toBeUndefined();
+			expect(await testDb.followeeReplaceableEvents.count()).toBe(1);
+		});
+
+		it('should keep all events when every pubkey is in the list', async () => {
+			await cache.put(
+				mockEvent({ id: '1'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 1000 })
+			);
+			await cache.put(
+				mockEvent({ id: '2'.repeat(64), kind: 0, pubkey: pubkey2, created_at: 2000 })
+			);
+
+			await cache.pruneExcept([pubkey1, pubkey2]);
+
+			expect(await testDb.followeeReplaceableEvents.count()).toBe(2);
+		});
+	});
 });

--- a/web/src/lib/cache/db.test.ts
+++ b/web/src/lib/cache/db.test.ts
@@ -1,7 +1,7 @@
 import 'fake-indexeddb/auto';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Dexie from 'dexie';
-import { EventCache, type CacheDB } from './db';
+import { EventCache, FolloweeReplaceableEventCache, type CacheDB } from './db';
 import type * as Nostr from 'nostr-typedef';
 
 const mockEvent = (overrides: Partial<Nostr.Event> = {}): Nostr.Event => ({
@@ -118,6 +118,105 @@ describe('EventCache', () => {
 			expect(events.length).toBe(2);
 			expect(events[0].created_at).toBe(2000);
 			expect(events[1].created_at).toBe(1000);
+		});
+	});
+});
+
+describe('FolloweeReplaceableEventCache', () => {
+	let testDb: CacheDB;
+	let cache: FolloweeReplaceableEventCache;
+
+	const pubkey1 = 'a'.repeat(64);
+	const pubkey2 = 'b'.repeat(64);
+
+	beforeEach(async () => {
+		testDb = new Dexie(`followee-cache-test-${Date.now()}`) as CacheDB;
+		testDb.version(1).stores({
+			events: 'id, kind, pubkey, [kind+pubkey]',
+			followeeReplaceableEvents: '[kind+pubkey], pubkey'
+		});
+		await testDb.open();
+
+		cache = new FolloweeReplaceableEventCache(testDb);
+	});
+
+	afterEach(async () => {
+		await testDb.delete();
+	});
+
+	describe('put', () => {
+		it('should store an event', async () => {
+			const event = mockEvent({
+				id: '1'.repeat(64),
+				kind: 0,
+				pubkey: pubkey1,
+				created_at: 1000
+			});
+			await cache.put(event);
+
+			const stored = await testDb.followeeReplaceableEvents.get([0, pubkey1]);
+			expect(stored?.id).toBe(event.id);
+		});
+
+		it('should keep only the latest per kind and pubkey', async () => {
+			await cache.put(
+				mockEvent({ id: '1'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 1000 })
+			);
+			await cache.put(
+				mockEvent({ id: '2'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 2000 })
+			);
+
+			const stored = await testDb.followeeReplaceableEvents.get([0, pubkey1]);
+			expect(stored?.created_at).toBe(2000);
+			expect(await testDb.followeeReplaceableEvents.count()).toBe(1);
+		});
+
+		it('should ignore an older event', async () => {
+			await cache.put(
+				mockEvent({ id: '2'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 2000 })
+			);
+			await cache.put(
+				mockEvent({ id: '1'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 1000 })
+			);
+
+			const stored = await testDb.followeeReplaceableEvents.get([0, pubkey1]);
+			expect(stored?.created_at).toBe(2000);
+		});
+	});
+
+	describe('getLatest', () => {
+		beforeEach(async () => {
+			await cache.put(
+				mockEvent({ id: '1'.repeat(64), kind: 0, pubkey: pubkey1, created_at: 1000 })
+			);
+			await cache.put(
+				mockEvent({ id: '2'.repeat(64), kind: 0, pubkey: pubkey2, created_at: 2000 })
+			);
+			await cache.put(
+				mockEvent({ id: '3'.repeat(64), kind: 3, pubkey: pubkey1, created_at: 1500 })
+			);
+		});
+
+		it('should return the latest event per pubkey for a kind', async () => {
+			const map = await cache.getLatest(0, [pubkey1, pubkey2]);
+
+			expect(map.size).toBe(2);
+			expect(map.get(pubkey1)?.created_at).toBe(1000);
+			expect(map.get(pubkey2)?.created_at).toBe(2000);
+		});
+
+		it('should not include pubkeys without a cached event', async () => {
+			const map = await cache.getLatest(0, [pubkey1, 'c'.repeat(64)]);
+
+			expect(map.size).toBe(1);
+			expect(map.has(pubkey1)).toBe(true);
+		});
+
+		it('should filter by kind', async () => {
+			const map = await cache.getLatest(3, [pubkey1, pubkey2]);
+
+			expect(map.size).toBe(1);
+			expect(map.get(pubkey1)?.kind).toBe(3);
 		});
 	});
 });

--- a/web/src/lib/cache/db.ts
+++ b/web/src/lib/cache/db.ts
@@ -60,4 +60,8 @@ export class FolloweeReplaceableEventCache {
 		}
 		return eventsMap;
 	}
+
+	async pruneExcept(pubkeys: string[]): Promise<void> {
+		await this.db.followeeReplaceableEvents.where('pubkey').noneOf(pubkeys).delete();
+	}
 }

--- a/web/src/lib/cache/db.ts
+++ b/web/src/lib/cache/db.ts
@@ -1,8 +1,9 @@
-import Dexie, { type EntityTable } from 'dexie';
+import Dexie, { type EntityTable, type Table } from 'dexie';
 import type * as Nostr from 'nostr-typedef';
 
 export type CacheDB = Dexie & {
 	events: EntityTable<Nostr.Event, 'id'>;
+	followeeReplaceableEvents: Table<Nostr.Event, [number, string]>;
 };
 
 const db = new Dexie('cache') as CacheDB;
@@ -10,6 +11,10 @@ const db = new Dexie('cache') as CacheDB;
 // Notice: Native version is x10. https://dexie.org/docs/Dexie/Dexie.verno
 db.version(1).stores({
 	events: 'id, kind, pubkey, [kind+pubkey]'
+});
+
+db.version(2).stores({
+	followeeReplaceableEvents: '[kind+pubkey], pubkey'
 });
 
 export { db };
@@ -28,5 +33,31 @@ export class EventCache {
 
 	async getReplaceableEvents(kind: number, pubkey: string): Promise<Nostr.Event[]> {
 		return this.db.events.where({ kind, pubkey }).reverse().sortBy('created_at');
+	}
+}
+
+export class FolloweeReplaceableEventCache {
+	constructor(private readonly db: CacheDB) {}
+
+	async put(event: Nostr.Event): Promise<void> {
+		await this.db.transaction('rw', [this.db.followeeReplaceableEvents], async () => {
+			const current = await this.db.followeeReplaceableEvents.get([event.kind, event.pubkey]);
+			if (current === undefined || current.created_at < event.created_at) {
+				await this.db.followeeReplaceableEvents.put(event);
+			}
+		});
+	}
+
+	async getLatest(kind: number, pubkeys: string[]): Promise<Map<string, Nostr.Event>> {
+		const events = await this.db.followeeReplaceableEvents.bulkGet(
+			pubkeys.map((pubkey): [number, string] => [kind, pubkey])
+		);
+		const eventsMap = new Map<string, Nostr.Event>();
+		for (const event of events) {
+			if (event !== undefined) {
+				eventsMap.set(event.pubkey, event);
+			}
+		}
+		return eventsMap;
 	}
 }

--- a/web/src/lib/stores/Author.ts
+++ b/web/src/lib/stores/Author.ts
@@ -28,6 +28,9 @@ export const writeRelays: Writable<string[]> = writable(
 );
 export const rom = writable(false);
 
+export let followeesSet = new Set<string>();
+followees.subscribe(($followees) => (followeesSet = new Set($followees)));
+
 let mutePubkeysSetRef: string[] | undefined;
 let mutePubkeysSet = new Set<string>();
 const getMutePubkeysSet = (): Set<string> => {


### PR DESCRIPTION
Followees' replaceable events (profiles, contact lists and relay lists) were only kept in memory and refetched from relays on every reload. This persists them in a dedicated IndexedDB table so that, on login, cached metadata is loaded immediately and followees' names and icons render before any relay round-trip, cutting startup latency and relay load.

Only received events are stored (no extra bulk REQ) and the table keeps only the latest event per author and kind. Freshness is delegated to the existing timeline subscriptions instead of an extra metadata REQ on login, and relay lists are seeded from the cache and refreshed on each fetch.