### PR TITLE
Decode HTML entities in proxied OGP titles

### DIFF
--- a/web/src/lib/ogp.test.ts
+++ b/web/src/lib/ogp.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchOgp, fetchOgpViaProxy } from './ogp';
+
+beforeEach(() => {
+	vi.stubGlobal(
+		'DOMParser',
+		class {
+			parseFromString(value: string) {
+				return { body: { textContent: value } };
+			}
+		}
+	);
+});
 
 function jsonResponse(body: Record<string, string>, init?: { ok?: boolean; contentType?: string }) {
 	return {

--- a/web/src/lib/ogp.ts
+++ b/web/src/lib/ogp.ts
@@ -5,6 +5,11 @@ export type Ogp = {
 	image?: string;
 };
 
+function decodeHtml(value: string): string {
+	const dom = new DOMParser().parseFromString(value, 'text/html');
+	return dom.body.textContent ?? value;
+}
+
 export async function fetchOgp(url: URL): Promise<Ogp | undefined> {
 	return (await fetchOgpViaProxy(url)) ?? (await fetchOgpDirect(url));
 }
@@ -30,8 +35,9 @@ export async function fetchOgpViaProxy(url: URL): Promise<Ogp | undefined> {
 
 	const ogp: Record<string, string> = await response.json();
 	console.debug('[ogp proxy]', url.href, ogp);
+	const title = ogp['og:title'] ?? ogp['title'];
 	return {
-		title: ogp['og:title'] ?? ogp['title'],
+		title: title === undefined ? undefined : decodeHtml(title),
 		image: ogp['og:image']
 	};
 }


### PR DESCRIPTION
## Summary

- Fix proxied OGP titles retaining HTML character references such as `&amp;`.
- Decode the selected `og:title` or fallback `title` with the browser's standard `DOMParser`.
- Add no dependencies and leave direct OGP parsing unchanged.

## Tests

- Kept the existing proxy behavior tests running with a minimal `DOMParser` test shim.
- `npm test -- --run` (18 files, 219 tests passed)
- `npm run lint` (passed)
- `npm run check` (0 errors, 0 warnings)
