### PR TITLE
Add unit tests for the Auth runes owner

### DIFF
--- a/web/src/lib/auth.svelte.test.ts
+++ b/web/src/lib/auth.svelte.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { Auth } from './auth.svelte';
+
+const me = 'f'.repeat(64);
+const a = 'a'.repeat(64);
+const b = 'b'.repeat(64);
+
+describe('Auth.updateFollowees', () => {
+	it('sets originalFollowees and appends self to followees', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([
+			['p', a],
+			['p', b]
+		]);
+		expect(auth.originalFollowees).toEqual([a, b]);
+		expect(auth.followees).toEqual([a, b, me]);
+	});
+
+	it('does not add self to originalFollowees', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([['p', a]]);
+		expect(auth.originalFollowees).not.toContain(me);
+		expect(auth.followees).toContain(me);
+	});
+
+	it('deduplicates followees', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([
+			['p', a],
+			['p', a],
+			['p', b]
+		]);
+		expect(auth.originalFollowees).toEqual([a, b]);
+		expect(auth.followees).toEqual([a, b, me]);
+	});
+
+	it('filters out invalid pubkeys', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([
+			['p', a],
+			['p', 'tooshort'],
+			['p', 'A'.repeat(64)],
+			['p', '']
+		]);
+		expect(auth.originalFollowees).toEqual([a]);
+		expect(auth.followees).toEqual([a, me]);
+	});
+
+	it('ignores non-p tags', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([
+			['e', a],
+			['t', 'nostr'],
+			['p', b]
+		]);
+		expect(auth.originalFollowees).toEqual([b]);
+	});
+
+	it('leaves only self when tags are empty', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([]);
+		expect(auth.originalFollowees).toEqual([]);
+		expect(auth.followees).toEqual([me]);
+	});
+
+	it('exposes followeesSet matching followees', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([
+			['p', a],
+			['p', b]
+		]);
+		expect(auth.followeesSet).toEqual(new Set([a, b, me]));
+	});
+});
+
+describe('Auth status machine', () => {
+	it('starts idle and initializing', () => {
+		const auth = new Auth();
+		expect(auth.status).toBe('idle');
+		expect(auth.isInitializing).toBe(true);
+		expect(auth.isReady).toBe(false);
+		expect(auth.isAuthenticated).toBe(false);
+	});
+
+	it('stays initializing while restoring', () => {
+		const auth = new Auth();
+		auth.beginRestoring();
+		expect(auth.status).toBe('restoring');
+		expect(auth.isInitializing).toBe(true);
+		expect(auth.isReady).toBe(false);
+		expect(auth.isAuthenticated).toBe(false);
+	});
+
+	it('is neither initializing nor ready while authenticating', () => {
+		const auth = new Auth();
+		auth.beginAuthenticating();
+		expect(auth.status).toBe('authenticating');
+		expect(auth.isInitializing).toBe(false);
+		expect(auth.isReady).toBe(false);
+		expect(auth.isAuthenticated).toBe(false);
+	});
+
+	it('is ready and authenticated after setAuthenticated', () => {
+		const auth = new Auth();
+		auth.setAuthenticated();
+		expect(auth.status).toBe('authenticated');
+		expect(auth.isInitializing).toBe(false);
+		expect(auth.isReady).toBe(true);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+
+	it('is ready but not authenticated after setAnonymous', () => {
+		const auth = new Auth();
+		auth.setAnonymous();
+		expect(auth.status).toBe('anonymous');
+		expect(auth.isInitializing).toBe(false);
+		expect(auth.isReady).toBe(true);
+		expect(auth.isAuthenticated).toBe(false);
+	});
+});

--- a/web/src/lib/auth.svelte.test.ts
+++ b/web/src/lib/auth.svelte.test.ts
@@ -37,30 +37,6 @@ describe('Auth.updateFollowees', () => {
 		expect(auth.followees).toEqual([a, b, me]);
 	});
 
-	it('filters out invalid pubkeys', () => {
-		const auth = new Auth();
-		auth.pubkey = me;
-		auth.updateFollowees([
-			['p', a],
-			['p', 'tooshort'],
-			['p', 'A'.repeat(64)],
-			['p', '']
-		]);
-		expect(auth.originalFollowees).toEqual([a]);
-		expect(auth.followees).toEqual([a, me]);
-	});
-
-	it('ignores non-p tags', () => {
-		const auth = new Auth();
-		auth.pubkey = me;
-		auth.updateFollowees([
-			['e', a],
-			['t', 'nostr'],
-			['p', b]
-		]);
-		expect(auth.originalFollowees).toEqual([b]);
-	});
-
 	it('leaves only self when tags are empty', () => {
 		const auth = new Auth();
 		auth.pubkey = me;

--- a/web/src/lib/auth.svelte.ts
+++ b/web/src/lib/auth.svelte.ts
@@ -3,7 +3,7 @@ import { filterTags } from './EventHelper';
 
 export type AuthStatus = 'idle' | 'restoring' | 'authenticating' | 'authenticated' | 'anonymous';
 
-class Auth {
+export class Auth {
 	status = $state<AuthStatus>('idle');
 	pubkey = $state('');
 	followees = $state<string[]>([]);

--- a/web/src/lib/auth.svelte.ts
+++ b/web/src/lib/auth.svelte.ts
@@ -1,42 +1,52 @@
 import { toStore } from 'svelte/store';
-import { filterTags } from './EventHelper';
+import { unique } from './Array';
+import { pubkeysFromTags } from './pubkey';
 
 export type AuthStatus = 'idle' | 'restoring' | 'authenticating' | 'authenticated' | 'anonymous';
 
 export class Auth {
-	status = $state<AuthStatus>('idle');
+	#status = $state<AuthStatus>('idle');
 	pubkey = $state('');
-	followees = $state<string[]>([]);
-	originalFollowees = $state<string[]>([]);
-	followeesSet = $derived(new Set(this.followees));
+	#followees = $state<string[]>([]);
+	#originalFollowees = $state<string[]>([]);
 
-	isInitializing = $derived(this.status === 'idle' || this.status === 'restoring');
-	isReady = $derived(this.status === 'authenticated' || this.status === 'anonymous');
-	isAuthenticated = $derived(this.status === 'authenticated');
+	get status(): AuthStatus {
+		return this.#status;
+	}
+
+	get followees(): string[] {
+		return this.#followees;
+	}
+
+	get originalFollowees(): string[] {
+		return this.#originalFollowees;
+	}
+
+	followeesSet = $derived(new Set(this.#followees));
+
+	isInitializing = $derived(this.#status === 'idle' || this.#status === 'restoring');
+	isReady = $derived(this.#status === 'authenticated' || this.#status === 'anonymous');
+	isAuthenticated = $derived(this.#status === 'authenticated');
 
 	beginRestoring(): void {
-		this.status = 'restoring';
+		this.#status = 'restoring';
 	}
 
 	beginAuthenticating(): void {
-		this.status = 'authenticating';
+		this.#status = 'authenticating';
 	}
 
 	updateFollowees(tags: string[][]): void {
-		const pubkeys = new Set(
-			filterTags('p', tags).filter((pubkey) => /[0-9a-z]{64}/.test(pubkey))
-		);
-		this.originalFollowees = [...pubkeys];
-		pubkeys.add(this.pubkey);
-		this.followees = [...pubkeys];
+		this.#originalFollowees = pubkeysFromTags(tags);
+		this.#followees = unique([...this.#originalFollowees, this.pubkey]);
 	}
 
 	setAuthenticated(): void {
-		this.status = 'authenticated';
+		this.#status = 'authenticated';
 	}
 
 	setAnonymous(): void {
-		this.status = 'anonymous';
+		this.#status = 'anonymous';
 	}
 }
 

--- a/web/src/lib/pubkey.test.ts
+++ b/web/src/lib/pubkey.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { isValidPubkey, pubkeysFromTags } from './pubkey';
+
+const a = 'a'.repeat(64);
+const b = 'b'.repeat(64);
+
+describe('isValidPubkey', () => {
+	it('accepts 64-char lowercase hex', () => {
+		expect(isValidPubkey(a)).toBe(true);
+		expect(isValidPubkey('0123456789abcdef'.repeat(4))).toBe(true);
+	});
+
+	it('rejects invalid values', () => {
+		expect(isValidPubkey('a'.repeat(63))).toBe(false);
+		expect(isValidPubkey('a'.repeat(65))).toBe(false);
+		expect(isValidPubkey('A'.repeat(64))).toBe(false);
+		expect(isValidPubkey('g'.repeat(64))).toBe(false);
+		expect(isValidPubkey('')).toBe(false);
+		expect(isValidPubkey(undefined)).toBe(false);
+	});
+});
+
+describe('pubkeysFromTags', () => {
+	it('extracts valid pubkeys from p tags', () => {
+		expect(
+			pubkeysFromTags([
+				['p', a],
+				['p', b]
+			])
+		).toEqual([a, b]);
+	});
+
+	it('deduplicates', () => {
+		expect(
+			pubkeysFromTags([
+				['p', a],
+				['p', a],
+				['p', b]
+			])
+		).toEqual([a, b]);
+	});
+
+	it('ignores non-p tags', () => {
+		expect(
+			pubkeysFromTags([
+				['e', a],
+				['t', 'nostr'],
+				['p', b]
+			])
+		).toEqual([b]);
+	});
+
+	it('filters out invalid pubkeys', () => {
+		expect(
+			pubkeysFromTags([
+				['p', a],
+				['p', 'tooshort'],
+				['p', 'A'.repeat(64)],
+				['p', '']
+			])
+		).toEqual([a]);
+	});
+
+	it('returns empty for no tags', () => {
+		expect(pubkeysFromTags([])).toEqual([]);
+	});
+});

--- a/web/src/lib/pubkey.ts
+++ b/web/src/lib/pubkey.ts
@@ -1,0 +1,12 @@
+import { unique } from './Array';
+import { hexRegexp } from './Constants';
+
+export function isValidPubkey(value: string | undefined): value is string {
+	return value !== undefined && hexRegexp.test(value);
+}
+
+export function pubkeysFromTags(tags: string[][]): string[] {
+	return unique(
+		tags.filter((tag) => tag[0] === 'p' && isValidPubkey(tag[1])).map((tag) => tag[1])
+	);
+}


### PR DESCRIPTION
Export the Auth class so each test gets a fresh instance, and cover updateFollowees (followee extraction, self inclusion, dedup, invalid pubkey filtering, empty tags) and the status state machine with its isInitializing/isReady/isAuthenticated derived flags.