### PR TITLE
Redirect kind 30023 note and nevent URLs to naddr

### DIFF
--- a/web/src/routes/(app)/[slug=note]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=note]/+layout.server.ts
@@ -1,9 +1,10 @@
 import { nip19 } from 'nostr-tools';
 import type * as Nostr from 'nostr-typedef';
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { defaultRelays } from '$lib/Constants';
 import { fetchEvent } from '$lib/Api';
+import { findIdentifier } from '$lib/EventHelper';
 import { checkRestriction } from '$lib/server/Restriction';
 
 export const load: LayoutServerLoad<{
@@ -11,11 +12,13 @@ export const load: LayoutServerLoad<{
 	relays: string[];
 	event: Nostr.Event | undefined;
 }> = async ({ params, platform }) => {
+	let id = '';
+	let relays: string[] = [];
+	let event: Nostr.Event | undefined;
+	let isNevent = false;
+
 	try {
 		const { type, data } = nip19.decode(params.slug);
-
-		let id: string;
-		let relays: string[] = [];
 
 		switch (type) {
 			case 'note': {
@@ -24,6 +27,7 @@ export const load: LayoutServerLoad<{
 			}
 			case 'nevent': {
 				id = data.id;
+				isNevent = true;
 				if (data.relays !== undefined) {
 					relays = data.relays;
 				}
@@ -34,7 +38,7 @@ export const load: LayoutServerLoad<{
 			}
 		}
 
-		const event = await fetchEvent(
+		event = await fetchEvent(
 			id,
 			relays.length > 0 ? relays : defaultRelays.map(({ url }) => url)
 		);
@@ -42,13 +46,23 @@ export const load: LayoutServerLoad<{
 		if (event !== undefined) {
 			await checkRestriction(event.pubkey, platform);
 		}
-
-		return {
-			eventId: id,
-			relays,
-			event
-		};
 	} catch {
 		error(404, 'Not Found');
 	}
+
+	if (isNevent && event?.kind === 30023) {
+		const naddr = nip19.naddrEncode({
+			kind: event.kind,
+			pubkey: event.pubkey,
+			identifier: findIdentifier(event.tags) ?? '',
+			relays
+		});
+		redirect(308, `/${naddr}`);
+	}
+
+	return {
+		eventId: id,
+		relays,
+		event
+	};
 };

--- a/web/src/routes/(app)/[slug=note]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=note]/+layout.server.ts
@@ -1,4 +1,5 @@
 import { nip19 } from 'nostr-tools';
+import { LongFormArticle } from 'nostr-tools/kinds';
 import type * as Nostr from 'nostr-typedef';
 import { error, redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
@@ -48,7 +49,7 @@ export const load: LayoutServerLoad<{
 		error(404, 'Not Found');
 	}
 
-	if (event?.kind === 30023) {
+	if (event?.kind === LongFormArticle) {
 		const naddr = nip19.naddrEncode({
 			kind: event.kind,
 			pubkey: event.pubkey,

--- a/web/src/routes/(app)/[slug=note]/+layout.server.ts
+++ b/web/src/routes/(app)/[slug=note]/+layout.server.ts
@@ -15,7 +15,6 @@ export const load: LayoutServerLoad<{
 	let id = '';
 	let relays: string[] = [];
 	let event: Nostr.Event | undefined;
-	let isNevent = false;
 
 	try {
 		const { type, data } = nip19.decode(params.slug);
@@ -27,7 +26,6 @@ export const load: LayoutServerLoad<{
 			}
 			case 'nevent': {
 				id = data.id;
-				isNevent = true;
 				if (data.relays !== undefined) {
 					relays = data.relays;
 				}
@@ -50,7 +48,7 @@ export const load: LayoutServerLoad<{
 		error(404, 'Not Found');
 	}
 
-	if (isNevent && event?.kind === 30023) {
+	if (event?.kind === 30023) {
 		const naddr = nip19.naddrEncode({
 			kind: event.kind,
 			pubkey: event.pubkey,


### PR DESCRIPTION
## What changed

- Detect kind `30023` after resolving either a `note` or `nevent` URL.
- Build the canonical `naddr` from the event kind, author pubkey, `d` tag identifier, and available relay hints.
- Return a `308 Permanent Redirect` to the existing `naddr` route.
- Keep all other event kinds unchanged.

## Why

NIP-23 long-form content is addressable and is linked using an NIP-19 `naddr`. Redirecting both `note` and `nevent` references to the addressable route ensures the article is resolved by its stable coordinate rather than a specific event revision.

## Validation

- Reviewed the shared route matcher, which accepts both `note` and `nevent` values.
- Reused the repository's existing `naddr` encoding convention and `findIdentifier()` helper.
- Kept `redirect()` outside the existing `try`/`catch` so SvelteKit can handle the thrown redirect response.
- Local checks could not be run because the execution environment could not resolve `github.com`; CI results should be used for final validation.