### PR TITLE
Replace emojito with emoemo

### DIFF
--- a/web/src/lib/components/actions/CustomEmojiMenuButton.svelte
+++ b/web/src/lib/components/actions/CustomEmojiMenuButton.svelte
@@ -48,7 +48,7 @@
 			relays: getSeenOnRelays(event.id)
 		})
 	);
-	let emojitoUrl = $derived(`https://emojito.meme/a/${naddr}`);
+	let emoemoUrl = $derived(`https://koteitan.github.io/emoemo/#/a/${naddr}`);
 
 	async function add(): Promise<void> {
 		try {
@@ -90,9 +90,9 @@
 	{/if}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div use:melt={$item} onclick={() => window.open(emojitoUrl)} class="item">
+	<div use:melt={$item} onclick={() => window.open(emoemoUrl)} class="item">
 		<div class="icon"><IconExternalLink size={20} /></div>
-		<div>{$_('actions.open_url.button').replace('%s', 'emojito')}</div>
+		<div>{$_('actions.open_url.button').replace('%s', 'emoemo')}</div>
 	</div>
 </div>
 


### PR DESCRIPTION
## Summary

[emojito](https://emojito.meme) has been returning **404 Not Found** for a long time, so the "Open in emojito" link on custom emoji sets (kind:30030) is not working now. This points it at [emoemo](https://koteitan.github.io/emoemo/) instead, a working emoji-set browser.

The "…" menu on a custom emoji set opened `https://emojito.meme/a/<naddr>` (now 404). It now opens the same NIP-19 `naddr` in emoemo at `https://koteitan.github.io/emoemo/#/a/<naddr>`.

## Changes

- Point the external emoji-set link from emojito.meme to koteitan.github.io/emoemo
- Rename the menu label from "emojito" to "emoemo"

## Notes

- The `naddr` (including its seen-on relay hints from `getSeenOnRelays`) is unchanged — only the base URL and label differ.
- Tested locally: the menu shows "Open in emoemo" and opens the corresponding pack, resolving via the naddr's relay hints.
