### PR TITLE
Fix channel header dropdown positioning in the sticky layout

### DIFF
--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelHeader.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelHeader.svelte
@@ -33,7 +33,13 @@
 
 	const {
 		elements: { menu, item, trigger, overlay, separator }
-	} = createDropdownMenu({ preventScroll: false });
+	} = createDropdownMenu({
+		preventScroll: false,
+		positioning: {
+			placement: 'bottom-end',
+			strategy: 'fixed'
+		}
+	});
 
 	let detailsDialog = $state<HTMLDialogElement>();
 	let brokenImage = $state(false);


### PR DESCRIPTION
## Summary

Fix the channel header overflow menu positioning while the header is sticky.

## Changes

- Configure the Melt UI dropdown to use Floating UI's `fixed` positioning strategy.
- Align the menu to the bottom end of the trigger.
- Keep the existing scroll-prevention behavior unchanged.

## Root cause

The channel header uses `position: sticky`, while the dropdown previously relied on Floating UI's default `absolute` positioning strategy. This combination can cause the floating menu to become mispositioned relative to its trigger.

## Impact

The channel menu should remain anchored to the three-dot trigger on both desktop and mobile layouts, including after the header becomes sticky.

## Validation

- Confirmed the branch changes only `ChannelHeader.svelte`.
- Confirmed the dropdown configuration includes `placement: 'bottom-end'` and `strategy: 'fixed'`.
- Browser interaction testing is still required in the deployment preview.

Closes #2259