### PR TITLE
Store the author's own metadata so the note editor shows their avatar

### DIFF
--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -21,7 +21,7 @@ import { WebStorage } from './WebStorage';
 import { Preferences, preferencesStore } from './Preferences';
 import { rxNostr, tie } from './timelines/MainTimeline';
 import { Signer } from './Signer';
-import { authorChannelsEventStore } from './cache/Events';
+import { authorChannelsEventStore, storeMetadata } from './cache/Events';
 import { updateFolloweesStore } from './Contacts';
 import {
 	authorReplaceableKinds,
@@ -95,6 +95,7 @@ export class Author {
 		const $metadataEvent = replaceableEvents.get(Kind.Metadata);
 		if ($metadataEvent !== undefined) {
 			metadataEvent.set($metadataEvent);
+			storeMetadata($metadataEvent);
 			try {
 				authorProfile.set(JSON.parse($metadataEvent.content));
 			} catch (error) {

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -19,6 +19,8 @@
 
 	let { children }: Props = $props();
 
+	let mounted = $state(false);
+
 	const konamiCode = [
 		'ArrowUp',
 		'ArrowUp',
@@ -114,6 +116,7 @@
 	}
 
 	onMount(() => {
+		mounted = true;
 		subscribeSystemTheme();
 		fetchLastNotification();
 		homeTimeline.subscribe();
@@ -151,7 +154,9 @@
 <Notice />
 
 <div class="app">
-	<NoteDialog />
+	{#if mounted}
+		<NoteDialog />
+	{/if}
 
 	<header>
 		<div>

--- a/web/src/routes/(app)/post/+page.ts
+++ b/web/src/routes/(app)/post/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
The note editor avatar uses ProfileIcon, which reads metadataStore and otherwise falls back to robohash. fetchEvents only populated authorProfile, leaving the user's own metadata out of metadataStore, so the composer showed robohash. Store the fetched kind 0 into metadataStore on login.