### PR TITLE
Support on.soundcloud.com

### DIFF
--- a/web/src/lib/SoundCloud.test.ts
+++ b/web/src/lib/SoundCloud.test.ts
@@ -85,6 +85,10 @@ describe('SoundCloud URL', () => {
 		expect(SoundCloud.isSoundCloudUrl(url)).toBe(true);
 	});
 
+	it('accepts an on.soundcloud.com URL', () => {
+		expect(SoundCloud.isSoundCloudUrl('https://on.soundcloud.com/AbCdEf123456')).toBe(true);
+	});
+
 	it.each([
 		'not a URL',
 		'http://soundcloud.com/user/track',

--- a/web/src/lib/SoundCloud.ts
+++ b/web/src/lib/SoundCloud.ts
@@ -14,7 +14,9 @@ export class SoundCloud {
 			const parsed = typeof url === 'string' ? new URL(url) : url;
 			return (
 				parsed.protocol === 'https:' &&
-				['soundcloud.com', 'www.soundcloud.com'].includes(parsed.hostname) &&
+				['soundcloud.com', 'www.soundcloud.com', 'on.soundcloud.com'].includes(
+					parsed.hostname
+				) &&
 				parsed.username === '' &&
 				parsed.password === '' &&
 				parsed.port === '' &&


### PR DESCRIPTION
SoundCloud EmbedでSoundCloud公式のショートリンクを表示できるように。
以下の投稿で動作を検証しました。
https://nostter.app/nevent1qyt8wumn8ghj7mn0wd68ytnp0f6kk6fwvfk82egpp4mhxue69uhhjctzw5hx6egpz9mhxue69uhhytntda4xjunp9e5k7qgdwaehxw309ahx7uewd3hkcqpq8e5f67dsxs6w4e7re7re6tdc6lxlghf7w3l0urnamyny9x40jrtsvyx0a0

<img width="606" height="961" alt="image" src="https://github.com/user-attachments/assets/282ed223-a40e-422a-9af1-11ea111c139e" />
