### PR TITLE
Add SoundCloud embed support

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -38,6 +38,7 @@ const cspDirectives: Record<string, string[]> = {
 		'https://www.youtube.com',
 		'https://www.youtube-nocookie.com',
 		'https://open.spotify.com',
+		'https://w.soundcloud.com',
 		'https://embed.nicovideo.jp',
 		'https://platform.twitter.com',
 		'https://syndication.twitter.com'

--- a/web/src/lib/SoundCloud.test.ts
+++ b/web/src/lib/SoundCloud.test.ts
@@ -1,9 +1,83 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SoundCloud } from './SoundCloud';
 
 const contentUrl = 'https://soundcloud.com/user/track';
 const playerUrl = 'https://w.soundcloud.com/player/?url=track';
 
+type TestElement = {
+	tagName: string;
+	getAttribute(name: string): string | null;
+};
+
+class TestDOMParser {
+	parseFromString(html: string) {
+		const elements = [
+			...html.matchAll(/<\s*(script|object|embed|style|iframe|div|p)\b([^>]*)>/gis)
+		].map(([, tagName, attributes]) => ({
+			tagName: tagName.toUpperCase(),
+			getAttribute(name: string): string | null {
+				const match = attributes.match(
+					new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i')
+				);
+				return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+			}
+		}));
+		const topLevelElements: TestElement[] = [];
+		let depth = 0;
+		for (const match of html.matchAll(
+			/<\s*(\/)?\s*(script|object|embed|style|iframe|div|p)\b([^>]*)>/gis
+		)) {
+			const [, closing, tagName, attributes] = match;
+			if (closing !== undefined) {
+				depth = Math.max(0, depth - 1);
+				continue;
+			}
+			if (depth === 0) {
+				topLevelElements.push({
+					tagName: tagName.toUpperCase(),
+					getAttribute(name: string): string | null {
+						const attribute = attributes.match(
+							new RegExp(
+								`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
+								'i'
+							)
+						);
+						return attribute?.[1] ?? attribute?.[2] ?? attribute?.[3] ?? null;
+					}
+				});
+			}
+			if (!attributes.trimEnd().endsWith('/')) {
+				depth += 1;
+			}
+		}
+
+		return {
+			body: {
+				children: topLevelElements,
+				firstElementChild: topLevelElements[0] ?? null
+			},
+			querySelector: (selector: string) => {
+				const forbidden = selector.split(',').map((tag) => tag.trim().toUpperCase());
+				return elements.find((element) => forbidden.includes(element.tagName)) ?? null;
+			}
+		};
+	}
+}
+
+function validResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		version: 1,
+		type: 'rich',
+		provider_name: 'SoundCloud',
+		provider_url: 'https://soundcloud.com',
+		html: `<iframe src="${playerUrl}"></iframe>`,
+		title: 'Track',
+		height: 166,
+		...overrides
+	};
+}
+
+beforeEach(() => vi.stubGlobal('DOMParser', TestDOMParser));
 afterEach(() => vi.unstubAllGlobals());
 
 describe('SoundCloud URL', () => {
@@ -21,60 +95,167 @@ describe('SoundCloud URL', () => {
 		expect(SoundCloud.isSoundCloudUrl(url)).toBe(false);
 	});
 
-	it('generates an oEmbed URL', () => {
+	it('generates an oEmbed URL with autoplay disabled', () => {
 		const url = SoundCloud.getOEmbedUrl(contentUrl);
-		expect(url?.href).toBe(
-			'https://soundcloud.com/oembed?format=json&url=https%3A%2F%2Fsoundcloud.com%2Fuser%2Ftrack'
+		expect(url?.origin).toBe('https://soundcloud.com');
+		expect(url?.pathname).toBe('/oembed');
+		expect(url?.searchParams.get('format')).toBe('json');
+		expect(url?.searchParams.get('url')).toBe(contentUrl);
+		expect(url?.searchParams.get('auto_play')).toBe('false');
+	});
+});
+
+describe('SoundCloud oEmbed response', () => {
+	it('parses a valid response', () => {
+		expect(SoundCloud.parseOEmbedResponse(validResponse())).toStrictEqual({
+			src: new URL(playerUrl),
+			title: 'Track',
+			height: 166
+		});
+	});
+
+	it.each([
+		['null', null],
+		['array', []],
+		['invalid version', validResponse({ version: '1.0' })],
+		['non-rich type', validResponse({ type: 'video' })],
+		['another provider', validResponse({ provider_name: 'Example' })],
+		['another provider origin', validResponse({ provider_url: 'https://example.com' })],
+		[
+			'similar provider domain',
+			validResponse({ provider_url: 'https://soundcloud.com.example' })
+		],
+		['provider userinfo', validResponse({ provider_url: 'https://user@soundcloud.com' })],
+		['provider port', validResponse({ provider_url: 'https://soundcloud.com:8443' })],
+		['missing html', validResponse({ html: undefined })],
+		['empty html', validResponse({ html: '   ' })],
+		['non-numeric height', validResponse({ height: '166' })],
+		['NaN height', validResponse({ height: Number.NaN })],
+		['infinite height', validResponse({ height: Number.POSITIVE_INFINITY })]
+	])('rejects %s', (_name, response) => {
+		expect(SoundCloud.parseOEmbedResponse(response)).toBeUndefined();
+	});
+
+	it.each([
+		[undefined, 166],
+		[0, 81],
+		[80, 81],
+		[451, 450],
+		[100_000, 450]
+	])('clamps height %s to %s', (height, expected) => {
+		expect(SoundCloud.parseOEmbedResponse(validResponse({ height }))?.height).toBe(expected);
+	});
+
+	it.each([undefined, null, '', '   ', 123])('uses a fallback title for %s', (title) => {
+		expect(SoundCloud.parseOEmbedResponse(validResponse({ title }))?.title).toBe(
+			'SoundCloud player'
 		);
 	});
 });
 
-describe('SoundCloud oEmbed', () => {
-	function stubPlayer(src = playerUrl): void {
-		vi.stubGlobal(
-			'DOMParser',
-			class {
-				parseFromString() {
-					return {
-						querySelector: () => ({ getAttribute: () => src })
-					};
-				}
-			}
-		);
-	}
-
-	it('parses the official player', () => {
-		stubPlayer();
-		expect(
-			SoundCloud.parseOEmbedResponse({
-				html: '<iframe></iframe>',
-				title: 'Track',
-				height: 166
-			})
-		).toStrictEqual({ src: new URL(playerUrl), title: 'Track', height: 166 });
+describe('SoundCloud oEmbed HTML', () => {
+	it('accepts one top-level iframe', () => {
+		expect(SoundCloud.parseOEmbedResponse(validResponse())).toBeDefined();
 	});
 
-	it('rejects a player from another origin', () => {
-		stubPlayer('https://example.com/player/');
+	it.each([
+		['another top-level element', `<div></div>`],
+		['multiple top-level elements', `<iframe src="${playerUrl}"></iframe><div></div>`],
+		['an iframe and script', `<iframe src="${playerUrl}"></iframe><script></script>`],
+		['a nested script', `<iframe src="${playerUrl}"><script></script></iframe>`],
+		['an object', `<iframe src="${playerUrl}"></iframe><object></object>`],
+		['an embed element', `<iframe src="${playerUrl}"></iframe><embed>`],
+		['a style element', `<iframe src="${playerUrl}"></iframe><style></style>`],
+		['an iframe without src', '<iframe></iframe>']
+	])('rejects %s', (_name, html) => {
+		expect(SoundCloud.parseOEmbedResponse(validResponse({ html }))).toBeUndefined();
+	});
+});
+
+describe('SoundCloud player URL', () => {
+	it.each([playerUrl, 'https://w.soundcloud.com/player?url=track'])('accepts %s', (src) => {
 		expect(
-			SoundCloud.parseOEmbedResponse({
-				html: '<iframe></iframe>',
-				title: 'Track',
-				height: 166
-			})
+			SoundCloud.parseOEmbedResponse(
+				validResponse({ html: `<iframe src="${src}"></iframe>` })
+			)
+		).toBeDefined();
+	});
+
+	it.each([
+		'http://w.soundcloud.com/player',
+		'https://example.com/player',
+		'https://w.soundcloud.com.example/player',
+		'https://sub.w.soundcloud.com/player',
+		'https://user@w.soundcloud.com/player',
+		'https://w.soundcloud.com:8443/player',
+		'https://w.soundcloud.com/players',
+		'https://w.soundcloud.com/other'
+	])('rejects %s', (src) => {
+		expect(
+			SoundCloud.parseOEmbedResponse(
+				validResponse({ html: `<iframe src="${src}"></iframe>` })
+			)
+		).toBeUndefined();
+	});
+});
+
+describe('SoundCloud fetch', () => {
+	function response(options: { ok?: boolean; json?: () => Promise<unknown> } = {}): Response {
+		return {
+			ok: options.ok ?? true,
+			json: options.json ?? (async () => validResponse())
+		} as Response;
+	}
+
+	it('fetches and validates oEmbed data without real network access', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => response())
+		);
+		expect(await SoundCloud.fetchEmbed(contentUrl)).toMatchObject({ title: 'Track' });
+	});
+
+	it('passes the abort signal to fetch', async () => {
+		const fetchMock = vi.fn(async () => response());
+		vi.stubGlobal('fetch', fetchMock);
+		const controller = new AbortController();
+		await SoundCloud.fetchEmbed(contentUrl, controller.signal);
+		expect(fetchMock).toHaveBeenCalledWith(expect.any(URL), { signal: controller.signal });
+	});
+
+	it('returns undefined for an HTTP error', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => response({ ok: false }))
+		);
+		expect(await SoundCloud.fetchEmbed(contentUrl)).toBeUndefined();
+	});
+
+	it('returns undefined for a JSON error', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				response({ json: async () => Promise.reject(new SyntaxError('JSON')) })
+			)
+		);
+		expect(await SoundCloud.fetchEmbed(contentUrl)).toBeUndefined();
+	});
+
+	it('returns undefined when aborted', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => Promise.reject(new DOMException('Aborted', 'AbortError')))
+		);
+		expect(
+			await SoundCloud.fetchEmbed(contentUrl, new AbortController().signal)
 		).toBeUndefined();
 	});
 
-	it('fetches and parses oEmbed data', async () => {
-		stubPlayer();
+	it('returns undefined when oEmbed validation fails', async () => {
 		vi.stubGlobal(
 			'fetch',
-			vi.fn(async () => ({
-				ok: true,
-				json: async () => ({ html: '<iframe></iframe>', title: 'Track', height: 166 })
-			}))
+			vi.fn(async () => response({ json: async () => validResponse({ type: 'video' }) }))
 		);
-
-		expect(await SoundCloud.fetchEmbed(contentUrl)).toMatchObject({ title: 'Track' });
+		expect(await SoundCloud.fetchEmbed(contentUrl)).toBeUndefined();
 	});
 });

--- a/web/src/lib/SoundCloud.test.ts
+++ b/web/src/lib/SoundCloud.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SoundCloud } from './SoundCloud';
+
+const contentUrl = 'https://soundcloud.com/user/track';
+const playerUrl = 'https://w.soundcloud.com/player/?url=track';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('SoundCloud URL', () => {
+	it.each([contentUrl, 'https://www.soundcloud.com/user/sets/playlist'])('accepts %s', (url) => {
+		expect(SoundCloud.isSoundCloudUrl(url)).toBe(true);
+	});
+
+	it.each([
+		'not a URL',
+		'http://soundcloud.com/user/track',
+		'https://soundcloud.com',
+		'https://api.soundcloud.com/user/track',
+		'https://soundcloud.example/user/track'
+	])('rejects %s', (url) => {
+		expect(SoundCloud.isSoundCloudUrl(url)).toBe(false);
+	});
+
+	it('generates an oEmbed URL', () => {
+		const url = SoundCloud.getOEmbedUrl(contentUrl);
+		expect(url?.href).toBe(
+			'https://soundcloud.com/oembed?format=json&url=https%3A%2F%2Fsoundcloud.com%2Fuser%2Ftrack'
+		);
+	});
+});
+
+describe('SoundCloud oEmbed', () => {
+	function stubPlayer(src = playerUrl): void {
+		vi.stubGlobal(
+			'DOMParser',
+			class {
+				parseFromString() {
+					return {
+						querySelector: () => ({ getAttribute: () => src })
+					};
+				}
+			}
+		);
+	}
+
+	it('parses the official player', () => {
+		stubPlayer();
+		expect(
+			SoundCloud.parseOEmbedResponse({
+				html: '<iframe></iframe>',
+				title: 'Track',
+				height: 166
+			})
+		).toStrictEqual({ src: new URL(playerUrl), title: 'Track', height: 166 });
+	});
+
+	it('rejects a player from another origin', () => {
+		stubPlayer('https://example.com/player/');
+		expect(
+			SoundCloud.parseOEmbedResponse({
+				html: '<iframe></iframe>',
+				title: 'Track',
+				height: 166
+			})
+		).toBeUndefined();
+	});
+
+	it('fetches and parses oEmbed data', async () => {
+		stubPlayer();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ html: '<iframe></iframe>', title: 'Track', height: 166 })
+			}))
+		);
+
+		expect(await SoundCloud.fetchEmbed(contentUrl)).toMatchObject({ title: 'Track' });
+	});
+});

--- a/web/src/lib/SoundCloud.ts
+++ b/web/src/lib/SoundCloud.ts
@@ -1,0 +1,85 @@
+export type SoundCloudEmbed = {
+	src: URL;
+	title: string;
+	height: number;
+};
+
+export class SoundCloud {
+	static isSoundCloudUrl(url: URL | string): boolean {
+		try {
+			const parsed = typeof url === 'string' ? new URL(url) : url;
+			return (
+				parsed.protocol === 'https:' &&
+				['soundcloud.com', 'www.soundcloud.com'].includes(parsed.hostname) &&
+				parsed.username === '' &&
+				parsed.password === '' &&
+				parsed.port === '' &&
+				parsed.pathname.split('/').some(Boolean)
+			);
+		} catch {
+			return false;
+		}
+	}
+
+	static getOEmbedUrl(url: URL | string): URL | undefined {
+		if (!this.isSoundCloudUrl(url)) {
+			return undefined;
+		}
+
+		const parsed = typeof url === 'string' ? new URL(url) : url;
+		const oEmbedUrl = new URL('https://soundcloud.com/oembed');
+		oEmbedUrl.searchParams.set('format', 'json');
+		oEmbedUrl.searchParams.set('url', parsed.href);
+		return oEmbedUrl;
+	}
+
+	static parseOEmbedResponse(value: unknown): SoundCloudEmbed | undefined {
+		if (value === null || typeof value !== 'object') {
+			return undefined;
+		}
+
+		const { html, title, height } = value as Record<string, unknown>;
+		if (
+			typeof html !== 'string' ||
+			typeof title !== 'string' ||
+			typeof height !== 'number' ||
+			!Number.isFinite(height) ||
+			height <= 0
+		) {
+			return undefined;
+		}
+
+		const src = new DOMParser()
+			.parseFromString(html, 'text/html')
+			.querySelector('iframe')
+			?.getAttribute('src');
+		if (src === null || src === undefined || !URL.canParse(src)) {
+			return undefined;
+		}
+
+		const playerUrl = new URL(src);
+		if (
+			playerUrl.protocol !== 'https:' ||
+			playerUrl.hostname !== 'w.soundcloud.com' ||
+			!['/player', '/player/'].includes(playerUrl.pathname)
+		) {
+			return undefined;
+		}
+
+		return { src: playerUrl, title, height };
+	}
+
+	static async fetchEmbed(url: URL | string): Promise<SoundCloudEmbed | undefined> {
+		const oEmbedUrl = this.getOEmbedUrl(url);
+		if (oEmbedUrl === undefined) {
+			return undefined;
+		}
+
+		try {
+			const response = await fetch(oEmbedUrl);
+			return response.ok ? this.parseOEmbedResponse(await response.json()) : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+}

--- a/web/src/lib/SoundCloud.ts
+++ b/web/src/lib/SoundCloud.ts
@@ -5,6 +5,10 @@ export type SoundCloudEmbed = {
 };
 
 export class SoundCloud {
+	private static readonly defaultHeight = 166;
+	private static readonly minHeight = 81;
+	private static readonly maxHeight = 450;
+
 	static isSoundCloudUrl(url: URL | string): boolean {
 		try {
 			const parsed = typeof url === 'string' ? new URL(url) : url;
@@ -30,53 +34,94 @@ export class SoundCloud {
 		const oEmbedUrl = new URL('https://soundcloud.com/oembed');
 		oEmbedUrl.searchParams.set('format', 'json');
 		oEmbedUrl.searchParams.set('url', parsed.href);
+		oEmbedUrl.searchParams.set('auto_play', 'false');
 		return oEmbedUrl;
 	}
 
 	static parseOEmbedResponse(value: unknown): SoundCloudEmbed | undefined {
-		if (value === null || typeof value !== 'object') {
+		if (value === null || typeof value !== 'object' || Array.isArray(value)) {
 			return undefined;
 		}
 
-		const { html, title, height } = value as Record<string, unknown>;
+		const { version, type, provider_name, provider_url, html, title, height } = value as Record<
+			string,
+			unknown
+		>;
 		if (
+			version !== 1 ||
+			type !== 'rich' ||
+			provider_name !== 'SoundCloud' ||
+			typeof provider_url !== 'string' ||
 			typeof html !== 'string' ||
-			typeof title !== 'string' ||
-			typeof height !== 'number' ||
-			!Number.isFinite(height) ||
-			height <= 0
+			html.trim() === '' ||
+			(height !== undefined && (typeof height !== 'number' || !Number.isFinite(height)))
 		) {
 			return undefined;
 		}
 
-		const src = new DOMParser()
-			.parseFromString(html, 'text/html')
-			.querySelector('iframe')
-			?.getAttribute('src');
-		if (src === null || src === undefined || !URL.canParse(src)) {
+		if (!URL.canParse(provider_url)) {
+			return undefined;
+		}
+		const providerUrl = new URL(provider_url);
+		if (
+			providerUrl.protocol !== 'https:' ||
+			!['soundcloud.com', 'www.soundcloud.com'].includes(providerUrl.hostname) ||
+			providerUrl.username !== '' ||
+			providerUrl.password !== '' ||
+			providerUrl.port !== ''
+		) {
 			return undefined;
 		}
 
+		const document = new DOMParser().parseFromString(html, 'text/html');
+		if (
+			document.body.children.length !== 1 ||
+			document.body.firstElementChild?.tagName !== 'IFRAME' ||
+			document.querySelector('script, object, embed, style') !== null
+		) {
+			return undefined;
+		}
+
+		const src = document.body.firstElementChild.getAttribute('src');
+		if (src === null || src.trim() === '') {
+			return undefined;
+		}
+
+		if (!URL.canParse(src)) {
+			return undefined;
+		}
 		const playerUrl = new URL(src);
 		if (
 			playerUrl.protocol !== 'https:' ||
 			playerUrl.hostname !== 'w.soundcloud.com' ||
+			playerUrl.username !== '' ||
+			playerUrl.password !== '' ||
+			playerUrl.port !== '' ||
 			!['/player', '/player/'].includes(playerUrl.pathname)
 		) {
 			return undefined;
 		}
 
-		return { src: playerUrl, title, height };
+		const safeHeight = Math.min(
+			this.maxHeight,
+			Math.max(this.minHeight, height ?? this.defaultHeight)
+		);
+		const safeTitle =
+			typeof title === 'string' && title.trim() !== '' ? title : 'SoundCloud player';
+		return { src: playerUrl, title: safeTitle, height: safeHeight };
 	}
 
-	static async fetchEmbed(url: URL | string): Promise<SoundCloudEmbed | undefined> {
+	static async fetchEmbed(
+		url: URL | string,
+		signal?: AbortSignal
+	): Promise<SoundCloudEmbed | undefined> {
 		const oEmbedUrl = this.getOEmbedUrl(url);
 		if (oEmbedUrl === undefined) {
 			return undefined;
 		}
 
 		try {
-			const response = await fetch(oEmbedUrl);
+			const response = await fetch(oEmbedUrl, { signal });
 			return response.ok ? this.parseOEmbedResponse(await response.json()) : undefined;
 		} catch {
 			return undefined;

--- a/web/src/lib/components/Content.svelte
+++ b/web/src/lib/components/Content.svelte
@@ -9,6 +9,7 @@
 	import CustomEmojiPopup from './content/CustomEmojiPopup.svelte';
 	import Ogp from './content/Ogp.svelte';
 	import { enablePreview } from '$lib/stores/Preference';
+	import { SoundCloud } from '$lib/SoundCloud';
 	import { Spotify } from '$lib/Spotify';
 	import { Twitter } from '$lib/Twitter';
 	import { nicovideoRegexp } from '$lib/Constants';
@@ -65,6 +66,8 @@
 				<!-- Twitter -->
 			{:else if Spotify.isSpotifyUrl(url)}
 				<!-- Spotify -->
+			{:else if SoundCloud.isSoundCloudUrl(url)}
+				<!-- SoundCloud -->
 			{:else if (url.hostname === 'youtu.be' || /^(.+\.)*youtube\.com$/s.test(url.hostname)) && !url.pathname.startsWith('/@')}
 				<!-- YouTube -->
 			{:else if url.hostname.endsWith('nicovideo.jp') && nicovideoRegexp.test(url.href)}

--- a/web/src/lib/components/content/SoundCloud.svelte
+++ b/web/src/lib/components/content/SoundCloud.svelte
@@ -11,13 +11,17 @@
 
 	$effect(() => {
 		let cancelled = false;
+		const controller = new AbortController();
 		embed = undefined;
-		void SoundCloud.fetchEmbed(link).then((result) => {
+		void SoundCloud.fetchEmbed(link, controller.signal).then((result) => {
 			if (!cancelled) {
 				embed = result;
 			}
 		});
-		return () => (cancelled = true);
+		return () => {
+			cancelled = true;
+			controller.abort();
+		};
 	});
 </script>
 

--- a/web/src/lib/components/content/SoundCloud.svelte
+++ b/web/src/lib/components/content/SoundCloud.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { SoundCloud, type SoundCloudEmbed } from '$lib/SoundCloud';
+	import ExternalLink from '../ExternalLink.svelte';
+
+	interface Props {
+		link: URL;
+	}
+
+	let { link }: Props = $props();
+	let embed: SoundCloudEmbed | undefined = $state();
+
+	$effect(() => {
+		let cancelled = false;
+		embed = undefined;
+		void SoundCloud.fetchEmbed(link).then((result) => {
+			if (!cancelled) {
+				embed = result;
+			}
+		});
+		return () => (cancelled = true);
+	});
+</script>
+
+{#if embed !== undefined}
+	<iframe
+		src={embed.src.href}
+		title={embed.title}
+		frameborder="0"
+		allow="autoplay"
+		loading="lazy"
+		referrerpolicy="strict-origin-when-cross-origin"
+		style:height={`${embed.height}px`}
+	></iframe>
+{:else}
+	<ExternalLink {link} />
+{/if}
+
+<style>
+	iframe {
+		display: block;
+		width: 100%;
+		max-width: 100%;
+		border: 0;
+	}
+</style>

--- a/web/src/lib/components/content/Url.svelte
+++ b/web/src/lib/components/content/Url.svelte
@@ -54,11 +54,13 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
 	import { newUrl } from '$lib/Helper';
+	import { SoundCloud } from '$lib/SoundCloud';
 	import { Spotify } from '$lib/Spotify';
 	import { Twitter } from '$lib/Twitter';
 	import { enablePreview } from '$lib/stores/Preference';
 	import Text from './Text.svelte';
 	import ExternalLink from '$lib/components/ExternalLink.svelte';
+	import SoundCloudPlayer from '$lib/components/content/SoundCloud.svelte';
 	import SpotifyPlayer from '$lib/components/content/Spotify.svelte';
 	import YouTube from '$lib/components/content/YouTube.svelte';
 	import Nicovideo from './Nicovideo.svelte';
@@ -143,6 +145,12 @@
 {:else if Spotify.isSpotifyUrl(link)}
 	{#if preview}
 		<SpotifyPlayer {link} />
+	{:else}
+		<ExternalLink {link} />
+	{/if}
+{:else if SoundCloud.isSoundCloudUrl(link)}
+	{#if preview}
+		<SoundCloudPlayer {link} />
 	{:else}
 		<ExternalLink {link} />
 	{/if}


### PR DESCRIPTION
Closes #2257 

# Summary
SoundCloudのEmbedを実装しました。
on.soundcloud.comなどの短縮URLはこのPRでは実装していません。