### PR TITLE
Add lazy loading and async decoding to images

### DIFF
--- a/web/src/lib/components/Badges.svelte
+++ b/web/src/lib/components/Badges.svelte
@@ -178,7 +178,13 @@
 					target="_blank"
 					rel="noreferrer"
 				>
-					<img src={thumb ? thumb : image} alt={name} title={name} />
+					<img
+						src={thumb ? thumb : image}
+						alt={name}
+						title={name}
+						loading="lazy"
+						decoding="async"
+					/>
 				</a>
 			</li>
 		{:else}

--- a/web/src/lib/components/ChannelTitle.svelte
+++ b/web/src/lib/components/ChannelTitle.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div>
-	<img src={channelMetadata?.picture} alt="" />
+	<img src={channelMetadata?.picture} alt="" decoding="async" />
 	<span>{channelMetadata?.name ?? ''}</span>
 </div>
 

--- a/web/src/lib/components/Nip94.svelte
+++ b/web/src/lib/components/Nip94.svelte
@@ -21,7 +21,7 @@
 
 {#if mimeType !== undefined && /image\/(gif|jpg|jpeg|png|webp|bmp)/.test(mimeType)}
 	<a href={url} target="_blank" rel="noopener noreferrer">
-		<img src={url} alt={event.content} />
+		<img src={url} alt={event.content} loading="lazy" decoding="async" />
 	</a>
 {:else}
 	<a href={url} target="_blank" rel="noopener noreferrer">{url}</a>

--- a/web/src/lib/components/RelayIcon.svelte
+++ b/web/src/lib/components/RelayIcon.svelte
@@ -33,7 +33,13 @@
 	{#if failed}
 		<span class="placeholder">{initial}</span>
 	{:else}
-		<img src={info.icon || favicon()} alt={host} onerror={onError} />
+		<img
+			src={info.icon || favicon()}
+			alt={host}
+			loading="lazy"
+			decoding="async"
+			onerror={onError}
+		/>
 	{/if}
 {/await}
 

--- a/web/src/lib/components/content/CustomEmoji.svelte
+++ b/web/src/lib/components/content/CustomEmoji.svelte
@@ -7,7 +7,7 @@
 	let { text = '', url }: Props = $props();
 </script>
 
-<img src={url} alt={text} title={text} />
+<img src={url} alt={text} title={text} decoding="async" />
 
 <style>
 	img {

--- a/web/src/lib/components/content/CustomEmojiPopup.svelte
+++ b/web/src/lib/components/content/CustomEmojiPopup.svelte
@@ -81,7 +81,7 @@
 	<div {...popover.content} class="popover">
 		<div {...popover.arrow}></div>
 
-		<img src={url} alt={text} title={text} />
+		<img src={url} alt={text} title={text} decoding="async" />
 
 		{#if $developerMode}
 			<div>{shortcode}</div>

--- a/web/src/lib/components/content/Img.svelte
+++ b/web/src/lib/components/content/Img.svelte
@@ -76,6 +76,7 @@
 		src={displaySrc}
 		alt={src}
 		loading="lazy"
+		decoding="async"
 		onload={() => {
 			loaded = true;
 			if (frozen) {

--- a/web/src/lib/components/content/LongFormContent.svelte
+++ b/web/src/lib/components/content/LongFormContent.svelte
@@ -43,7 +43,7 @@
 <article class="timeline-item">
 	<main>
 		{#if image !== undefined}
-			<img src={image} alt="" />
+			<img src={image} alt="" loading="lazy" decoding="async" />
 		{/if}
 		<div class="content">
 			<h1>{title ?? '-'}</h1>

--- a/web/src/lib/components/content/Ogp.svelte
+++ b/web/src/lib/components/content/Ogp.svelte
@@ -44,7 +44,7 @@
 			{#if data.image}
 				{@const image = resolveImage(data.image, url)}
 				{#if image?.protocol === 'https:'}
-					<img src={image.href} alt="" onerror={error} loading="lazy" />
+					<img src={image.href} alt="" onerror={error} loading="lazy" decoding="async" />
 				{:else if image?.protocol === 'http:'}
 					<!-- Don't show image due to mixed content -->
 				{/if}

--- a/web/src/lib/components/content/Thumbnail.svelte
+++ b/web/src/lib/components/content/Thumbnail.svelte
@@ -61,7 +61,13 @@
 			{#each urls as url}
 				<div class="swiper-slide">
 					<div class="swiper-zoom-container">
-						<img src={url.href} alt={url.href} class:single={urls.length === 1} />
+						<img
+							src={url.href}
+							alt={url.href}
+							class:single={urls.length === 1}
+							loading="lazy"
+							decoding="async"
+						/>
 					</div>
 				</div>
 			{/each}

--- a/web/src/lib/components/items/BadgeDefinition.svelte
+++ b/web/src/lib/components/items/BadgeDefinition.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <article>
-	<img src={url} alt="" />
+	<img src={url} alt="" loading="lazy" decoding="async" />
 	<main>
 		<h2>{name}</h2>
 		<p>{description}</p>

--- a/web/src/lib/components/items/Channel.svelte
+++ b/web/src/lib/components/items/Channel.svelte
@@ -68,7 +68,7 @@
 <article class="timeline-item">
 	<main>
 		{#if channelMetadata?.picture !== undefined}
-			<img src={channelMetadata.picture} alt="" />
+			<img src={channelMetadata.picture} alt="" loading="lazy" decoding="async" />
 		{/if}
 		<div class="channel">
 			<h1>

--- a/web/src/lib/components/items/Relay.svelte
+++ b/web/src/lib/components/items/Relay.svelte
@@ -19,6 +19,8 @@
 				src={icon || url + '/favicon.ico'}
 				alt={name ?? hostname}
 				style="width: 48px; height: 48px;"
+				loading="lazy"
+				decoding="async"
 			/>
 		</a>
 	</div>

--- a/web/src/lib/components/profile/ProfileIcon.svelte
+++ b/web/src/lib/components/profile/ProfileIcon.svelte
@@ -28,6 +28,8 @@
 	alt=""
 	title={tooltip ? name : ''}
 	style="width: {width}; height: {height};"
+	loading="lazy"
+	decoding="async"
 	onerror={onError}
 />
 

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/Profile.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/Profile.svelte
@@ -87,7 +87,7 @@
 
 <div class="banner">
 	{#if user?.banner}
-		<img src={user.banner} alt="" />
+		<img src={user.banner} alt="" decoding="async" />
 	{:else}
 		<div class="blank"></div>
 	{/if}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelHeader.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelHeader.svelte
@@ -60,7 +60,12 @@
 		<div class="identity">
 			<div class="avatar">
 				{#if metadata?.picture && !brokenImage}
-					<img src={metadata.picture} alt="" onerror={() => (brokenImage = true)} />
+					<img
+						src={metadata.picture}
+						alt=""
+						decoding="async"
+						onerror={() => (brokenImage = true)}
+					/>
 				{:else}
 					<div class="placeholder"><IconMessages size={22} /></div>
 				{/if}
@@ -156,7 +161,12 @@
 			<div class="details-head">
 				<div class="avatar">
 					{#if metadata?.picture && !brokenImage}
-						<img src={metadata.picture} alt="" onerror={() => (brokenImage = true)} />
+						<img
+							src={metadata.picture}
+							alt=""
+							decoding="async"
+							onerror={() => (brokenImage = true)}
+						/>
 					{:else}
 						<div class="placeholder"><IconMessages size={22} /></div>
 					{/if}


### PR DESCRIPTION
Add loading="lazy" and decoding="async" to images in timelines, cards, and lists (profile icons, NIP-94 attachments, badges, relay/channel cards, long-form content thumbnails, thumbnail dialog). Images that already had loading="lazy" (Img.svelte, Ogp.svelte) get decoding="async" added. Hero/header images that should render immediately (channel header, profile banner, channel title, inline custom emoji) get decoding="async" only, without lazy loading.