### PR TITLE
Guard notifications and profile redirects on auth being ready

### DIFF
--- a/web/src/routes/(app)/notifications/+page.svelte
+++ b/web/src/routes/(app)/notifications/+page.svelte
@@ -3,13 +3,14 @@
 	import { createRxOneshotReq, now, uniq } from 'rx-nostr';
 	import { tap } from 'rxjs';
 	import { _ } from 'svelte-i18n';
-	import { afterNavigate, beforeNavigate, goto } from '$app/navigation';
+	import { beforeNavigate, goto } from '$app/navigation';
 	import { authorActionReqEmit } from '$lib/author/Action';
 	import { referencesReqEmit, rxNostr, storeSeenOn, tie } from '$lib/timelines/MainTimeline';
 	import { appName, minTimelineLength, notificationsFilterKinds } from '$lib/Constants';
 	import { EventItem } from '$lib/Items';
 	import { lastReadAt, notifiedEventItems } from '$lib/author/Notifications';
 	import { pubkey, author } from '$lib/stores/Author';
+	import { isReady } from '$lib/auth.svelte';
 	import TimelineView from '../TimelineView.svelte';
 	import IconAt from '@tabler/icons-svelte-runes/icons/at';
 	import IconRepeat from '@tabler/icons-svelte-runes/icons/repeat';
@@ -42,11 +43,9 @@
 		$notifiedEventItems.filter((item) => isVisibleNotification(item.event.pubkey))
 	);
 
-	afterNavigate(async () => {
-		console.debug('[notifications page]');
-
-		if ($author === undefined) {
-			await goto('/');
+	$effect(() => {
+		if ($isReady && $author === undefined) {
+			goto('/');
 		}
 	});
 

--- a/web/src/routes/(app)/profile/+page.svelte
+++ b/web/src/routes/(app)/profile/+page.svelte
@@ -12,7 +12,7 @@
 	import { sendEvent } from '$lib/RxNostrHelper';
 	import { storeMetadata } from '$lib/cache/Events';
 	import { WebStorage } from '$lib/WebStorage';
-	import { onMount } from 'svelte';
+	import { isReady } from '$lib/auth.svelte';
 
 	//#region Cropper
 
@@ -23,9 +23,9 @@
 	let pixels: Pixels | undefined;
 	let complete: (value: File | PromiseLike<File | undefined> | undefined) => void;
 
-	onMount(async () => {
-		if (!$pubkey) {
-			await goto('/');
+	$effect(() => {
+		if ($isReady && !$pubkey) {
+			goto('/');
 		}
 	});
 


### PR DESCRIPTION
On reload the auth restore (tryLogin) runs asynchronously, so the notifications page (afterNavigate, $author === undefined) and the profile page (onMount, !$pubkey) treated the user as logged out and redirected to /, which then forwards to /home. Both now check $isReady in an $effect and only redirect once auth has settled, matching the home page pattern, so a reload stays on the current page.