### PR TITLE
Fix strange scroll-back at the channel bottom

### DIFF
--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
@@ -213,7 +213,8 @@ export class ChannelChat {
 		}
 		this.#seen.add(event.id);
 		const index = this.messages.findIndex((e) => e.created_at > event.created_at);
-		this.shift = true;
+		// virtua's shift mode is only valid when items are added at the start.
+		this.shift = index === 0;
 		this.messages =
 			index < 0 ? [...this.messages, event] : this.messages.toSpliced(index, 0, event);
 	}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelMessageList.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelMessageList.svelte
@@ -26,9 +26,9 @@
 	const groupingThreshold = 5 * 60;
 
 	let ref = $state<VirtualizerRef>();
+	let listHeight = $state(0);
 
 	let atBottom = true;
-	let initialScrolled = false;
 	let lastSeq = 0;
 
 	let unread = $state(0);
@@ -69,6 +69,7 @@
 		const length = visible.length;
 		if (length > 0) {
 			ref?.scrollToIndex(length - 1, { align: 'end' });
+			requestAnimationFrame(() => window.scrollTo(0, document.documentElement.scrollHeight));
 		}
 	}
 
@@ -94,9 +95,7 @@
 	});
 
 	$effect(() => {
-		const length = visible.length;
-		if (!initialScrolled && length > 0) {
-			initialScrolled = true;
+		if (listHeight > 0 && atBottom && visible.length > 0) {
 			tick().then(scrollToBottom);
 		}
 	});
@@ -116,7 +115,7 @@
 	});
 </script>
 
-<div class="chat">
+<div class="chat" bind:clientHeight={listHeight}>
 	{#if chat.loading && visible.length === 0}
 		<div class="loading"><Loading /></div>
 	{/if}


### PR DESCRIPTION
# Problem

- 1. Open an image-heavy channel, such as [this channel](https://nostter.app/channels/nevent1qqs0gq5f622uyal7yyslert4zd60gcd5ehqs4ccsfrn299wsqyjssvcqarct2).
- 2. Scroll to the bottom of the channel.
- 3. Problem: The view can scroll up in the several messages from the bottom even though the user was already at the bottom. (So we never can see the latest post.)
  - Expected behavior: the view should remain pinned to the bottom while the user is at the bottom.

## Mechanism

- Recent channel events are received incrementally and inserted into the message list in chronological order, so an event may be inserted in the middle or at the end.
- Every insertion previously enabled virtua's `shift` mode.
- With `shift` enabled, virtua interprets the array-length increase as all new items having been prepended. It therefore:
  - Moves the cached sizes of existing items toward later indexes.
  - Adds the estimated total height of the new leading items to the scroll offset.
- When an event was actually inserted in the middle or at the end, the cache indexes no longer matched the message indexes:
  - When one event was appended, the indexes of all existing messages stayed unchanged, but virtua moved every cached size one index later. For example, the measured height of the message at index `n` was then used as the estimated height of the message at index `n + 1`.
  - When one event was inserted in the middle, only messages at and after the insertion point moved one index later, but virtua also moved the cached sizes for messages before the insertion point.
- These cache mismatches changed the estimated list height and caused a scroll-offset correction that was not appropriate for the actual insertion position.
- The virtualized list's total height also continued to change as more events arrived and image-heavy messages were measured.
- The initial scroll to the bottom ran only once. Later history insertions and height changes did not trigger another bottom scroll.
- As a result, the document became taller while the window kept its previous scroll offset, making the view appear to jump several messages upward.

# Changes

- Enable virtua's `shift` mode only when an older event is inserted at the start of the message list. Mid-list and end insertions now use the normal anchoring mode.
- Observe changes to the rendered message-list height and scroll to the bottom again only when the user is already at the bottom.
- Align the window with the document bottom after the virtualizer scrolls to the last message, accounting for the sticky channel composer.

# test

- `npm run check` → passed with 0 errors and 0 warnings
- `npm test -- --run` → 17 test files and 161 tests passed
- `npm run build` → passed
- Verified against the affected channel in a local browser:
  - After the user scrolled to the bottom, the view did not scroll back.
  - After scrolling to the top, the scroll position remained there while the list was updated.
  - When a new message was posted while the view was at the bottom, the view followed the new message and remained at the bottom.