### PR TITLE
Remove obsolete emoji-mart types and type EmojiPicker callbacks

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -44,7 +44,6 @@
 				"@sveltejs/vite-plugin-svelte": "^7.2.0",
 				"@types/async-lock": "^1.4.2",
 				"@types/beyonk__gdpr-cookie-consent-banner": "^9.0.4",
-				"@types/emoji-mart": "^3.0.14",
 				"@types/qrcode": "^1.5.6",
 				"@types/twitter-text": "^3.1.10",
 				"esbuild": "^0.27.3",
@@ -2556,15 +2555,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/emoji-mart": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/@types/emoji-mart/-/emoji-mart-3.0.14.tgz",
-			"integrity": "sha512-/vMkVnet466bK37ugf2jry9ldCZklFPXYMB2m+qNo3vkP2I7L0cvtNFPKAjfcHgPg9Z8pbYqVqZn7AgsC0qf+g==",
-			"dev": true,
-			"dependencies": {
-				"@types/react": "*"
-			}
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2594,12 +2584,6 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
-		"node_modules/@types/prop-types": {
-			"version": "15.7.5",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-			"dev": true
-		},
 		"node_modules/@types/qrcode": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -2609,23 +2593,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/react": {
-			"version": "18.2.21",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-			"integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
-			"dev": true,
-			"dependencies": {
-				"@types/prop-types": "*",
-				"@types/scheduler": "*",
-				"csstype": "^3.0.2"
-			}
-		},
-		"node_modules/@types/scheduler": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-			"integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-			"dev": true
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -3539,12 +3506,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/csstype": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-			"dev": true
 		},
 		"node_modules/d": {
 			"version": "1.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,6 @@
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"@types/async-lock": "^1.4.2",
 		"@types/beyonk__gdpr-cookie-consent-banner": "^9.0.4",
-		"@types/emoji-mart": "^3.0.14",
 		"@types/qrcode": "^1.5.6",
 		"@types/twitter-text": "^3.1.10",
 		"esbuild": "^0.27.3",

--- a/web/src/lib/Emoji.ts
+++ b/web/src/lib/Emoji.ts
@@ -3,8 +3,14 @@ export type Emoji = {
 	url?: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function toEmoji(emoji: any): Emoji {
+export type PickerEmoji = {
+	id: string;
+	native?: string;
+	shortcodes?: string;
+	src?: string;
+};
+
+export function toEmoji(emoji: PickerEmoji): Emoji {
 	if (emoji.native !== undefined) {
 		return {
 			content: emoji.native

--- a/web/src/lib/components/EmojiPicker.svelte
+++ b/web/src/lib/components/EmojiPicker.svelte
@@ -3,11 +3,10 @@
 </script>
 
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
-	import type { BaseEmoji } from 'emoji-mart';
 	import data from '@emoji-mart/data';
 	import IconMoodSmile from '@tabler/icons-svelte-runes/icons/mood-smile';
 	import { customEmojiTags } from '../author/CustomEmojis';
+	import type { PickerEmoji } from '$lib/Emoji';
 	import { _ } from 'svelte-i18n';
 	import { Popover } from 'melt/builders';
 
@@ -16,13 +15,15 @@
 		autoClose?: boolean;
 		children?: import('svelte').Snippet;
 		inEditor?: boolean;
+		onPick?: (emoji: PickerEmoji) => void;
 	}
 
 	let {
 		containsDefaultEmoji = true,
 		autoClose = true,
 		children,
-		inEditor = false
+		inEditor = false,
+		onPick
 	}: Props = $props();
 
 	let emojiPicker: HTMLElement | undefined | null = $state();
@@ -30,8 +31,6 @@
 	let PickerConstructor = $state<typeof import('emoji-kitchen-mart').Picker>();
 
 	const popover = new Popover();
-
-	const dispatch = createEventDispatcher();
 
 	$effect(() => {
 		if (PickerConstructor || !popover.open) {
@@ -107,8 +106,8 @@
 		return custom;
 	}
 
-	function onEmojiSelect(emoji: BaseEmoji): void {
-		dispatch('pick', emoji);
+	function onEmojiSelect(emoji: PickerEmoji): void {
+		onPick?.(emoji);
 		if (autoClose) {
 			popover.open = false;
 		}

--- a/web/src/lib/components/actions/ActionMenu.svelte
+++ b/web/src/lib/components/actions/ActionMenu.svelte
@@ -17,6 +17,7 @@
 	import SeenOnRelays from '../SeenOnRelays.svelte';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import CodePoints from './CodePoints.svelte';
+	import type { PickerEmoji } from '$lib/Emoji';
 
 	interface Props {
 		item: EventItem;
@@ -45,8 +46,7 @@
 		$openNoteDialog = true;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async function emojiReaction(note: Nostr.Event, emoji: any) {
+	async function emojiReaction(note: Nostr.Event, emoji: PickerEmoji) {
 		console.log('[reaction with emoji]', note, emoji);
 
 		if ($rom) {
@@ -74,7 +74,7 @@
 	<RepostButton event={item.event} {iconSize} />
 	<ReactionButton event={item.event} {iconSize} />
 	<span>
-		<EmojiPicker on:pick={({ detail }) => emojiReaction(item.event, detail)} />
+		<EmojiPicker onPick={(emoji) => emojiReaction(item.event, emoji)} />
 	</span>
 	<button
 		class="zap"

--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -29,6 +29,7 @@
 	import CustomEmoji from '../content/CustomEmoji.svelte';
 	import ContentWarning from './ContentWarning.svelte';
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
+	import type { PickerEmoji } from '$lib/Emoji';
 	import ProfileIcon from '../profile/ProfileIcon.svelte';
 	import Loading from '$lib/components/Loading.svelte';
 	import { SvelteMap } from 'svelte/reactivity';
@@ -414,8 +415,7 @@
 		mention = undefined;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async function onEmojiPick({ detail: emoji }: { detail: any }): Promise<void> {
+	async function onEmojiPick(emoji: PickerEmoji): Promise<void> {
 		if (textarea === undefined) {
 			return;
 		}
@@ -711,7 +711,7 @@
 				containsDefaultEmoji={false}
 				autoClose={false}
 				inEditor={true}
-				on:pick={onEmojiPick}
+				onPick={onEmojiPick}
 			/>
 			<button class="clear editor-option advanced" {...collapsible.trigger}>
 				{$_('editor.options.advanced')}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -14,6 +14,7 @@
 	import { metadataStore } from '$lib/cache/Events';
 	import { alternativeName } from '$lib/Items';
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
+	import type { PickerEmoji } from '$lib/Emoji';
 	import MediaPicker from '$lib/components/MediaPicker.svelte';
 	import { composerFocus } from './ComposerFocus.svelte';
 
@@ -90,8 +91,7 @@
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async function onEmojiPick({ detail: emoji }: { detail: any }): Promise<void> {
+	async function onEmojiPick(emoji: PickerEmoji): Promise<void> {
 		if (textarea === undefined) {
 			return;
 		}
@@ -186,7 +186,7 @@
 	{/if}
 	<div class="input">
 		<MediaPicker multiple={true} on:pick={mediaPicked} />
-		<EmojiPicker inEditor={true} on:pick={onEmojiPick} />
+		<EmojiPicker inEditor={true} onPick={onEmojiPick} />
 		<textarea
 			bind:this={textarea}
 			bind:value={content}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelMessage.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelMessage.svelte
@@ -14,6 +14,7 @@
 	import ReactionButton from '$lib/components/ReactionButton.svelte';
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
 	import ZapDialog from '$lib/components/ZapDialog.svelte';
+	import type { PickerEmoji } from '$lib/Emoji';
 
 	interface Props {
 		event: Event;
@@ -40,8 +41,7 @@
 		onSelect?.(event.id);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	function emojiReaction(emoji: any): void {
+	function emojiReaction(emoji: PickerEmoji): void {
 		if ($rom) {
 			return;
 		}
@@ -87,7 +87,7 @@
 			{/if}
 			<ReactionButton {event} iconSize={20} />
 			<span class="emoji">
-				<EmojiPicker on:pick={({ detail }) => emojiReaction(detail)} />
+				<EmojiPicker onPick={emojiReaction} />
 			</span>
 			<button
 				class="clear"

--- a/web/src/routes/(app)/preferences/ReactionEmoji.svelte
+++ b/web/src/routes/(app)/preferences/ReactionEmoji.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
-	import { toEmoji } from '$lib/Emoji';
+	import { toEmoji, type PickerEmoji } from '$lib/Emoji';
 	import { preferencesStore, savePreferences } from '$lib/Preferences';
 	import IconHeart from '@tabler/icons-svelte-runes/icons/heart';
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
 	import CustomEmoji from '$lib/components/content/CustomEmoji.svelte';
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async function save({ detail }: { detail: any }) {
-		const emoji = toEmoji(detail);
+	async function save(pickerEmoji: PickerEmoji) {
+		const emoji = toEmoji(pickerEmoji);
 		console.log('[reaction emoji save]', emoji, $preferencesStore.reactionEmoji);
 
 		if (
@@ -25,7 +24,7 @@
 </script>
 
 <span>{$_('preferences.emoji.like')}:</span>
-<EmojiPicker on:pick={save}>
+<EmojiPicker onPick={save}>
 	{#if $preferencesStore.reactionEmoji.content === '+'}
 		<IconHeart size={26} color="lightpink" />
 	{:else if $preferencesStore.reactionEmoji.url !== undefined}


### PR DESCRIPTION
## Summary

- Remove obsolete `@types/emoji-mart`, which described a different package than the runtime `emoji-kitchen-mart` implementation.
- Add the app-owned `PickerEmoji` boundary type with only the fields nostter consumes: `id`, `native`, `shortcodes`, and `src`.
- Type EmojiPicker consumers with `PickerEmoji` and remove their emoji-related `any` usage.
- Replace the EmojiPicker `createEventDispatcher` / `on:pick` component event with the Svelte 5 `onPick` callback prop.

## Runtime behavior

The existing picker UI, normal emoji/custom emoji/Emoji Kitchen selection logic, reaction behavior, conversion logic, and `autoClose` behavior are unchanged.

`emojiPicker.appendChild(picker as any)` remains unchanged. `emoji-kitchen-mart`'s published declaration models `Picker` through its own `HTMLElement` hierarchy but does not expose it as a DOM `Node`/`HTMLElement` accepted by `appendChild`. Replacing this with a double assertion would only hide the upstream declaration gap without adding type safety.

## Validation

- `npm ci` — passed
- `npm run check` — passed (0 errors, 0 warnings)
- `npm run lint` — passed
- `npm test` — passed (20 files, 255 tests)
- `npm run build` — passed
- `npm run test:e2e` — web server and build passed, but the single test could not launch because the environment does not have the Playwright Chromium executable installed
- Searches confirmed no `@types/emoji-mart`, `BaseEmoji`, EmojiPicker `createEventDispatcher`, EmojiPicker `on:pick`, or emoji consumer `any` remains
- Confirmed `emoji-mart` was not added and `emoji-kitchen-mart` remains at `^6.0.5` (`6.0.5` in the lockfile)
