### PR TITLE
Document browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ javascript:window.open(`https://nostter.app/post?content=${document.title}%20${l
 
 See full list at [package.json](web/package.json)
 
+## Browser compatibility
+
+Known not to work: Chrome 118 and earlier, Firefox 120 and earlier, Safari/iOS Safari 17.3 and earlier.
+
 ## Contribution
 
 Welcome issues, pull requests and discussions.


### PR DESCRIPTION
## Summary

- add a minimal browser compatibility note to README
- list browser versions that are known not to work

## Why

nostter uses modern Web APIs such as `Promise.withResolvers()`, so some older browser versions are known to be incompatible. This documents those known incompatibilities without defining a formal browser support matrix.

## Validation

Documentation-only change; no runtime checks required.