### PR TITLE
Fix composer avatar hydration and harden persisted-store init and login routing

### DIFF
--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -11,6 +11,7 @@ import { now } from 'rx-nostr';
 import type { User } from '../routes/types';
 import { remoteSigner } from './RemoteSigner';
 import { setLoginStatus, clearLoginStatus } from './stores/LoginStatus';
+import { loginResolved } from './login-state';
 
 export class Login {
 	public async saveBasicInfo(name: string): Promise<void> {
@@ -164,5 +165,49 @@ export class Login {
 		clearLoginStatus();
 
 		remoteSigner.subscribeIfEnabled();
+	}
+}
+
+export async function tryLogin(): Promise<boolean> {
+	try {
+		const storage = new WebStorage(localStorage);
+		const savedLogin = storage.get('login');
+
+		if (savedLogin === null) {
+			return false;
+		}
+
+		setLoginStatus('checking');
+
+		const login = new Login();
+		if (savedLogin === 'NIP-07') {
+			setLoginStatus('waiting_extension');
+			const { waitNostr } = await import('nip07-awaiter');
+			const nostr = await waitNostr(10000);
+			console.debug('[NIP-07]', nostr);
+			if (nostr === undefined) {
+				console.error('Browser Extension was not found');
+				setLoginStatus('extension_not_found', 'error');
+				return false;
+			}
+			await login.withNip07();
+		} else if (savedLogin.startsWith('bunker://')) {
+			const success = await login.withNip46(savedLogin);
+			if (!success) {
+				return false;
+			}
+		} else if (savedLogin.startsWith('nsec')) {
+			await login.withNsec(savedLogin);
+		} else if (savedLogin.startsWith('npub')) {
+			await login.withNpub(savedLogin);
+		} else {
+			console.error('[login logic error]');
+			setLoginStatus('failed', 'error');
+			return false;
+		}
+
+		return true;
+	} finally {
+		loginResolved.set(true);
 	}
 }

--- a/web/src/lib/RemoteSigner.ts
+++ b/web/src/lib/RemoteSigner.ts
@@ -4,7 +4,7 @@ import { createRxForwardReq, createRxNostr, now, type RxNostr } from 'rx-nostr';
 import { get } from 'svelte/store';
 import { pubkey } from './stores/Author';
 import type { Subscription } from 'rxjs';
-import { persistedStore } from './WebStorage';
+import { persistedStore } from './persisted-store';
 import type { Persisted } from 'svelte-persisted-store';
 import { Signer } from './Signer';
 import { verificationClient } from './timelines/MainTimeline';

--- a/web/src/lib/SeenOnRelayIcon.ts
+++ b/web/src/lib/SeenOnRelayIcon.ts
@@ -1,3 +1,3 @@
-import { persistedStore } from '$lib/WebStorage';
+import { persistedStore } from '$lib/persisted-store';
 
 export const seenOnRelayIcon = persistedStore<boolean>('preference:seen-on-relay-icon', false);

--- a/web/src/lib/ShowVia.ts
+++ b/web/src/lib/ShowVia.ts
@@ -1,3 +1,3 @@
-import { persistedStore } from '$lib/WebStorage';
+import { persistedStore } from '$lib/persisted-store';
 
 export const showVia = persistedStore<boolean>('preference:show-via', false);

--- a/web/src/lib/WebStorage.ts
+++ b/web/src/lib/WebStorage.ts
@@ -2,17 +2,7 @@ import type { Event } from 'nostr-tools';
 import { get } from 'svelte/store';
 import { findIdentifier } from './EventHelper';
 import { pubkey } from './stores/Author';
-import { appName } from './Constants';
-import { persisted, type Options, type Persisted } from 'svelte-persisted-store';
 import { eventCache } from './cache/Events';
-
-export function persistedStore<StoreType, SerializerType = StoreType>(
-	key: string,
-	initialValue: StoreType,
-	options?: Options<StoreType, SerializerType>
-): Persisted<StoreType> {
-	return persisted(`${appName}:${key}`, initialValue, options);
-}
 
 export class WebStorage {
 	public constructor(private readonly storage: Storage) {}

--- a/web/src/lib/author/Via.ts
+++ b/web/src/lib/author/Via.ts
@@ -1,5 +1,5 @@
 import { appName } from '$lib/Constants';
-import { persistedStore } from '$lib/WebStorage';
+import { persistedStore } from '$lib/persisted-store';
 import { Handlerinformation } from 'nostr-tools/kinds';
 
 export const ViaOption = ['none', 'once', 'always'] as const;

--- a/web/src/lib/components/ZapDialog.svelte
+++ b/web/src/lib/components/ZapDialog.svelte
@@ -3,7 +3,8 @@
 	import QRCode from 'qrcode';
 	import { writeRelays } from '$lib/stores/Author';
 	import { createEventDispatcher } from 'svelte';
-	import { persistedStore, WebStorage } from '$lib/WebStorage';
+	import { persistedStore } from '$lib/persisted-store';
+	import { WebStorage } from '$lib/WebStorage';
 	import { Signer } from '$lib/Signer';
 	import { zapWithWalletConnect } from '$lib/Zap';
 	import { metadataStore } from '$lib/cache/Events';

--- a/web/src/lib/login-state.ts
+++ b/web/src/lib/login-state.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const loginResolved = writable(false);

--- a/web/src/lib/persisted-store.ts
+++ b/web/src/lib/persisted-store.ts
@@ -1,0 +1,10 @@
+import { persisted, type Options, type Persisted } from 'svelte-persisted-store';
+import { appName } from './Constants';
+
+export function persistedStore<StoreType, SerializerType = StoreType>(
+	key: string,
+	initialValue: StoreType,
+	options?: Options<StoreType, SerializerType>
+): Persisted<StoreType> {
+	return persisted(`${appName}:${key}`, initialValue, options);
+}

--- a/web/src/lib/preferences/NotificationVisibility.svelte.ts
+++ b/web/src/lib/preferences/NotificationVisibility.svelte.ts
@@ -1,6 +1,6 @@
 import { followeesOfFollowees } from '$lib/author/MuteAutomatically';
 import { followees } from '$lib/stores/Author';
-import { persistedStore } from '$lib/WebStorage';
+import { persistedStore } from '$lib/persisted-store';
 import { get } from 'svelte/store';
 
 export const notificationVisibilities = ['all', 'follows_of_follows', 'follows'] as const;

--- a/web/src/lib/preferences/UserStatus.ts
+++ b/web/src/lib/preferences/UserStatus.ts
@@ -1,3 +1,3 @@
-import { persistedStore } from '$lib/WebStorage';
+import { persistedStore } from '$lib/persisted-store';
 
 export const showUserStatus = persistedStore('preference:user-status', true);

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -11,15 +11,13 @@
 	import Gdpr from '$lib/components/Gdpr.svelte';
 	import '$lib/styles/menu.css';
 	import { fetchMinutes } from '$lib/Helper';
-	import { followees } from '$lib/stores/Author';
+	import { author, followees } from '$lib/stores/Author';
 	import { composerFocus } from './channels/[nevent=note]/ComposerFocus.svelte';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
 
 	let { children }: Props = $props();
-
-	let mounted = $state(false);
 
 	const konamiCode = [
 		'ArrowUp',
@@ -116,8 +114,15 @@
 	}
 
 	onMount(() => {
-		mounted = true;
 		subscribeSystemTheme();
+	});
+
+	let initialized = false;
+	$effect(() => {
+		if ($author === undefined || initialized) {
+			return;
+		}
+		initialized = true;
 		fetchLastNotification();
 		homeTimeline.subscribe();
 	});
@@ -154,9 +159,7 @@
 <Notice />
 
 <div class="app">
-	{#if mounted}
-		<NoteDialog />
-	{/if}
+	<NoteDialog />
 
 	<header>
 		<div>

--- a/web/src/routes/(app)/home/+page.svelte
+++ b/web/src/routes/(app)/home/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { loginResolved } from '$lib/login-state';
 	import { goto } from '$app/navigation';
 	import { followees, author } from '$lib/stores/Author';
 	import { timeline } from '$lib/timelines/HomeTimeline';
@@ -19,9 +19,15 @@
 		states: { open }
 	} = createCollapsible();
 
-	onMount(async () => {
+	let initialized = false;
+	$effect(() => {
+		if (!$loginResolved || initialized) {
+			return;
+		}
+		initialized = true;
 		if ($followees.length === 0) {
-			await goto('/public');
+			goto('/public');
+			return;
 		}
 
 		applyTimelieFilter();

--- a/web/src/routes/(app)/post/+page.ts
+++ b/web/src/routes/(app)/post/+page.ts
@@ -1,1 +1,0 @@
-export const ssr = false;

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -14,7 +14,7 @@
 	import { ChannelMessage, LongFormArticle, Poll, ShortTextNote } from 'nostr-tools/kinds';
 	import { writable } from 'svelte/store';
 	import { _ } from 'svelte-i18n';
-	import { persistedStore } from '$lib/WebStorage';
+	import { persistedStore } from '$lib/persisted-store';
 	import { pushSearchHistory, rankSearchHistory } from '$lib/SearchHistory';
 	import { IconX, IconTrash } from '@tabler/icons-svelte-runes';
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,11 +4,17 @@
 	import '../app.css';
 	import Toaster from '$lib/components/Toaster.svelte';
 	import LoginStatus from '$lib/components/LoginStatus.svelte';
+	import { onMount } from 'svelte';
+	import { tryLogin } from '$lib/Login';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
 
 	let { children }: Props = $props();
+
+	onMount(() => {
+		void tryLogin();
+	});
 </script>
 
 <svelte:head>

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -1,17 +1,13 @@
 import { get } from 'svelte/store';
 import { _, locale, waitLocale } from 'svelte-i18n';
 import { browser } from '$app/environment';
-import { Login } from '$lib/Login';
-import { WebStorage } from '$lib/WebStorage';
 import { initialize } from '$lib/i18n';
 import { rxNostr } from '$lib/timelines/MainTimeline';
 import { appName, defaultRelays, localizedRelays } from '$lib/Constants';
 import type { LayoutLoad } from './$types';
 import { readRelays, writeRelays } from '$lib/stores/Author';
-import { setLoginStatus } from '$lib/stores/LoginStatus';
 
 export const load: LayoutLoad = async ({ url }) => {
-	let authenticated = false;
 	await initialize();
 	if (browser) {
 		rxNostr.setDefaultRelays(defaultRelays);
@@ -29,55 +25,12 @@ export const load: LayoutLoad = async ({ url }) => {
 			);
 		}
 		console.debug('[default relays]', rxNostr.getDefaultRelays());
-		authenticated = await tryLogin();
 	}
 	await waitLocale();
 	const $_ = get(_);
 	return {
-		splash: !browser || authenticated,
-		authenticated,
 		title: appName,
 		description: $_('app.description'),
 		image: `${url.origin}/logo.png`
 	};
 };
-
-async function tryLogin(): Promise<boolean> {
-	const storage = new WebStorage(localStorage);
-	const savedLogin = storage.get('login');
-
-	if (savedLogin === null) {
-		return false;
-	}
-
-	setLoginStatus('checking');
-
-	const login = new Login();
-	if (savedLogin === 'NIP-07') {
-		setLoginStatus('waiting_extension');
-		const { waitNostr } = await import('nip07-awaiter');
-		const nostr = await waitNostr(10000);
-		console.debug('[NIP-07]', nostr);
-		if (nostr === undefined) {
-			console.error('Browser Extension was not found');
-			setLoginStatus('extension_not_found', 'error');
-			return false;
-		}
-		await login.withNip07();
-	} else if (savedLogin.startsWith('bunker://')) {
-		const success = await login.withNip46(savedLogin);
-		if (!success) {
-			return false;
-		}
-	} else if (savedLogin.startsWith('nsec')) {
-		await login.withNsec(savedLogin);
-	} else if (savedLogin.startsWith('npub')) {
-		await login.withNpub(savedLogin);
-	} else {
-		console.error('[login logic error]');
-		setLoginStatus('failed', 'error');
-		return false;
-	}
-
-	return true;
-}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,25 +1,17 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
 	import { goto } from '$app/navigation';
-	import type { LayoutData } from './$types';
-	import { followees, pubkey } from '$lib/stores/Author';
+	import { followees, pubkey, author } from '$lib/stores/Author';
+	import { loginResolved } from '$lib/login-state';
 	import Notice from '$lib/components/Notice.svelte';
 	import SplashScreen from './SplashScreen.svelte';
 	import Login from './(app)/Login.svelte';
-
-	interface Props {
-		data: LayoutData;
-	}
-
-	let { data }: Props = $props();
 
 	let homeLink = $derived(
 		$followees.filter((x) => x !== $pubkey).length > 0 ? '/home' : '/public'
 	);
 
-	run(() => {
-		if (data.authenticated) {
+	$effect(() => {
+		if ($author !== undefined) {
 			goto(homeLink);
 		}
 	});
@@ -27,7 +19,7 @@
 
 <Notice />
 
-{#if data.splash}
+{#if !$loginResolved || $pubkey}
 	<SplashScreen />
 {:else}
 	<Login />


### PR DESCRIPTION
Root cause solution for #2232

Defer login restoration to onMount so the first client render matches the
logged-out SSR output, fixing the note composer avatar that stayed on the
robohash placeholder. Drive the landing page off the auth stores, gate the
(app) layout's home initialization on the author store, and drop the /post
ssr=false and NoteDialog mount-guard workarounds.

Extract persistedStore into its own dependency-light module (persisted-store.ts)
so calling it during a module's initialization no longer re-enters a
half-initialized WebStorage and crashes SSR with a circular-import "cannot
access before initialization" error.

Wait for login to resolve before the landing and home pages redirect, so a
logged-in user with followees lands on /home instead of the public timeline.

Use kebab-case file names for the new modules (login-state.ts, persisted-store.ts).