### PR TITLE
bugfix:Jump to the wrong image

### DIFF
--- a/web/src/lib/components/content/Thumbnail.svelte
+++ b/web/src/lib/components/content/Thumbnail.svelte
@@ -32,7 +32,7 @@
 				});
 			}
 			const index = urls.findIndex((u) => u.href === url.href);
-			swiper.activeIndex = index >= 0 ? index : 0;
+			swiper.slideTo(index >= 0 ? index : 0, 0);
 		}
 	});
 


### PR DESCRIPTION
# problem
- Jump to the wrong image (the 1st image) when clicking on the 2nd or later image in the post
  - demo:
    - 1: [open the post](https://nostter.app/nevent1qyxhwumn8ghj77tpvf6jumt9qyghwumn8ghj7u3wddhk56tjvyhxjmcpypmhxue69uhhyetvv9uj66ns9ehx7um5wgh8w6tjv4jxuet59e48qqg5waehxw309aex2mrp0yhxgctdw4eju6t0qyv8wumn8ghj7un9d3shjtnndehhyapwwdhkx6tpdsq3vamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet5qqsxmqxmsw3898txksednttq8r3cp0ltved3rd40pjcy5rwlhln4grqmpk4nq)
    - 2: click the second image (typhoon)
    - 3: problem: the first image (sashimi) is closed up
      - expected: Jump to the clicked image (typhoon)

# change
- Use Swiper's slideTo API to update the active slide and rendered position

# test
- `npm run build`: There is no new problem
- `npm run preview`: Goto the demo page and click the second image -> the seconds image was closed up successfully.