### PR TITLE
Remove obsolete @types/emoji-mart dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -44,7 +44,6 @@
 				"@sveltejs/vite-plugin-svelte": "^7.2.0",
 				"@types/async-lock": "^1.4.2",
 				"@types/beyonk__gdpr-cookie-consent-banner": "^9.0.4",
-				"@types/emoji-mart": "^3.0.14",
 				"@types/qrcode": "^1.5.6",
 				"@types/twitter-text": "^3.1.10",
 				"esbuild": "^0.27.3",
@@ -1199,9 +1198,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1219,9 +1215,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1239,9 +1232,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1259,9 +1249,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1279,9 +1266,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1299,9 +1283,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1319,9 +1300,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1339,9 +1317,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1359,9 +1334,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1385,9 +1357,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1411,9 +1380,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1437,9 +1403,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1463,9 +1426,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1489,9 +1449,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1515,9 +1472,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1541,9 +1495,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2018,9 +1969,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2038,9 +1986,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2058,9 +2003,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2078,9 +2020,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2098,9 +2037,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2118,9 +2054,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2556,15 +2489,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/emoji-mart": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/@types/emoji-mart/-/emoji-mart-3.0.14.tgz",
-			"integrity": "sha512-/vMkVnet466bK37ugf2jry9ldCZklFPXYMB2m+qNo3vkP2I7L0cvtNFPKAjfcHgPg9Z8pbYqVqZn7AgsC0qf+g==",
-			"dev": true,
-			"dependencies": {
-				"@types/react": "*"
-			}
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2594,12 +2518,6 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
-		"node_modules/@types/prop-types": {
-			"version": "15.7.5",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-			"dev": true
-		},
 		"node_modules/@types/qrcode": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -2609,23 +2527,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/react": {
-			"version": "18.2.21",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-			"integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
-			"dev": true,
-			"dependencies": {
-				"@types/prop-types": "*",
-				"@types/scheduler": "*",
-				"csstype": "^3.0.2"
-			}
-		},
-		"node_modules/@types/scheduler": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-			"integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-			"dev": true
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -3539,12 +3440,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/csstype": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-			"dev": true
 		},
 		"node_modules/d": {
 			"version": "1.0.1",
@@ -5881,9 +5776,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5905,9 +5797,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5929,9 +5818,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5953,9 +5839,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,6 @@
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"@types/async-lock": "^1.4.2",
 		"@types/beyonk__gdpr-cookie-consent-banner": "^9.0.4",
-		"@types/emoji-mart": "^3.0.14",
 		"@types/qrcode": "^1.5.6",
 		"@types/twitter-text": "^3.1.10",
 		"esbuild": "^0.27.3",

--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -4,7 +4,6 @@
 
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
-	import type { BaseEmoji } from 'emoji-mart';
 	import data from '@emoji-mart/data';
 	import IconMoodSmile from '@tabler/icons-svelte-runes/icons/mood-smile';
 	import { customEmojiTags } from '../author/CustomEmojis';
@@ -17,6 +16,8 @@
 		children?: import('svelte').Snippet;
 		inEditor?: boolean;
 	}
+
+	type PickerEmoji = { id: string; native?: string; src?: string };
 
 	let {
 		containsDefaultEmoji = true,
@@ -107,7 +108,7 @@
 		return custom;
 	}
 
-	function onEmojiSelect(emoji: BaseEmoji): void {
+	function onEmojiSelect(emoji: PickerEmoji): void {
 		dispatch('pick', emoji);
 		if (autoClose) {
 			popover.open = false;


### PR DESCRIPTION
### Motivation

- `@types/emoji-mart` is a deprecated stub package and is no longer needed because the project uses `emoji-kitchen-mart` at runtime.  
- Avoid pulling `emoji-mart` into the dependency graph via the stub package.  
- Make the `EmojiPicker.svelte` types match the actual data produced by `emoji-kitchen-mart` without changing runtime behavior.

### Description

- Removed `@types/emoji-mart` from `web/package.json` devDependencies.  
- Removed the corresponding `node_modules/@types/emoji-mart` entry and root devDependency reference from `web/package-lock.json`.  
- Replaced the `BaseEmoji` type import in `web/src/lib/components/EmojiPicker.svelte` with a local type `type PickerEmoji = { id: string; native?: string; src?: string }` and updated `onEmojiSelect` to accept `PickerEmoji`.  
- Preserved existing runtime behavior: `dispatch('pick', emoji)` and `autoClose` logic remain unchanged, and `emoji-kitchen-mart` dependency/version were not modified.

### Testing

- Ran `npm run check`, `npm run lint`, and `npm test` in `web` and they succeeded: `svelte-check` reported 0 errors/warnings, lint passed, and tests ran with 20 files / 255 tests passed.  
- Verified that `@types/emoji-mart` no longer appears in `web/package.json` or `web/package-lock.json` and that `emoji-mart` was not added to the lockfile, and that `emoji-kitchen-mart` remains at `^6.0.5`.  
- Changes were committed on branch `remove-obsolete-emoji-mart-types`; creation of a remote PR was not performed because the environment was not authenticated to GitHub (`gh auth` not configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f9e30cb9c832ebf7e56df73443aa3)