### PR TITLE
Fix NIP-46 auth challenge timeout

### DIFF
--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -15,6 +15,7 @@ export const maxFilters = 10;
 export const timelineBufferMs = 1500;
 export const timeout = 5000;
 export const nip46ConnectTimeout = 10000;
+export const nip46AuthTimeout = 5 * 60 * 1000;
 
 export const hexRegexp = /^[0-9a-f]{64}$/;
 export const addressRegexp = /^[0-9]+:[0-9a-f]{64}:.*$/;

--- a/web/src/lib/signer-strategy.test.ts
+++ b/web/src/lib/signer-strategy.test.ts
@@ -1,44 +1,80 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { nip46AuthTimeout, nip46ConnectTimeout } from './Constants';
-import { establishBunkerConnection, resolveSigner } from './signer-strategy';
+import {
+	abolishBunkerConnection,
+	establishBunkerConnection,
+	resolveSigner
+} from './signer-strategy';
 import { signerCanSign } from './signer-capability';
 
 const nip46Mock = vi.hoisted(() => {
-	let onauth: ((url: string) => void) | undefined;
-	let connectResolve: (() => void) | undefined;
-	let getPublicKeyResolve: ((pubkey: string) => void) | undefined;
+	type MockSigner = {
+		onauth: ((url: string) => void) | undefined;
+		connect: ReturnType<typeof vi.fn>;
+		getPublicKey: ReturnType<typeof vi.fn>;
+		close: ReturnType<typeof vi.fn>;
+		connectResolve: (() => void) | undefined;
+		connectReject: ((error: Error) => void) | undefined;
+		getPublicKeyResolve: ((pubkey: string) => void) | undefined;
+		getPublicKeyReject: ((error: Error) => void) | undefined;
+	};
+	const signers: MockSigner[] = [];
+
+	const getSigner = (index = signers.length - 1) => {
+		const signer = signers[index];
+		if (!signer) {
+			throw new Error(`missing signer at index ${index}`);
+		}
+		return signer;
+	};
 
 	return {
 		fromBunker: vi.fn((...args: unknown[]) => {
 			const options = args[2] as { onauth?: (url: string) => void };
-			onauth = options.onauth;
-			return {
-				connect: vi.fn(
-					() =>
-						new Promise<void>((resolve) => {
-							connectResolve = resolve;
-						})
-				),
-				getPublicKey: vi.fn(
-					() =>
-						new Promise<string>((resolve) => {
-							getPublicKeyResolve = resolve;
-						})
-				),
-				close: vi.fn()
+			const signer: MockSigner = {
+				onauth: options.onauth,
+				connect: vi.fn(),
+				getPublicKey: vi.fn(),
+				close: vi.fn(),
+				connectResolve: undefined,
+				connectReject: undefined,
+				getPublicKeyResolve: undefined,
+				getPublicKeyReject: undefined
 			};
+			signer.connect = vi.fn(
+				() =>
+					new Promise<void>((resolve, reject) => {
+						signer.connectResolve = resolve;
+						signer.connectReject = reject;
+					})
+			);
+			signer.getPublicKey = vi.fn(
+				() =>
+					new Promise<string>((resolve, reject) => {
+						signer.getPublicKeyResolve = resolve;
+						signer.getPublicKeyReject = reject;
+					})
+			);
+			signers.push(signer);
+			return signer;
 		}),
 		parseBunkerInput: vi.fn(async () => ({
 			pubkey: 'pubkey',
 			relays: ['wss://relay.example.com']
 		})),
-		auth: (url = 'https://auth.example.com') => onauth?.(url),
-		resolveConnect: () => connectResolve?.(),
-		resolveGetPublicKey: (pubkey = 'user-pubkey') => getPublicKeyResolve?.(pubkey),
+		auth: (index = signers.length - 1, url = 'https://auth.example.com') =>
+			getSigner(index).onauth?.(url),
+		resolveConnect: (index = signers.length - 1) => getSigner(index).connectResolve?.(),
+		rejectConnect: (index = signers.length - 1, error = new Error('connect failed')) =>
+			getSigner(index).connectReject?.(error),
+		resolveGetPublicKey: (index = signers.length - 1, pubkey = 'user-pubkey') =>
+			getSigner(index).getPublicKeyResolve?.(pubkey),
+		rejectGetPublicKey: (index = signers.length - 1, error = new Error('get pubkey failed')) =>
+			getSigner(index).getPublicKeyReject?.(error),
+		signer: getSigner,
+		signers: () => signers,
 		reset: () => {
-			onauth = undefined;
-			connectResolve = undefined;
-			getPublicKeyResolve = undefined;
+			signers.length = 0;
 		}
 	};
 });
@@ -75,7 +111,8 @@ beforeEach(() => {
 	vi.stubGlobal('open', vi.fn());
 });
 
-afterEach(() => {
+afterEach(async () => {
+	await abolishBunkerConnection();
 	vi.useRealTimers();
 	vi.unstubAllGlobals();
 });
@@ -94,37 +131,44 @@ describe('signerCanSign', () => {
 });
 
 describe('establishBunkerConnection', () => {
+	const flush = async () => {
+		await vi.advanceTimersByTimeAsync(0);
+	};
+
 	it('rejects on connection timeout when auth challenge is not requested', async () => {
 		vi.useFakeTimers();
 		stubBunkerStorage();
 
 		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
 		promise.catch(() => {});
+		await flush();
 		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
 
 		await expect(promise).rejects.toThrow('NIP-46 connection timed out');
 		expect(vi.getTimerCount()).toBe(0);
+		expect(nip46Mock.signer(0).close).toHaveBeenCalledTimes(1);
 	});
 
-	it('rejects on auth timeout after an auth challenge without using the connection timeout', async () => {
+	it('does not settle at the connection timeout after an auth challenge', async () => {
 		vi.useFakeTimers();
 		stubBunkerStorage();
 
 		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
 		promise.catch(() => {});
-		await vi.advanceTimersByTimeAsync(0);
-		nip46Mock.auth();
+		let settled = false;
+		void promise.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+		await flush();
+		nip46Mock.auth(0);
 
 		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
-		await expect(
-			Promise.race([
-				promise.then(
-					() => 'resolved',
-					() => 'rejected'
-				),
-				Promise.resolve('pending')
-			])
-		).resolves.toBe('pending');
+		expect(settled).toBe(false);
 
 		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - nip46ConnectTimeout);
 		await expect(promise).rejects.toThrow('NIP-46 authentication timed out');
@@ -136,31 +180,215 @@ describe('establishBunkerConnection', () => {
 		stubBunkerStorage();
 
 		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
-		await vi.advanceTimersByTimeAsync(0);
-		nip46Mock.auth();
+		await flush();
+		nip46Mock.auth(0);
 		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - 1);
-		nip46Mock.resolveConnect();
-		await vi.advanceTimersByTimeAsync(0);
-		nip46Mock.resolveGetPublicKey();
+		nip46Mock.resolveConnect(0);
+		await flush();
+		nip46Mock.resolveGetPublicKey(0);
 
 		await expect(promise).resolves.toBeUndefined();
 		expect(vi.getTimerCount()).toBe(0);
 	});
 
-	it('ignores delayed auth challenge callbacks after connection attempt is settled', async () => {
+	it('opens auth challenges after a successful login without starting login timers', async () => {
 		vi.useFakeTimers();
 		stubBunkerStorage();
 
 		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
-		await vi.advanceTimersByTimeAsync(0);
-		nip46Mock.resolveConnect();
-		await vi.advanceTimersByTimeAsync(0);
-		nip46Mock.resolveGetPublicKey();
+		await flush();
+		nip46Mock.resolveConnect(0);
+		await flush();
+		nip46Mock.resolveGetPublicKey(0);
 		await expect(promise).resolves.toBeUndefined();
 
-		nip46Mock.auth();
+		vi.mocked(open).mockClear();
+		nip46Mock.auth(0, 'https://auth.example.com/post-login');
+		expect(open).toHaveBeenCalledWith('https://auth.example.com/post-login', '_blank');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('ignores delayed auth challenge callbacks after connection timeout', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await flush();
+		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
+		await expect(promise).rejects.toThrow('NIP-46 connection timed out');
+
+		nip46Mock.auth(0);
 		expect(open).not.toHaveBeenCalled();
 		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('ignores delayed auth challenge callbacks after auth timeout', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await flush();
+		nip46Mock.auth(0, 'https://auth.example.com/first');
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout);
+		await expect(promise).rejects.toThrow('NIP-46 authentication timed out');
+		vi.mocked(open).mockClear();
+
+		nip46Mock.auth(0, 'https://auth.example.com/late');
+		expect(open).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('opens multiple auth challenges in a phase without extending the auth deadline', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await flush();
+		nip46Mock.auth(0, 'https://auth.example.com/first');
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - 1);
+		nip46Mock.auth(0, 'https://auth.example.com/second');
+
+		expect(open).toHaveBeenCalledWith('https://auth.example.com/first', '_blank');
+		expect(open).toHaveBeenCalledWith('https://auth.example.com/second', '_blank');
+		await vi.advanceTimersByTimeAsync(1);
+		await expect(promise).rejects.toThrow('NIP-46 authentication timed out');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('does not let the connect auth timer reject getPublicKey after connect succeeds', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		let settled = false;
+		void promise.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+		await flush();
+		nip46Mock.auth(0);
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - 1);
+		nip46Mock.resolveConnect(0);
+		await flush();
+		expect(nip46Mock.signer(0).getPublicKey).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(settled).toBe(false);
+		nip46Mock.resolveGetPublicKey(0);
+		await expect(promise).resolves.toBeUndefined();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('rejects when getPublicKey does not respond before its connection timeout', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await flush();
+		nip46Mock.resolveConnect(0);
+		await flush();
+		expect(nip46Mock.signer(0).getPublicKey).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
+		await expect(promise).rejects.toThrow('NIP-46 connection timed out');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('uses an independent auth timeout for getPublicKey auth challenges', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		await flush();
+		nip46Mock.resolveConnect(0);
+		await flush();
+		nip46Mock.auth(0, 'https://auth.example.com/get-pubkey');
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - 1);
+		nip46Mock.resolveGetPublicKey(0, 'user-pubkey');
+
+		await expect(promise).resolves.toBeUndefined();
+		expect(open).toHaveBeenCalledWith('https://auth.example.com/get-pubkey', '_blank');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('rejects when getPublicKey auth challenge is not completed before auth timeout', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await flush();
+		nip46Mock.resolveConnect(0);
+		await flush();
+		nip46Mock.auth(0, 'https://auth.example.com/get-pubkey');
+
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout);
+		await expect(promise).rejects.toThrow('NIP-46 authentication timed out');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('does not overwrite the current public key when an old timed-out attempt completes late', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const first = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		first.catch(() => {});
+		await flush();
+		nip46Mock.auth(0);
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout);
+		await expect(first).rejects.toThrow('NIP-46 authentication timed out');
+
+		const second = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		await flush();
+		nip46Mock.resolveConnect(1);
+		await flush();
+		nip46Mock.resolveGetPublicKey(1, 'second-pubkey');
+		await expect(second).resolves.toBeUndefined();
+
+		nip46Mock.resolveConnect(0);
+		await flush();
+		nip46Mock.resolveGetPublicKey(0, 'first-pubkey');
+		await flush();
+
+		stubLogin('bunker://relay.example.com?pubkey=abc');
+		const signer = resolveSigner();
+		await expect(signer.getPublicKey()).resolves.toBe('second-pubkey');
+	});
+
+	it('does not let an old connection attempt destroy the current signer', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const first = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		first.catch(() => {});
+		await flush();
+		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
+		await expect(first).rejects.toThrow('NIP-46 connection timed out');
+
+		const second = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		await flush();
+		nip46Mock.resolveConnect(1);
+		await flush();
+		nip46Mock.resolveGetPublicKey(1, 'second-pubkey');
+		await expect(second).resolves.toBeUndefined();
+
+		nip46Mock.resolveConnect(0);
+		await flush();
+		nip46Mock.resolveGetPublicKey(0, 'first-pubkey');
+		await flush();
+
+		stubLogin('bunker://relay.example.com?pubkey=abc');
+		await expect(resolveSigner().getPublicKey()).resolves.toBe('second-pubkey');
+		nip46Mock.auth(1, 'https://auth.example.com/current');
+		expect(open).toHaveBeenCalledWith('https://auth.example.com/current', '_blank');
 	});
 });
 

--- a/web/src/lib/signer-strategy.test.ts
+++ b/web/src/lib/signer-strategy.test.ts
@@ -1,6 +1,54 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { resolveSigner } from './signer-strategy';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { nip46AuthTimeout, nip46ConnectTimeout } from './Constants';
+import { establishBunkerConnection, resolveSigner } from './signer-strategy';
 import { signerCanSign } from './signer-capability';
+
+const nip46Mock = vi.hoisted(() => {
+	let onauth: ((url: string) => void) | undefined;
+	let connectResolve: (() => void) | undefined;
+	let getPublicKeyResolve: ((pubkey: string) => void) | undefined;
+
+	return {
+		fromBunker: vi.fn((...args: unknown[]) => {
+			const options = args[2] as { onauth?: (url: string) => void };
+			onauth = options.onauth;
+			return {
+				connect: vi.fn(
+					() =>
+						new Promise<void>((resolve) => {
+							connectResolve = resolve;
+						})
+				),
+				getPublicKey: vi.fn(
+					() =>
+						new Promise<string>((resolve) => {
+							getPublicKeyResolve = resolve;
+						})
+				),
+				close: vi.fn()
+			};
+		}),
+		parseBunkerInput: vi.fn(async () => ({
+			pubkey: 'pubkey',
+			relays: ['wss://relay.example.com']
+		})),
+		auth: (url = 'https://auth.example.com') => onauth?.(url),
+		resolveConnect: () => connectResolve?.(),
+		resolveGetPublicKey: (pubkey = 'user-pubkey') => getPublicKeyResolve?.(pubkey),
+		reset: () => {
+			onauth = undefined;
+			connectResolve = undefined;
+			getPublicKeyResolve = undefined;
+		}
+	};
+});
+
+vi.mock('nostr-tools/nip46', () => ({
+	BunkerSigner: {
+		fromBunker: nip46Mock.fromBunker
+	},
+	parseBunkerInput: nip46Mock.parseBunkerInput
+}));
 
 function stubLogin(value: string | null): void {
 	vi.stubGlobal('localStorage', {
@@ -11,7 +59,24 @@ function stubLogin(value: string | null): void {
 	});
 }
 
+function stubBunkerStorage(): void {
+	vi.stubGlobal('localStorage', {
+		getItem: () => null,
+		setItem: () => {},
+		removeItem: () => {},
+		clear: () => {}
+	});
+}
+
+beforeEach(() => {
+	nip46Mock.reset();
+	nip46Mock.fromBunker.mockClear();
+	nip46Mock.parseBunkerInput.mockClear();
+	vi.stubGlobal('open', vi.fn());
+});
+
 afterEach(() => {
+	vi.useRealTimers();
 	vi.unstubAllGlobals();
 });
 
@@ -25,6 +90,77 @@ describe('signerCanSign', () => {
 	it('returns false for npub and undefined', () => {
 		expect(signerCanSign('npub')).toBe(false);
 		expect(signerCanSign(undefined)).toBe(false);
+	});
+});
+
+describe('establishBunkerConnection', () => {
+	it('rejects on connection timeout when auth challenge is not requested', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
+
+		await expect(promise).rejects.toThrow('NIP-46 connection timed out');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('rejects on auth timeout after an auth challenge without using the connection timeout', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		promise.catch(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+		nip46Mock.auth();
+
+		await vi.advanceTimersByTimeAsync(nip46ConnectTimeout);
+		await expect(
+			Promise.race([
+				promise.then(
+					() => 'resolved',
+					() => 'rejected'
+				),
+				Promise.resolve('pending')
+			])
+		).resolves.toBe('pending');
+
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - nip46ConnectTimeout);
+		await expect(promise).rejects.toThrow('NIP-46 authentication timed out');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('resolves and clears timers when auth challenge is followed by a completed connection', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		await vi.advanceTimersByTimeAsync(0);
+		nip46Mock.auth();
+		await vi.advanceTimersByTimeAsync(nip46AuthTimeout - 1);
+		nip46Mock.resolveConnect();
+		await vi.advanceTimersByTimeAsync(0);
+		nip46Mock.resolveGetPublicKey();
+
+		await expect(promise).resolves.toBeUndefined();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('ignores delayed auth challenge callbacks after connection attempt is settled', async () => {
+		vi.useFakeTimers();
+		stubBunkerStorage();
+
+		const promise = establishBunkerConnection('bunker://relay.example.com?pubkey=abc');
+		await vi.advanceTimersByTimeAsync(0);
+		nip46Mock.resolveConnect();
+		await vi.advanceTimersByTimeAsync(0);
+		nip46Mock.resolveGetPublicKey();
+		await expect(promise).resolves.toBeUndefined();
+
+		nip46Mock.auth();
+		expect(open).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
 	});
 });
 

--- a/web/src/lib/signer-strategy.ts
+++ b/web/src/lib/signer-strategy.ts
@@ -21,6 +21,21 @@ declare const window: {
 
 let bunkerSigner: BunkerSigner | undefined;
 let nip46CachedPublicKey: string | undefined;
+let bunkerConnectionGeneration = 0;
+
+type ConnectionState = 'pending' | 'succeeded' | 'failed';
+
+type LoginPhase = {
+	onauth: (url: string) => void;
+};
+
+async function closeBunkerSigner(signer: BunkerSigner): Promise<void> {
+	try {
+		await signer.close();
+	} catch (e) {
+		console.debug('[NIP-46] close error', e);
+	}
+}
 
 export async function establishBunkerConnection(bunker: string): Promise<void> {
 	const bunkerPointer = await parseBunkerInput(bunker);
@@ -36,70 +51,100 @@ export async function establishBunkerConnection(bunker: string): Promise<void> {
 		storage.set('login:bunker:client-seckey', bytesToHex(clientSeckey));
 	}
 
-	let settled = false;
-	let connectTimer: ReturnType<typeof setTimeout> | undefined;
-	let authTimer: ReturnType<typeof setTimeout> | undefined;
-	const clearTimers = () => {
-		if (connectTimer !== undefined) {
-			clearTimeout(connectTimer);
-			connectTimer = undefined;
-		}
-		if (authTimer !== undefined) {
-			clearTimeout(authTimer);
-			authTimer = undefined;
-		}
-	};
-
-	let rejectOnTimeout: (error: Error) => void;
-	const timeout = new Promise<never>((_resolve, reject) => {
-		rejectOnTimeout = reject;
-	});
+	let connectionState: ConnectionState = 'pending';
+	let activeLoginPhase: LoginPhase | undefined;
+	const generation = ++bunkerConnectionGeneration;
 	bunkerSigner = BunkerSigner.fromBunker(clientSeckey, bunkerPointer, {
 		onauth: (url) => {
-			if (settled) {
+			if (generation !== bunkerConnectionGeneration) {
 				return;
 			}
-			if (authTimer === undefined) {
-				if (connectTimer !== undefined) {
-					clearTimeout(connectTimer);
-					connectTimer = undefined;
-				}
-				authTimer = setTimeout(() => {
-					rejectOnTimeout(new Error('NIP-46 authentication timed out'));
-				}, nip46AuthTimeout);
+			if (connectionState === 'failed') {
+				return;
 			}
-			open(url, '_blank');
+			if (connectionState === 'succeeded') {
+				open(url, '_blank');
+				return;
+			}
+			activeLoginPhase?.onauth(url);
 		}
 	});
 	console.debug('[NIP-46 client pubkey]', getPublicKey(clientSeckey));
 
 	const signer = bunkerSigner;
-	connectTimer = setTimeout(() => {
-		rejectOnTimeout(new Error('NIP-46 connection timed out'));
-	}, nip46ConnectTimeout);
+
+	const runRequestWithAuthTimeout = async <T>(request: () => Promise<T>): Promise<T> => {
+		let connectTimer: ReturnType<typeof setTimeout> | undefined;
+		let authTimer: ReturnType<typeof setTimeout> | undefined;
+		const clearTimers = () => {
+			if (connectTimer !== undefined) {
+				clearTimeout(connectTimer);
+				connectTimer = undefined;
+			}
+			if (authTimer !== undefined) {
+				clearTimeout(authTimer);
+				authTimer = undefined;
+			}
+		};
+
+		let rejectOnTimeout: (error: Error) => void;
+		const timeout = new Promise<never>((_resolve, reject) => {
+			rejectOnTimeout = reject;
+		});
+		const phase: LoginPhase = {
+			onauth: (url) => {
+				if (authTimer === undefined) {
+					if (connectTimer !== undefined) {
+						clearTimeout(connectTimer);
+						connectTimer = undefined;
+					}
+					authTimer = setTimeout(() => {
+						rejectOnTimeout(new Error('NIP-46 authentication timed out'));
+					}, nip46AuthTimeout);
+				}
+				open(url, '_blank');
+			}
+		};
+
+		activeLoginPhase = phase;
+		connectTimer = setTimeout(() => {
+			rejectOnTimeout(new Error('NIP-46 connection timed out'));
+		}, nip46ConnectTimeout);
+
+		try {
+			return await Promise.race([request(), timeout]);
+		} finally {
+			if (activeLoginPhase === phase) {
+				activeLoginPhase = undefined;
+			}
+			clearTimers();
+		}
+	};
+
 	try {
-		await Promise.race([
-			(async () => {
-				await signer.connect();
-				console.debug('[NIP-46 connected]');
-				nip46CachedPublicKey = await signer.getPublicKey();
-			})(),
-			timeout
-		]);
-	} finally {
-		settled = true;
-		clearTimers();
+		await runRequestWithAuthTimeout(() => signer.connect());
+		console.debug('[NIP-46 connected]');
+		const publicKey = await runRequestWithAuthTimeout(() => signer.getPublicKey());
+		if (generation !== bunkerConnectionGeneration || bunkerSigner !== signer) {
+			throw new Error('NIP-46 connection was superseded');
+		}
+		nip46CachedPublicKey = publicKey;
+		connectionState = 'succeeded';
+	} catch (e) {
+		connectionState = 'failed';
+		await closeBunkerSigner(signer);
+		if (generation === bunkerConnectionGeneration && bunkerSigner === signer) {
+			bunkerSigner = undefined;
+			nip46CachedPublicKey = undefined;
+		}
+		throw e;
 	}
 	console.debug('[NIP-46 user pubkey]', nip46CachedPublicKey);
 }
 
 export async function abolishBunkerConnection(): Promise<void> {
 	if (bunkerSigner) {
-		try {
-			await bunkerSigner.close();
-		} catch (e) {
-			console.debug('[NIP-46] close error', e);
-		}
+		await closeBunkerSigner(bunkerSigner);
 		bunkerSigner = undefined;
 		nip46CachedPublicKey = undefined;
 	}

--- a/web/src/lib/signer-strategy.ts
+++ b/web/src/lib/signer-strategy.ts
@@ -11,7 +11,7 @@ import { BunkerSigner, parseBunkerInput } from 'nostr-tools/nip46';
 import { generateSecretKey } from 'nostr-tools/pure';
 import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
 import { WebStorage } from './WebStorage';
-import { nip46ConnectTimeout } from './Constants';
+import { nip46AuthTimeout, nip46ConnectTimeout } from './Constants';
 import type * as Nostr from 'nostr-typedef';
 import { type LoginType, signerCanSign } from './signer-capability';
 
@@ -36,21 +36,46 @@ export async function establishBunkerConnection(bunker: string): Promise<void> {
 		storage.set('login:bunker:client-seckey', bytesToHex(clientSeckey));
 	}
 
-	let authRequested = false;
+	let settled = false;
+	let connectTimer: ReturnType<typeof setTimeout> | undefined;
+	let authTimer: ReturnType<typeof setTimeout> | undefined;
+	const clearTimers = () => {
+		if (connectTimer !== undefined) {
+			clearTimeout(connectTimer);
+			connectTimer = undefined;
+		}
+		if (authTimer !== undefined) {
+			clearTimeout(authTimer);
+			authTimer = undefined;
+		}
+	};
+
+	let rejectOnTimeout: (error: Error) => void;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		rejectOnTimeout = reject;
+	});
 	bunkerSigner = BunkerSigner.fromBunker(clientSeckey, bunkerPointer, {
 		onauth: (url) => {
-			authRequested = true;
+			if (settled) {
+				return;
+			}
+			if (authTimer === undefined) {
+				if (connectTimer !== undefined) {
+					clearTimeout(connectTimer);
+					connectTimer = undefined;
+				}
+				authTimer = setTimeout(() => {
+					rejectOnTimeout(new Error('NIP-46 authentication timed out'));
+				}, nip46AuthTimeout);
+			}
 			open(url, '_blank');
 		}
 	});
 	console.debug('[NIP-46 client pubkey]', getPublicKey(clientSeckey));
 
 	const signer = bunkerSigner;
-	const { promise: timeout, reject: rejectOnTimeout } = Promise.withResolvers<never>();
-	const timer = setTimeout(() => {
-		if (!authRequested) {
-			rejectOnTimeout(new Error('NIP-46 connection timed out'));
-		}
+	connectTimer = setTimeout(() => {
+		rejectOnTimeout(new Error('NIP-46 connection timed out'));
 	}, nip46ConnectTimeout);
 	try {
 		await Promise.race([
@@ -62,7 +87,8 @@ export async function establishBunkerConnection(bunker: string): Promise<void> {
 			timeout
 		]);
 	} finally {
-		clearTimeout(timer);
+		settled = true;
+		clearTimers();
 	}
 	console.debug('[NIP-46 user pubkey]', nip46CachedPublicKey);
 }


### PR DESCRIPTION
### Motivation

- `establishBunkerConnection()` が `onauth` を受け取った後に既存の接続タイマーで `reject` しなくなり、ユーザーが外部で認証を完了しないとログイン処理が無期限待機する不具合を修正するため。 
- NIP-46 の仕様上、Auth Challenge の後で最終レスポンスが届かないことがあるため、Auth Challenge 後にも有限のタイムアウトを設ける必要がある。 

### Description

- `web/src/lib/Constants.ts` に新しい定数 `nip46AuthTimeout = 5 * 60 * 1000` を追加して、Auth Challenge 後の待機上限を定義した。 
- `web/src/lib/signer-strategy.ts` の `establishBunkerConnection()` を接続／認証で別々のタイマー管理に差し替え、`connectTimer`（接続タイムアウト）と `authTimer`（Auth Challenge 後タイムアウト）を導入し、終了済みを示す `settled` フラグと `clearTimers()` を実装して不要な再起動や解除漏れを防止した。 
- タイムアウト時のエラーメッセージを区別可能にして、接続タイムアウトは `NIP-46 connection timed out`、認証待機タイムアウトは `NIP-46 authentication timed out` を投げるようにした。 
- `web/src/lib/signer-strategy.test.ts` に最小限の `nostr-tools/nip46` モックと fake timers を用いたテストを追加し、接続タイムアウト、Auth Challenge 後のタイムアウト、Auth Challenge 後の正常完了、終了後に来る遅延 `onauth` の無視 を検証するテストを追加した。 

### Testing

- `npm test` を実行し、プロジェクトのテストスイートは `17 files / 165 tests` すべてが通過した（成功）。 
- `npm run check` を実行し、`svelte-check` は `0 errors and 0 warnings` を報告した（成功）。 
- `npm run lint` を実行し、`prettier` と `eslint` のチェックが通った（成功）。 
- 追加した単体テストでは次を確認しており、いずれも期待どおりに動作した：接続タイムアウト（Auth Challenge が発生しない）、Auth Challenge 後の認証タイムアウト（接続タイムアウトでは終わらない）、Auth Challenge 後に `connect()`/`getPublicKey()` が完了する場合の正常終了、および接続終了後に届く遅延 `onauth` の無視。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ec9ec964832eaaa6467121dc5c72)