### PR TITLE
Show current navigation with filled icons

### DIFF
--- a/web/src/routes/(app)/Header.svelte
+++ b/web/src/routes/(app)/Header.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
 	import IconHome from '@tabler/icons-svelte-runes/icons/home';
+	import IconHomeFilled from '@tabler/icons-svelte-runes/icons/home-filled';
 	import IconWorld from '@tabler/icons-svelte-runes/icons/world';
+	import IconWorldFilled from '@tabler/icons-svelte-runes/icons/world-filled';
 	import IconSearch from '@tabler/icons-svelte-runes/icons/search';
+	import IconSearchFilled from '@tabler/icons-svelte-runes/icons/search-filled';
 	import IconBell from '@tabler/icons-svelte-runes/icons/bell';
+	import IconBellFilled from '@tabler/icons-svelte-runes/icons/bell-filled';
 	import IconUser from '@tabler/icons-svelte-runes/icons/user';
+	import IconUserFilled from '@tabler/icons-svelte-runes/icons/user-filled';
 	import IconSettings from '@tabler/icons-svelte-runes/icons/settings';
+	import IconSettingsFilled from '@tabler/icons-svelte-runes/icons/settings-filled';
 	import IconList from '@tabler/icons-svelte-runes/icons/list';
+	import IconListFilled from '@tabler/icons-svelte-runes/icons/list-filled';
 	import IconBookmark from '@tabler/icons-svelte-runes/icons/bookmark';
+	import IconBookmarkFilled from '@tabler/icons-svelte-runes/icons/bookmark-filled';
 	import IconMessages from '@tabler/icons-svelte-runes/icons/messages';
+	import IconMessagesFilled from '@tabler/icons-svelte-runes/icons/messages-filled';
 	import IconPencilPlus from '@tabler/icons-svelte-runes/icons/pencil-plus';
 	import IconLogin from '@tabler/icons-svelte-runes/icons/login';
 	import IconDots from '@tabler/icons-svelte-runes/icons/dots';
+	import IconDotsFilled from '@tabler/icons-svelte-runes/icons/dots-filled';
 	import IconPaw from '@tabler/icons-svelte-runes/icons/paw';
+	import IconPawFilled from '@tabler/icons-svelte-runes/icons/paw-filled';
 	import { nip19 } from 'nostr-tools';
 	import { _ } from 'svelte-i18n';
 	import { goto } from '$app/navigation';
@@ -26,6 +37,7 @@
 	import { MouseButton } from '$lib/DomHelper';
 	import { requestTimelineScrollToTop } from '$lib/timelines/ScrollToTop';
 	import { composerFocus } from './channels/[nevent=note]/ComposerFocus.svelte';
+	import { getCurrentHeaderNavigation, isMoreNavigationCurrent } from './HeaderNavigation';
 
 	const {
 		elements: { menu, item, trigger, overlay }
@@ -78,6 +90,29 @@
 				item.event.created_at > $lastReadAt && isVisibleNotification(item.event.pubkey)
 		).length > 0
 	);
+	let currentNavigation = $derived(
+		getCurrentHeaderNavigation(page.route.id, page.data.pubkey, $pubkey)
+	);
+	let moreNavigationCurrent = $derived(isMoreNavigationCurrent(currentNavigation));
+	let HomeIcon = $derived(currentNavigation === 'home' ? IconHomeFilled : IconHome);
+	let PublicIcon = $derived(currentNavigation === 'public' ? IconWorldFilled : IconWorld);
+	let SearchIcon = $derived(currentNavigation === 'search' ? IconSearchFilled : IconSearch);
+	let NotificationsIcon = $derived(
+		currentNavigation === 'notifications' ? IconBellFilled : IconBell
+	);
+	let ListsIcon = $derived(currentNavigation === 'lists' ? IconListFilled : IconList);
+	let BookmarksIcon = $derived(
+		currentNavigation === 'bookmarks' ? IconBookmarkFilled : IconBookmark
+	);
+	let ChannelsIcon = $derived(
+		currentNavigation === 'channels' ? IconMessagesFilled : IconMessages
+	);
+	let ProfileIcon = $derived(currentNavigation === 'profile' ? IconUserFilled : IconUser);
+	let PreferencesIcon = $derived(
+		currentNavigation === 'preferences' ? IconSettingsFilled : IconSettings
+	);
+	let AboutIcon = $derived(currentNavigation === 'about' ? IconPawFilled : IconPaw);
+	let MoreIcon = $derived(moreNavigationCurrent ? IconDotsFilled : IconDots);
 </script>
 
 <div class="header">
@@ -94,27 +129,41 @@
 	<nav>
 		<ul class="full">
 			<li class="clickable">
-				<a href={homeLink} onclick={onClickHomeLink}>
-					<IconHome size={30} />
+				<a
+					href={homeLink}
+					onclick={onClickHomeLink}
+					aria-current={currentNavigation === 'home' ? 'page' : undefined}
+				>
+					<HomeIcon size={30} />
 					<p>{$_('layout.header.home')}</p>
 				</a>
 			</li>
 			<li class="clickable">
-				<a href="/public" onclick={onClickPublicLink}>
-					<IconWorld size={30} />
+				<a
+					href="/public"
+					onclick={onClickPublicLink}
+					aria-current={currentNavigation === 'public' ? 'page' : undefined}
+				>
+					<PublicIcon size={30} />
 					<p>{$_('pages.public')}</p>
 				</a>
 			</li>
 			<li class="clickable">
-				<a href="/search">
-					<IconSearch size={30} />
+				<a
+					href="/search"
+					aria-current={currentNavigation === 'search' ? 'page' : undefined}
+				>
+					<SearchIcon size={30} />
 					<p>{$_('layout.header.search')}</p>
 				</a>
 			</li>
 			{#if $pubkey}
 				<li class="clickable notifications-icon">
-					<a href="/notifications">
-						<IconBell size={30} />
+					<a
+						href="/notifications"
+						aria-current={currentNavigation === 'notifications' ? 'page' : undefined}
+					>
+						<NotificationsIcon size={30} />
 						{#if notificationsBadge}
 							<span class="notifications-icon-badge"></span>
 						{/if}
@@ -124,70 +173,103 @@
 			{/if}
 			{#if $pubkey}
 				<li class="clickable">
-					<a href="/{nprofile}/lists">
-						<IconList size={30} />
+					<a
+						href="/{nprofile}/lists"
+						aria-current={currentNavigation === 'lists' ? 'page' : undefined}
+					>
+						<ListsIcon size={30} />
 						<p>{$_('lists.title')}</p>
 					</a>
 				</li>
 				<li class="clickable">
-					<a href="/{nprofile}/bookmarks">
-						<IconBookmark size={30} />
+					<a
+						href="/{nprofile}/bookmarks"
+						aria-current={currentNavigation === 'bookmarks' ? 'page' : undefined}
+					>
+						<BookmarksIcon size={30} />
 						<p>{$_('layout.header.bookmarks')}</p>
 					</a>
 				</li>
 			{/if}
 			<li class="clickable">
-				<a href="/channels">
-					<IconMessages size={30} />
+				<a
+					href="/channels"
+					aria-current={currentNavigation === 'channels' ? 'page' : undefined}
+				>
+					<ChannelsIcon size={30} />
 					<p>{$_('layout.header.channels')}</p>
 				</a>
 			</li>
 			{#if $pubkey}
 				<li class="clickable">
-					<a href="/{nprofile}">
-						<IconUser size={30} />
+					<a
+						href="/{nprofile}"
+						aria-current={currentNavigation === 'profile' ? 'page' : undefined}
+					>
+						<ProfileIcon size={30} />
 						<p>{$_('layout.header.profile')}</p>
 					</a>
 				</li>
 				<li class="clickable">
-					<a href="/preferences">
-						<IconSettings size={30} />
+					<a
+						href="/preferences"
+						aria-current={currentNavigation === 'preferences' ? 'page' : undefined}
+					>
+						<PreferencesIcon size={30} />
 						<p>{$_('layout.header.preferences')}</p>
 					</a>
 				</li>
 			{/if}
 			<li class="clickable">
-				<a href="/about">
-					<IconPaw size={30} />
+				<a href="/about" aria-current={currentNavigation === 'about' ? 'page' : undefined}>
+					<AboutIcon size={30} />
 					<p>{$_('about.title')}</p>
 				</a>
 			</li>
 		</ul>
 		<ul class="fold">
 			<li>
-				<a href={homeLink} class="active" onclick={onClickHomeLink}>
-					<IconHome size={30} />
+				<a
+					href={homeLink}
+					class="active"
+					onclick={onClickHomeLink}
+					aria-current={currentNavigation === 'home' ? 'page' : undefined}
+				>
+					<HomeIcon size={30} />
 					<p>{$_('layout.header.home')}</p>
 				</a>
 			</li>
 			{#if !$pubkey}
 				<li>
-					<a href="/public" class="active" onclick={onClickPublicLink}>
-						<IconWorld size={30} />
+					<a
+						href="/public"
+						class="active"
+						onclick={onClickPublicLink}
+						aria-current={currentNavigation === 'public' ? 'page' : undefined}
+					>
+						<PublicIcon size={30} />
 						<p>{$_('pages.public')}</p>
 					</a>
 				</li>
 			{/if}
 			<li>
-				<a href="/search" class="active">
-					<IconSearch size={30} />
+				<a
+					href="/search"
+					class="active"
+					aria-current={currentNavigation === 'search' ? 'page' : undefined}
+				>
+					<SearchIcon size={30} />
 					<p>{$_('layout.header.search')}</p>
 				</a>
 			</li>
 			{#if $pubkey}
 				<li class="notifications-icon">
-					<a href="/notifications" class="active">
-						<IconBell size={30} />
+					<a
+						href="/notifications"
+						class="active"
+						aria-current={currentNavigation === 'notifications' ? 'page' : undefined}
+					>
+						<NotificationsIcon size={30} />
 						{#if notificationsBadge}
 							<span class="notifications-icon-badge"></span>
 						{/if}
@@ -195,21 +277,25 @@
 					</a>
 				</li>
 				<li>
-					<a href="/{nprofile}" class="active">
-						<IconUser size={30} />
+					<a
+						href="/{nprofile}"
+						class="active"
+						aria-current={currentNavigation === 'profile' ? 'page' : undefined}
+					>
+						<ProfileIcon size={30} />
 						<p>{$_('layout.header.profile')}</p>
 					</a>
 				</li>
 				<li>
 					<button class="clear active" use:melt={$trigger}>
-						<IconDots size={30} />
+						<MoreIcon size={30} />
 					</button>
 					<div use:melt={$overlay} class="overlay"></div>
 					<div use:melt={$menu} class="menu">
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div use:melt={$item} onclick={onClickPublicMenuItem} class="item">
-							<div class="icon"><IconWorld /></div>
+							<div class="icon"><PublicIcon /></div>
 							<div>{$_('pages.public')}</div>
 						</div>
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -219,7 +305,7 @@
 							onclick={async () => await goto(`/${nprofile}/lists`)}
 							class="item"
 						>
-							<div class="icon"><IconList /></div>
+							<div class="icon"><ListsIcon /></div>
 							<div>{$_('lists.title')}</div>
 						</div>
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -229,7 +315,7 @@
 							onclick={async () => await goto(`/${nprofile}/bookmarks`)}
 							class="item"
 						>
-							<div class="icon"><IconBookmark /></div>
+							<div class="icon"><BookmarksIcon /></div>
 							<div>{$_('layout.header.bookmarks')}</div>
 						</div>
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -239,7 +325,7 @@
 							onclick={async () => await goto('/channels')}
 							class="item"
 						>
-							<div class="icon"><IconMessages /></div>
+							<div class="icon"><ChannelsIcon /></div>
 							<div>{$_('layout.header.channels')}</div>
 						</div>
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -249,7 +335,7 @@
 							onclick={async () => await goto('/preferences')}
 							class="item"
 						>
-							<div class="icon"><IconSettings /></div>
+							<div class="icon"><PreferencesIcon /></div>
 							<div>{$_('layout.header.preferences')}</div>
 						</div>
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -259,21 +345,29 @@
 							onclick={async () => await goto('/about')}
 							class="item"
 						>
-							<div class="icon"><IconPaw /></div>
+							<div class="icon"><AboutIcon /></div>
 							<div>{$_('about.title')}</div>
 						</div>
 					</div>
 				</li>
 			{:else}
 				<li>
-					<a href="/channels" class="active">
-						<IconMessages size={30} />
+					<a
+						href="/channels"
+						class="active"
+						aria-current={currentNavigation === 'channels' ? 'page' : undefined}
+					>
+						<ChannelsIcon size={30} />
 						<p>{$_('layout.header.channels')}</p>
 					</a>
 				</li>
 				<li>
-					<a href="/about" class="active">
-						<IconPaw size={30} />
+					<a
+						href="/about"
+						class="active"
+						aria-current={currentNavigation === 'about' ? 'page' : undefined}
+					>
+						<AboutIcon size={30} />
 						<p>{$_('about.title')}</p>
 					</a>
 				</li>

--- a/web/src/routes/(app)/Header.svelte
+++ b/web/src/routes/(app)/Header.svelte
@@ -1,28 +1,30 @@
 <script lang="ts">
-	import IconHome from '@tabler/icons-svelte-runes/icons/home';
-	import IconHomeFilled from '@tabler/icons-svelte-runes/icons/home-filled';
-	import IconWorld from '@tabler/icons-svelte-runes/icons/world';
-	import IconWorldFilled from '@tabler/icons-svelte-runes/icons/world-filled';
-	import IconSearch from '@tabler/icons-svelte-runes/icons/search';
-	import IconSearchFilled from '@tabler/icons-svelte-runes/icons/search-filled';
-	import IconBell from '@tabler/icons-svelte-runes/icons/bell';
-	import IconBellFilled from '@tabler/icons-svelte-runes/icons/bell-filled';
-	import IconUser from '@tabler/icons-svelte-runes/icons/user';
-	import IconUserFilled from '@tabler/icons-svelte-runes/icons/user-filled';
-	import IconSettings from '@tabler/icons-svelte-runes/icons/settings';
-	import IconSettingsFilled from '@tabler/icons-svelte-runes/icons/settings-filled';
-	import IconList from '@tabler/icons-svelte-runes/icons/list';
-	import IconListFilled from '@tabler/icons-svelte-runes/icons/list-filled';
-	import IconBookmark from '@tabler/icons-svelte-runes/icons/bookmark';
-	import IconBookmarkFilled from '@tabler/icons-svelte-runes/icons/bookmark-filled';
-	import IconMessages from '@tabler/icons-svelte-runes/icons/messages';
-	import IconMessagesFilled from '@tabler/icons-svelte-runes/icons/messages-filled';
-	import IconPencilPlus from '@tabler/icons-svelte-runes/icons/pencil-plus';
-	import IconLogin from '@tabler/icons-svelte-runes/icons/login';
-	import IconDots from '@tabler/icons-svelte-runes/icons/dots';
-	import IconDotsFilled from '@tabler/icons-svelte-runes/icons/dots-filled';
-	import IconPaw from '@tabler/icons-svelte-runes/icons/paw';
-	import IconPawFilled from '@tabler/icons-svelte-runes/icons/paw-filled';
+	import {
+		IconBell,
+		IconBellFilled,
+		IconBookmark,
+		IconBookmarkFilled,
+		IconDots,
+		IconDotsFilled,
+		IconHome,
+		IconHomeFilled,
+		IconList,
+		IconListFilled,
+		IconLogin,
+		IconMessages,
+		IconMessagesFilled,
+		IconPaw,
+		IconPawFilled,
+		IconPencilPlus,
+		IconSearch,
+		IconSearchFilled,
+		IconSettings,
+		IconSettingsFilled,
+		IconUser,
+		IconUserFilled,
+		IconWorld,
+		IconWorldFilled
+	} from '@tabler/icons-svelte-runes';
 	import { nip19 } from 'nostr-tools';
 	import { _ } from 'svelte-i18n';
 	import { goto } from '$app/navigation';

--- a/web/src/routes/(app)/HeaderNavigation.test.ts
+++ b/web/src/routes/(app)/HeaderNavigation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { getCurrentHeaderNavigation, isMoreNavigationCurrent } from './HeaderNavigation';
+
+const userPubkey = 'user';
+const otherPubkey = 'other';
+
+describe('getCurrentHeaderNavigation', () => {
+	it.each([
+		['/(app)/home', 'home'],
+		['/(app)/public', 'public'],
+		['/(app)/search', 'search'],
+		['/(app)/notifications', 'notifications'],
+		['/(app)/channels/[nevent=note]', 'channels'],
+		['/(app)/preferences/display', 'preferences'],
+		['/(app)/about/licenses', 'about']
+	] as const)('%s is %s', (routeId, expected) => {
+		expect(getCurrentHeaderNavigation(routeId, undefined, userPubkey)).toBe(expected);
+	});
+
+	it('selects Public when the Home link also points to /public', () => {
+		const homeLink = '/public';
+		const current = getCurrentHeaderNavigation('/(app)/public', undefined, userPubkey);
+		const currentLinks = [
+			{ item: 'home', href: homeLink },
+			{ item: 'public', href: '/public' }
+		].filter(({ item }) => item === current);
+
+		expect(currentLinks).toEqual([{ item: 'public', href: '/public' }]);
+	});
+
+	it.each([
+		['/(app)/[slug=npub]/(tabs)/lists', 'lists'],
+		['/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]', 'lists'],
+		['/(app)/[slug=npub]/(tabs)/lists/[naddr=naddr]/members', 'lists'],
+		['/(app)/[slug=npub]/bookmarks', 'bookmarks'],
+		['/(app)/[slug=npub]/bookmarks/archive', 'bookmarks'],
+		['/(app)/[slug=npub]/(tabs)', 'profile'],
+		['/(app)/[slug=npub]/(tabs)/media', 'profile'],
+		['/(app)/[slug=npub]/followers', 'profile']
+	] as const)('classifies the current user route %s as %s', (routeId, expected) => {
+		expect(getCurrentHeaderNavigation(routeId, userPubkey, userPubkey)).toBe(expected);
+	});
+
+	it.each([
+		'/(app)/[slug=npub]/(tabs)',
+		'/(app)/[slug=npub]/(tabs)/lists',
+		'/(app)/[slug=npub]/bookmarks'
+	])('does not select the current-user navigation for another user at %s', (routeId) => {
+		expect(getCurrentHeaderNavigation(routeId, otherPubkey, userPubkey)).toBeUndefined();
+	});
+
+	it('does not select Profile for Lists or Bookmarks', () => {
+		expect(
+			['/(app)/[slug=npub]/(tabs)/lists', '/(app)/[slug=npub]/bookmarks'].map((routeId) =>
+				getCurrentHeaderNavigation(routeId, userPubkey, userPubkey)
+			)
+		).toEqual(['lists', 'bookmarks']);
+	});
+});
+
+describe('isMoreNavigationCurrent', () => {
+	it.each(['public', 'lists', 'bookmarks', 'channels', 'preferences', 'about'] as const)(
+		'returns true for %s',
+		(navigation) => {
+			expect(isMoreNavigationCurrent(navigation)).toBe(true);
+		}
+	);
+
+	it.each(['home', 'search', 'notifications', 'profile', undefined] as const)(
+		'returns false for %s',
+		(navigation) => {
+			expect(isMoreNavigationCurrent(navigation)).toBe(false);
+		}
+	);
+});

--- a/web/src/routes/(app)/HeaderNavigation.ts
+++ b/web/src/routes/(app)/HeaderNavigation.ts
@@ -1,0 +1,68 @@
+export const headerNavigationItems = [
+	'home',
+	'public',
+	'search',
+	'notifications',
+	'lists',
+	'bookmarks',
+	'channels',
+	'profile',
+	'preferences',
+	'about'
+] as const;
+
+export type HeaderNavigationItem = (typeof headerNavigationItems)[number];
+
+const profileRoute = '/(app)/[slug=npub]';
+const listsRoute = `${profileRoute}/(tabs)/lists`;
+const bookmarksRoute = `${profileRoute}/bookmarks`;
+
+function isRouteOrChild(routeId: string, route: string): boolean {
+	return routeId === route || routeId.startsWith(`${route}/`);
+}
+
+export function getCurrentHeaderNavigation(
+	routeId: string | null,
+	pagePubkey: string | undefined,
+	userPubkey: string | undefined
+): HeaderNavigationItem | undefined {
+	if (routeId === null) {
+		return undefined;
+	}
+
+	if (isRouteOrChild(routeId, '/(app)/home')) return 'home';
+	if (isRouteOrChild(routeId, '/(app)/public')) return 'public';
+	if (isRouteOrChild(routeId, '/(app)/search')) return 'search';
+	if (isRouteOrChild(routeId, '/(app)/notifications')) return 'notifications';
+	if (isRouteOrChild(routeId, '/(app)/channels')) return 'channels';
+	if (isRouteOrChild(routeId, '/(app)/preferences')) return 'preferences';
+	if (isRouteOrChild(routeId, '/(app)/about')) return 'about';
+
+	if (
+		!isRouteOrChild(routeId, profileRoute) ||
+		userPubkey === undefined ||
+		pagePubkey !== userPubkey
+	) {
+		return undefined;
+	}
+
+	if (isRouteOrChild(routeId, listsRoute)) return 'lists';
+	if (isRouteOrChild(routeId, bookmarksRoute)) return 'bookmarks';
+
+	return 'profile';
+}
+
+const moreNavigationItems = new Set<HeaderNavigationItem>([
+	'public',
+	'lists',
+	'bookmarks',
+	'channels',
+	'preferences',
+	'about'
+]);
+
+export function isMoreNavigationCurrent(
+	currentNavigation: HeaderNavigationItem | undefined
+): boolean {
+	return currentNavigation !== undefined && moreNavigationItems.has(currentNavigation);
+}


### PR DESCRIPTION
## Summary

- determine the current header navigation from SvelteKit route IDs
- switch the current item from Tabler's outline icon to its official filled variant
- expose the same current state through `aria-current="page"`

## Implementation

- Use `page.route.id` to classify Home, Public, Search, Notifications, Channels, Preferences, About, and their child routes.
- Use the decoded `page.data.pubkey` from the existing `[slug=npub]` layout and compare it with the logged-in pubkey for user-specific navigation.
- Classify Lists and Bookmarks before Profile so those states cannot collide. Other users' profile routes do not activate the current user's Profile navigation.
- Treat `/public` as Public even when `homeLink === '/public'`, keeping a maximum of one current item per navigation set.
- Reuse the same current state for desktop and mobile. When a current item is inside the mobile More menu, the Dots icon uses its filled variant; the More button itself does not receive `aria-current`.
- Keep existing foreground colors, hover backgrounds, timeline scroll-to-top behavior, modifier-key behavior, notification badge, More navigation, and post button unchanged.

## Validation

- `npm run format` — passed
- `npm run lint` — passed
- `npm run check` — passed (0 errors, 0 warnings)
- `npm test -- --run` — passed (19 files, 251 tests)
- `npm run build` — passed (existing unused-import and chunk-size warnings only)

Closes #649