### PR TITLE
Unify auth state into a single authStatus signal and consolidate post-login navigation

### DIFF
--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -11,7 +11,7 @@ import { now } from 'rx-nostr';
 import type { User } from '../routes/types';
 import { remoteSigner } from './RemoteSigner';
 import { setLoginStatus, clearLoginStatus } from './stores/LoginStatus';
-import { loginResolved } from './login-state';
+import { authStatus } from './auth-status';
 
 export class Login {
 	public async saveBasicInfo(name: string): Promise<void> {
@@ -162,6 +162,7 @@ export class Login {
 		await loadFolloweesMetadataCache(get(followees));
 
 		author.set($author);
+		authStatus.set('authenticated');
 		clearLoginStatus();
 
 		remoteSigner.subscribeIfEnabled();
@@ -177,6 +178,7 @@ export async function tryLogin(): Promise<boolean> {
 			return false;
 		}
 
+		authStatus.set('restoring');
 		setLoginStatus('checking');
 
 		const login = new Login();
@@ -208,6 +210,8 @@ export async function tryLogin(): Promise<boolean> {
 
 		return true;
 	} finally {
-		loginResolved.set(true);
+		if (get(authStatus) !== 'authenticated') {
+			authStatus.set('anonymous');
+		}
 	}
 }

--- a/web/src/lib/auth-status.ts
+++ b/web/src/lib/auth-status.ts
@@ -1,0 +1,9 @@
+import { derived, writable } from 'svelte/store';
+
+export type AuthStatus = 'idle' | 'restoring' | 'authenticating' | 'authenticated' | 'anonymous';
+
+export const authStatus = writable<AuthStatus>('idle');
+
+export const isInitializing = derived(authStatus, ($s) => $s === 'idle' || $s === 'restoring');
+export const isReady = derived(authStatus, ($s) => $s === 'authenticated' || $s === 'anonymous');
+export const isAuthenticated = derived(authStatus, ($s) => $s === 'authenticated');

--- a/web/src/lib/login-state.ts
+++ b/web/src/lib/login-state.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const loginResolved = writable(false);

--- a/web/src/lib/post-login-navigation.ts
+++ b/web/src/lib/post-login-navigation.ts
@@ -1,0 +1,11 @@
+import { get } from 'svelte/store';
+import { goto } from '$app/navigation';
+import { originalFollowees } from '$lib/stores/Author';
+
+export function resolveLandingPath(): '/home' | '/public' {
+	return get(originalFollowees).length > 0 ? '/home' : '/public';
+}
+
+export async function gotoAfterLogin(): Promise<void> {
+	await goto(resolveLandingPath());
+}

--- a/web/src/routes/(app)/Login.svelte
+++ b/web/src/routes/(app)/Login.svelte
@@ -7,7 +7,9 @@
 	import { loginType } from '$lib/stores/Author';
 	import { page } from '$app/state';
 	import { afterNavigate, goto } from '$app/navigation';
-	import { authorProfile } from '$lib/stores/Author';
+	import { get } from 'svelte/store';
+	import { authStatus } from '$lib/auth-status';
+	import { gotoAfterLogin } from '$lib/post-login-navigation';
 	import { WebStorage } from '$lib/WebStorage';
 	import { setLoginStatus } from '$lib/stores/LoginStatus';
 	import ModalDialog from '$lib/components/ModalDialog.svelte';
@@ -29,6 +31,7 @@
 	function resetLoginProgress() {
 		loggingInWith = undefined;
 		loginType.set(undefined);
+		authStatus.set('anonymous');
 	}
 
 	async function loginWithNip07() {
@@ -42,6 +45,7 @@
 		storage.set('login', 'NIP-07');
 
 		try {
+			authStatus.set('authenticating');
 			await login.withNip07();
 			if (!(await gotoHome())) {
 				resetLoginProgress();
@@ -62,6 +66,7 @@
 		loggingInWith = 'nip46';
 		failedToLogin = false;
 		try {
+			authStatus.set('authenticating');
 			const success = await login.withNip46(bunker);
 			if (!success) {
 				failedToLogin = true;
@@ -88,6 +93,7 @@
 		loggingInWith = 'key';
 		failedToLogin = false;
 		try {
+			authStatus.set('authenticating');
 			if (key.startsWith('nsec')) {
 				await login.withNsec(key);
 			} else {
@@ -122,6 +128,7 @@
 
 		registering = true;
 		try {
+			authStatus.set('authenticating');
 			await login.withNsec(key);
 			await login.saveBasicInfo(name);
 			await goto('/public');
@@ -130,6 +137,7 @@
 			setLoginStatus('failed', 'error');
 			registering = false;
 			loginType.set(undefined);
+			authStatus.set('anonymous');
 		}
 	}
 
@@ -143,13 +151,13 @@
 	});
 
 	async function gotoHome(): Promise<boolean> {
-		if ($authorProfile === undefined) {
+		if (get(authStatus) !== 'authenticated') {
 			console.error('[login failed]');
 			setLoginStatus('failed', 'error');
 			return false;
 		}
 
-		await goto('/home');
+		await gotoAfterLogin();
 		return true;
 	}
 

--- a/web/src/routes/(app)/home/+page.svelte
+++ b/web/src/routes/(app)/home/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { loginResolved } from '$lib/login-state';
+	import { isReady } from '$lib/auth-status';
+	import { resolveLandingPath } from '$lib/post-login-navigation';
 	import { goto } from '$app/navigation';
-	import { followees, author } from '$lib/stores/Author';
+	import { author } from '$lib/stores/Author';
 	import { timeline } from '$lib/timelines/HomeTimeline';
 	import { applyTimelieFilter } from '$lib/TimelineFilter';
 	import { _ } from 'svelte-i18n';
@@ -21,11 +22,11 @@
 
 	let initialized = false;
 	$effect(() => {
-		if (!$loginResolved || initialized) {
+		if (!$isReady || initialized) {
 			return;
 		}
 		initialized = true;
-		if ($followees.length === 0) {
+		if (resolveLandingPath() === '/public') {
 			goto('/public');
 			return;
 		}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,25 +1,20 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { followees, pubkey, author } from '$lib/stores/Author';
-	import { loginResolved } from '$lib/login-state';
+	import { isAuthenticated, isInitializing } from '$lib/auth-status';
+	import { gotoAfterLogin } from '$lib/post-login-navigation';
 	import Notice from '$lib/components/Notice.svelte';
 	import SplashScreen from './SplashScreen.svelte';
 	import Login from './(app)/Login.svelte';
 
-	let homeLink = $derived(
-		$followees.filter((x) => x !== $pubkey).length > 0 ? '/home' : '/public'
-	);
-
 	$effect(() => {
-		if ($author !== undefined) {
-			goto(homeLink);
+		if ($isAuthenticated) {
+			gotoAfterLogin();
 		}
 	});
 </script>
 
 <Notice />
 
-{#if !$loginResolved || $pubkey}
+{#if $isInitializing || $isAuthenticated}
 	<SplashScreen />
 {:else}
 	<Login />


### PR DESCRIPTION
Replace the binary loginResolved flag with an authStatus state machine (idle, restoring, authenticating, authenticated, anonymous) plus derived isReady, isAuthenticated and isInitializing signals. fetchAuthor flips authStatus to authenticated as the single confirmation point after the author store is set, so consumers gate on one signal and never observe the intermediate "pubkey set but author missing" state.

Move the duplicated post-login redirect logic into post-login-navigation (resolveLandingPath and gotoAfterLogin). The landing page and /home now both decide between /home and /public from originalFollowees, fixing the inconsistency where /home checked followees including self.

Remove the now-unused login-state module.