### PR TITLE
Enable direct Spotify embed playback on desktop

### DIFF
--- a/web/src/lib/components/content/Spotify.svelte
+++ b/web/src/lib/components/content/Spotify.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { MediaQuery } from 'svelte/reactivity';
 	import { _ } from 'svelte-i18n';
 	import { Spotify } from '$lib/Spotify';
 	import ExternalLink from '../ExternalLink.svelte';
@@ -9,29 +10,33 @@
 
 	let { link }: Props = $props();
 
+	const supportsDirectInteraction = new MediaQuery('(hover: hover) and (pointer: fine)', false);
 	let embedUrl = $derived(Spotify.getEmbedUrl(link));
 </script>
 
 {#if embedUrl !== undefined}
-	<div class="spotify-embed-card">
+	<div class="spotify-embed-card" class:external-link-mode={!supportsDirectInteraction.current}>
+		<!-- svelte-ignore a11y_no_noninteractive_tabindex (The embedded Spotify player is interactive) -->
 		<iframe
 			src={embedUrl.href}
-			title=""
+			title={$_('content.spotify.player')}
 			frameborder="0"
 			loading="lazy"
-			aria-hidden="true"
-			tabindex="-1"
+			aria-hidden={supportsDirectInteraction.current ? undefined : 'true'}
+			tabindex={supportsDirectInteraction.current ? 0 : -1}
 		></iframe>
 
-		<a
-			class="spotify-embed-cover"
-			href={link.href}
-			target="_blank"
-			rel="noopener noreferrer"
-			aria-label={$_('content.spotify.play')}
-		>
-			<span class="spotify-embed-label">{$_('content.spotify.play')}</span>
-		</a>
+		{#if !supportsDirectInteraction.current}
+			<a
+				class="spotify-embed-cover"
+				href={link.href}
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={$_('content.spotify.play')}
+			>
+				<span class="spotify-embed-label">{$_('content.spotify.play')}</span>
+			</a>
+		{/if}
 	</div>
 {:else}
 	<ExternalLink {link} />
@@ -53,6 +58,9 @@
 		height: 352px;
 		border: 0;
 		border-radius: 12px;
+	}
+
+	.spotify-embed-card.external-link-mode iframe {
 		transition:
 			filter 0.18s ease,
 			transform 0.18s ease;
@@ -95,19 +103,19 @@
 			transform 0.18s ease;
 	}
 
-	.spotify-embed-card:hover iframe,
-	.spotify-embed-card:focus-within iframe {
+	.spotify-embed-card.external-link-mode:hover iframe,
+	.spotify-embed-card.external-link-mode:focus-within iframe {
 		filter: blur(3px) brightness(0.65);
 		transform: scale(1.01);
 	}
 
-	.spotify-embed-card:hover .spotify-embed-cover::before,
-	.spotify-embed-card:focus-within .spotify-embed-cover::before {
+	.spotify-embed-card.external-link-mode:hover .spotify-embed-cover::before,
+	.spotify-embed-card.external-link-mode:focus-within .spotify-embed-cover::before {
 		background: rgba(0, 0, 0, 0.18);
 	}
 
-	.spotify-embed-card:hover .spotify-embed-label,
-	.spotify-embed-card:focus-within .spotify-embed-label {
+	.spotify-embed-card.external-link-mode:hover .spotify-embed-label,
+	.spotify-embed-card.external-link-mode:focus-within .spotify-embed-label {
 		opacity: 1;
 		transform: translateY(0);
 	}
@@ -124,14 +132,14 @@
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.spotify-embed-card iframe,
+		.spotify-embed-card.external-link-mode iframe,
 		.spotify-embed-cover::before,
 		.spotify-embed-label {
 			transition: none;
 		}
 
-		.spotify-embed-card:hover iframe,
-		.spotify-embed-card:focus-within iframe {
+		.spotify-embed-card.external-link-mode:hover iframe,
+		.spotify-embed-card.external-link-mode:focus-within iframe {
 			transform: none;
 		}
 	}

--- a/web/src/lib/components/content/Spotify.svelte
+++ b/web/src/lib/components/content/Spotify.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { MediaQuery } from 'svelte/reactivity';
 	import { _ } from 'svelte-i18n';
 	import { Spotify } from '$lib/Spotify';
@@ -10,8 +11,14 @@
 
 	let { link }: Props = $props();
 
-	const supportsDirectInteraction = new MediaQuery('(hover: hover) and (pointer: fine)', false);
+	const directInteractionMediaQuery = new MediaQuery('(hover: hover) and (pointer: fine)', false);
+	let mounted = $state(false);
+	let supportsDirectInteraction = $derived(mounted && directInteractionMediaQuery.current);
 	let embedUrl = $derived(Spotify.getEmbedUrl(link));
+
+	onMount(() => {
+		mounted = true;
+	});
 </script>
 
 {#if embedUrl !== undefined}
@@ -22,11 +29,11 @@
 			title={$_('content.spotify.player')}
 			frameborder="0"
 			loading="lazy"
-			aria-hidden={supportsDirectInteraction.current ? undefined : 'true'}
-			tabindex={supportsDirectInteraction.current ? 0 : -1}
+			aria-hidden={supportsDirectInteraction ? undefined : 'true'}
+			tabindex={supportsDirectInteraction ? 0 : -1}
 		></iframe>
 
-		{#if !supportsDirectInteraction.current}
+		{#if !supportsDirectInteraction}
 			<a
 				class="spotify-embed-cover"
 				href={link.href}

--- a/web/src/lib/components/content/Spotify.svelte
+++ b/web/src/lib/components/content/Spotify.svelte
@@ -15,7 +15,7 @@
 </script>
 
 {#if embedUrl !== undefined}
-	<div class="spotify-embed-card" class:external-link-mode={!supportsDirectInteraction.current}>
+	<div class="spotify-embed-card">
 		<!-- svelte-ignore a11y_no_noninteractive_tabindex (The embedded Spotify player is interactive) -->
 		<iframe
 			src={embedUrl.href}
@@ -33,9 +33,7 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				aria-label={$_('content.spotify.play')}
-			>
-				<span class="spotify-embed-label">{$_('content.spotify.play')}</span>
-			</a>
+			></a>
 		{/if}
 	</div>
 {:else}
@@ -60,64 +58,13 @@
 		border-radius: 12px;
 	}
 
-	.spotify-embed-card.external-link-mode iframe {
-		transition:
-			filter 0.18s ease,
-			transform 0.18s ease;
-	}
-
 	.spotify-embed-cover {
 		position: absolute;
 		inset: 0;
 		z-index: 10;
-		display: grid;
-		place-items: center;
 		border-radius: 12px;
 		text-decoration: none;
 		cursor: pointer;
-	}
-
-	.spotify-embed-cover::before {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background: rgba(0, 0, 0, 0);
-		transition: background 0.18s ease;
-	}
-
-	.spotify-embed-label {
-		position: relative;
-		z-index: 1;
-		opacity: 0;
-		transform: translateY(4px);
-		padding: 10px 16px;
-		border-radius: 999px;
-		background: rgba(0, 0, 0, 0.78);
-		color: white;
-		font-size: 15px;
-		font-weight: 700;
-		letter-spacing: 0.02em;
-		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
-		transition:
-			opacity 0.18s ease,
-			transform 0.18s ease;
-	}
-
-	.spotify-embed-card.external-link-mode:hover iframe,
-	.spotify-embed-card.external-link-mode:focus-within iframe {
-		filter: blur(3px) brightness(0.65);
-		transform: scale(1.01);
-	}
-
-	.spotify-embed-card.external-link-mode:hover .spotify-embed-cover::before,
-	.spotify-embed-card.external-link-mode:focus-within .spotify-embed-cover::before {
-		background: rgba(0, 0, 0, 0.18);
-	}
-
-	.spotify-embed-card.external-link-mode:hover .spotify-embed-label,
-	.spotify-embed-card.external-link-mode:focus-within .spotify-embed-label {
-		opacity: 1;
-		transform: translateY(0);
 	}
 
 	.spotify-embed-cover:focus-visible {
@@ -128,19 +75,6 @@
 	@media (max-width: 600px) {
 		.spotify-embed-card iframe {
 			height: 232px;
-		}
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.spotify-embed-card.external-link-mode iframe,
-		.spotify-embed-cover::before,
-		.spotify-embed-label {
-			transition: none;
-		}
-
-		.spotify-embed-card.external-link-mode:hover iframe,
-		.spotify-embed-card.external-link-mode:focus-within iframe {
-			transform: none;
 		}
 	}
 </style>

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -196,7 +196,8 @@
 		"deleted": "Deleted content",
 		"not_found": "Not found",
 		"spotify": {
-			"play": "Play in new page"
+			"play": "Play in new page",
+			"player": "Spotify player"
 		}
 	},
 	"wallet": {

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -195,7 +195,8 @@
 		"deleted": "削除されたコンテンツ",
 		"not_found": "見つかりませんでした",
 		"spotify": {
-			"play": "新しいページで再生"
+			"play": "新しいページで再生",
+			"player": "Spotifyプレーヤー"
 		}
 	},
 	"wallet": {


### PR DESCRIPTION
Closes: #2258 

## Summary
タッチ環境では新しいタブで開き、ポインター環境ではそのままEmbedを利用できるように変更しました。基本的にはIssueの通りです。
現行のバージョンでは、ホバー時の演出(ブラー等)がありますが、タップ環境ではポインタが存在せずブラーの表示ができないため演出は全て削除しました。
また、Accessibilityについてタップ環境ではembedの操作ができないためtab-indexに-1を定義し、ポインター環境では0を定義しています。