### PR TITLE
Fix home timeline stuck loading with follows-of-follows visibility

### DIFF
--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -13,6 +13,7 @@ import {
 	storeMutedTagsByEvent
 } from './stores/Author';
 import { RelayList } from './author/RelayList';
+import { auth } from './auth.svelte';
 import { filterTags, findIdentifier, parseRelayJson } from './EventHelper';
 import { customEmojiListEvent, storeCustomEmojis } from './author/CustomEmojis';
 import type { User } from '../routes/types';
@@ -85,7 +86,7 @@ export class Author {
 		return contactsEvent?.tags ?? [];
 	}
 
-	public async fetchEvents(): Promise<string[][]> {
+	public async fetchEvents(): Promise<void> {
 		const { replaceableEvents, parameterizedReplaceableEvents } =
 			await this.fetchAuthorEventsWithCache(this.pubkey);
 
@@ -104,6 +105,7 @@ export class Author {
 		console.log('[profile]', get(authorProfile));
 
 		const contactsTags = this.storeRelays(replaceableEvents);
+		auth.updateFollowees(contactsTags);
 
 		customEmojiListEvent.set(replaceableEvents.get(Kind.UserEmojiList));
 		const $customEmojiListEvent = get(customEmojiListEvent);
@@ -167,8 +169,6 @@ export class Author {
 		}
 
 		console.log('[relays]', get(readRelays), get(writeRelays));
-
-		return contactsTags;
 	}
 
 	private async fetchAuthorEventsWithCache(pubkey: string): Promise<{

--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -155,10 +155,9 @@ export class Login {
 		await $author.fetchRelays();
 		console.timeLog('fetch author');
 
-		const contactsTags = await $author.fetchEvents();
+		await $author.fetchEvents();
 		console.timeEnd('fetch author');
 
-		auth.updateFollowees(contactsTags);
 		await loadFolloweesMetadataCache(auth.followees);
 		pruneFolloweeReplaceableEventsCache(auth.followees);
 

--- a/web/src/lib/author/MuteAutomatically.ts
+++ b/web/src/lib/author/MuteAutomatically.ts
@@ -5,7 +5,7 @@ import type * as Nostr from 'nostr-typedef';
 import { chunk } from '$lib/Array';
 import { filterLimit, maxFilters } from '$lib/Constants';
 import { rxNostr, tie } from '$lib/timelines/MainTimeline';
-import { followees } from '$lib/stores/Author';
+import { auth } from '$lib/auth.svelte';
 import { cacheFolloweeReplaceableEvent, followeeEventCache } from '$lib/cache/Events';
 
 export const followeesOfFollowees = writable<Set<string>>(new Set());
@@ -16,7 +16,7 @@ contactsOfFollowees.subscribe((events) => {
 		return;
 	}
 
-	const $followees = get(followees);
+	const $followees = auth.followees;
 	const pubkeys = [...events]
 		.flatMap(([, event]) =>
 			event.tags.filter(([t, pubkey]) => t === 'p' && typeof pubkey === 'string')
@@ -35,7 +35,7 @@ export function contactsOfFolloweesReqEmit(): void {
 
 	loaded = true;
 
-	const $followees = get(followees);
+	const $followees = auth.followees;
 	followeesOfFollowees.set(new Set($followees)); // For UX
 
 	followeeEventCache.getLatest(Kind.Contacts, $followees).then((cached) => {


### PR DESCRIPTION
contactsOfFolloweesReqEmit() runs inside Author.fetchEvents() and reads the followees at call time, but the auth refactor moved the followees commit to after fetchEvents() returned. With empty followees it never populated followeesOfFollowees, so isVisibleNotification() filtered out every event and the home timeline stayed on the loading spinner.

Commit the followees inside fetchEvents(), right after storeRelays(), so the dependent contacts-of-followees fetch sees them.