### PR TITLE
Add Blossom media uploader

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
 				"@rust-nostr/nostr-sdk": "^0.44.0",
 				"@tabler/icons-svelte-runes": "^3.46.0",
 				"async-lock": "^1.4.1",
+				"blossom-client-sdk": "^5.0.0",
 				"dexie": "^4.4.2",
 				"emoji-kitchen-mart": "^6.0.5",
 				"escape-string-regexp": "^5.0.0",
@@ -1839,9 +1840,9 @@
 			}
 		},
 		"node_modules/@noble/hashes": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-			"integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+			"integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
 			"license": "MIT",
 			"engines": {
 				"node": "^14.21.3 || >=16"
@@ -3273,6 +3274,30 @@
 			"integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/blossom-client-sdk": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/blossom-client-sdk/-/blossom-client-sdk-5.0.0.tgz",
+			"integrity": "sha512-xz7w6eBQv6uiNK9ogh5AymnzCAohiU029XySpKxJyG7RsDHkoru+xoZhY55tiIOyWFX/5s8pip4hVh5hO1PN/Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "^1.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cashu/cashu-ts": "^2.4.3",
+				"hls.js": "^1.6.16"
+			},
+			"peerDependenciesMeta": {
+				"@cashu/cashu-ts": {
+					"optional": true
+				},
+				"hls.js": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/bundle-name": {
 			"version": "4.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,7 @@
 		"@rust-nostr/nostr-sdk": "^0.44.0",
 		"@tabler/icons-svelte-runes": "^3.46.0",
 		"async-lock": "^1.4.1",
+		"blossom-client-sdk": "^5.0.0",
 		"dexie": "^4.4.2",
 		"emoji-kitchen-mart": "^6.0.5",
 		"escape-string-regexp": "^5.0.0",

--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -36,7 +36,7 @@ import {
 	getAccountLocalPreferences,
 	initializeMediaUploaderPreference
 } from './preferences/AccountLocalPreferences';
-import { updateBlossomServerList } from './author/BlossomServerList';
+import { updateBlossomServerList } from './author/BlossomServerList.svelte';
 
 export class Author {
 	constructor(private pubkey: string) {}

--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -8,7 +8,6 @@ import {
 	updateRelays,
 	authorProfile,
 	metadataEvent,
-	blossomServerListEvent,
 	isMuteEvent,
 	storeMutedPubkeysByKind,
 	storeMutedTagsByEvent
@@ -37,6 +36,7 @@ import {
 	getAccountLocalPreferences,
 	initializeMediaUploaderPreference
 } from './preferences/AccountLocalPreferences';
+import { updateBlossomServerList } from './author/BlossomServerList';
 
 export class Author {
 	constructor(private pubkey: string) {}
@@ -113,7 +113,6 @@ export class Author {
 		auth.updateFollowees(contactsTags);
 
 		customEmojiListEvent.set(replaceableEvents.get(Kind.UserEmojiList));
-		blossomServerListEvent.set(replaceableEvents.get(Kind.BlossomServerList));
 		const $customEmojiListEvent = get(customEmojiListEvent);
 		if ($customEmojiListEvent !== undefined) {
 			storeCustomEmojis($customEmojiListEvent);
@@ -150,6 +149,7 @@ export class Author {
 			getAccountLocalPreferences(this.pubkey),
 			legacyMediaUploader
 		);
+		updateBlossomServerList(this.pubkey, replaceableEvents.get(Kind.BlossomServerList));
 
 		const lastReadEvent = parameterizedReplaceableEvents.get(`${30078}:nostter-read`);
 		const regacyLastReadEvent = parameterizedReplaceableEvents.get(

--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -8,6 +8,7 @@ import {
 	updateRelays,
 	authorProfile,
 	metadataEvent,
+	blossomServerListEvent,
 	isMuteEvent,
 	storeMutedPubkeysByKind,
 	storeMutedTagsByEvent
@@ -32,6 +33,10 @@ import { bookmarkEvent } from './author/Bookmark';
 import { profileBadgesEvent, profileBadgesKey } from './author/ProfileBadges';
 import { contactsOfFolloweesReqEmit } from './author/MuteAutomatically';
 import { notificationVisibility } from './preferences/NotificationVisibility.svelte';
+import {
+	getAccountLocalPreferences,
+	initializeMediaUploaderPreference
+} from './preferences/AccountLocalPreferences';
 
 export class Author {
 	constructor(private pubkey: string) {}
@@ -108,6 +113,7 @@ export class Author {
 		auth.updateFollowees(contactsTags);
 
 		customEmojiListEvent.set(replaceableEvents.get(Kind.UserEmojiList));
+		blossomServerListEvent.set(replaceableEvents.get(Kind.BlossomServerList));
 		const $customEmojiListEvent = get(customEmojiListEvent);
 		if ($customEmojiListEvent !== undefined) {
 			storeCustomEmojis($customEmojiListEvent);
@@ -117,8 +123,10 @@ export class Author {
 		profileBadgesEvent.set(parameterizedReplaceableEvents.get(profileBadgesKey));
 
 		const preferencesEvent = parameterizedReplaceableEvents.get(`${30078}:nostter-preferences`);
+		let legacyMediaUploader: string | undefined;
 		if (preferencesEvent !== undefined) {
 			const preferences = new Preferences(preferencesEvent.content);
+			legacyMediaUploader = preferences.mediaUploader;
 			preferencesStore.set(preferences);
 
 			if (
@@ -138,6 +146,10 @@ export class Author {
 				preferencesStore.set(preferences);
 			}
 		}
+		initializeMediaUploaderPreference(
+			getAccountLocalPreferences(this.pubkey),
+			legacyMediaUploader
+		);
 
 		const lastReadEvent = parameterizedReplaceableEvents.get(`${30078}:nostter-read`);
 		const regacyLastReadEvent = parameterizedReplaceableEvents.get(

--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -15,6 +15,7 @@ export const maxFilters = 10;
 export const timelineBufferMs = 1500;
 export const timeout = 5000;
 export const nip46ConnectTimeout = 10000;
+export const defaultBlossomServerUrl = 'https://blossom.band';
 
 export const hexRegexp = /^[0-9a-f]{64}$/;
 export const addressRegexp = /^[0-9]+:[0-9a-f]{64}:.*$/;

--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -31,7 +31,8 @@ export const replaceableKinds = [
 	Kind.RelayList,
 	10005,
 	10015,
-	10030
+	10030,
+	Kind.BlossomServerList
 ];
 export const parameterizedReplaceableKinds = [30000, 30001, 30007, 30008, 30078];
 

--- a/web/src/lib/author/BlossomServerList.svelte.ts
+++ b/web/src/lib/author/BlossomServerList.svelte.ts
@@ -1,6 +1,5 @@
 import type { Event } from 'nostr-tools';
 import { getServersFromServerListEvent } from 'blossom-client-sdk/nostr';
-import { writable } from 'svelte/store';
 import { defaultBlossomServerUrl } from '$lib/Constants';
 import {
 	getAccountLocalPreferences,
@@ -8,7 +7,11 @@ import {
 } from '$lib/preferences/AccountLocalPreferences';
 
 export { defaultBlossomServerUrl } from '$lib/Constants';
-export const blossomServer = writable<URL | undefined>();
+let blossomServer = $state<URL | undefined>();
+
+export function getBlossomServer(): URL | undefined {
+	return blossomServer;
+}
 
 export function resolveBlossomServer(event: Event): URL {
 	return (
@@ -30,12 +33,12 @@ function withBlossomServer(
 
 export function updateBlossomServerList(pubkey: string, event: Event | undefined): void {
 	if (event === undefined) {
-		blossomServer.set(undefined);
+		blossomServer = undefined;
 		return;
 	}
 
 	const server = resolveBlossomServer(event);
-	blossomServer.set(server);
+	blossomServer = server;
 	getAccountLocalPreferences(pubkey).update((preferences) =>
 		withBlossomServer(preferences, server)
 	);

--- a/web/src/lib/author/BlossomServerList.test.ts
+++ b/web/src/lib/author/BlossomServerList.test.ts
@@ -1,11 +1,57 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Event } from 'nostr-tools';
-import { withBlossomServer } from './BlossomServerList';
+import { get, writable } from 'svelte/store';
+import type { AccountLocalPreferences } from '$lib/preferences/AccountLocalPreferences';
+
+const { preferencesByPubkey } = vi.hoisted(() => ({
+	preferencesByPubkey: new Map<string, ReturnType<typeof writable<AccountLocalPreferences>>>()
+}));
+
+vi.mock('$lib/preferences/AccountLocalPreferences', () => ({
+	getAccountLocalPreferences: (pubkey: string) => {
+		let preferences = preferencesByPubkey.get(pubkey);
+		if (preferences === undefined) {
+			preferences = writable({});
+			preferencesByPubkey.set(pubkey, preferences);
+		}
+		return preferences;
+	}
+}));
+
+import {
+	blossomServer,
+	resolveBlossomServer,
+	updateBlossomServerList,
+	withBlossomServer
+} from './BlossomServerList';
 
 const serverList = (tags: string[][]): Event =>
 	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
 
-describe('withBlossomServer', () => {
+describe('resolveBlossomServer', () => {
+	it('selects the first HTTPS server in SDK-parsed tag order', () => {
+		const event = serverList([
+			['server', 'not a URL'],
+			['server', 'http://insecure.example'],
+			['server', 'https://first.example/path'],
+			['server', 'https://second.example']
+		]);
+		expect(resolveBlossomServer(event).href).toBe('https://first.example/');
+	});
+
+	it('does not select HTTP and falls back when no HTTPS server exists', () => {
+		expect(resolveBlossomServer(serverList([['server', 'http://insecure.example']])).href).toBe(
+			'https://blossom.band/'
+		);
+	});
+});
+
+describe('Blossom server list state', () => {
+	beforeEach(() => {
+		preferencesByPubkey.clear();
+		blossomServer.set(undefined);
+	});
+
 	it('updates the persisted server while Blossom is selected', () => {
 		expect(
 			withBlossomServer(
@@ -13,7 +59,7 @@ describe('withBlossomServer', () => {
 					mediaUploader: { type: 'blossom', server: 'https://blossom.band' },
 					futurePreference: true
 				} as never,
-				serverList([['server', 'https://cdn.example.com']])
+				new URL('https://cdn.example.com')
 			)
 		).toEqual({
 			mediaUploader: { type: 'blossom', server: 'https://cdn.example.com/' },
@@ -25,10 +71,12 @@ describe('withBlossomServer', () => {
 		expect(
 			withBlossomServer(
 				{ mediaUploader: { type: 'blossom', server: 'https://previous.example' } },
-				serverList([
-					['server', 'not a URL'],
-					['server', 'http://insecure.example']
-				])
+				resolveBlossomServer(
+					serverList([
+						['server', 'not a URL'],
+						['server', 'http://insecure.example']
+					])
+				)
 			).mediaUploader
 		).toEqual({ type: 'blossom', server: 'https://blossom.band/' });
 	});
@@ -37,8 +85,46 @@ describe('withBlossomServer', () => {
 		const preferences = {
 			mediaUploader: { type: 'nip96' as const, server: 'https://nostr.build' }
 		};
-		expect(
-			withBlossomServer(preferences, serverList([['server', 'https://cdn.example.com']]))
-		).toBe(preferences);
+		expect(withBlossomServer(preferences, new URL('https://cdn.example.com'))).toBe(
+			preferences
+		);
+	});
+
+	it.each(['cached', 'live'])('uses the same update entry point for a %s event', (source) => {
+		const pubkey = `${source}-account`;
+		preferencesByPubkey.set(
+			pubkey,
+			writable({ mediaUploader: { type: 'blossom', server: 'https://previous.example' } })
+		);
+		updateBlossomServerList(pubkey, serverList([['server', `https://${source}.example`]]));
+		expect(get(blossomServer)?.href).toBe(`https://${source}.example/`);
+		expect(get(preferencesByPubkey.get(pubkey)!)).toEqual({
+			mediaUploader: { type: 'blossom', server: `https://${source}.example/` }
+		});
+	});
+
+	it('updates memory but preserves a NIP-96 selection and server', () => {
+		const preferences = writable<AccountLocalPreferences>({
+			mediaUploader: { type: 'nip96', server: 'https://nostr.build' }
+		});
+		preferencesByPubkey.set('alice', preferences);
+		updateBlossomServerList('alice', serverList([['server', 'https://cdn.example.com']]));
+		expect(get(blossomServer)?.href).toBe('https://cdn.example.com/');
+		expect(get(preferences)).toEqual({
+			mediaUploader: { type: 'nip96', server: 'https://nostr.build' }
+		});
+	});
+
+	it('clears memory for an undefined event without overwriting the last-known server', () => {
+		const preferences = writable<AccountLocalPreferences>({
+			mediaUploader: { type: 'blossom', server: 'https://previous.example' }
+		});
+		preferencesByPubkey.set('alice', preferences);
+		blossomServer.set(new URL('https://current.example'));
+		updateBlossomServerList('alice', undefined);
+		expect(get(blossomServer)).toBeUndefined();
+		expect(get(preferences)).toEqual({
+			mediaUploader: { type: 'blossom', server: 'https://previous.example' }
+		});
 	});
 });

--- a/web/src/lib/author/BlossomServerList.test.ts
+++ b/web/src/lib/author/BlossomServerList.test.ts
@@ -22,7 +22,11 @@ vi.mock('$lib/preferences/AccountLocalPreferences', () => ({
 }));
 vi.mock(import('blossom-client-sdk/nostr'), () => ({ getServersFromServerListEvent }));
 
-import { blossomServer, resolveBlossomServer, updateBlossomServerList } from './BlossomServerList';
+import {
+	getBlossomServer,
+	resolveBlossomServer,
+	updateBlossomServerList
+} from './BlossomServerList.svelte';
 
 const serverList = (tags: string[][]): Event =>
 	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
@@ -47,7 +51,7 @@ describe('resolveBlossomServer', () => {
 describe('Blossom server list state', () => {
 	beforeEach(() => {
 		preferencesByPubkey.clear();
-		blossomServer.set(undefined);
+		updateBlossomServerList('reset', undefined);
 		getServersFromServerListEvent.mockReset();
 	});
 
@@ -62,7 +66,7 @@ describe('Blossom server list state', () => {
 			} as never)
 		);
 		updateBlossomServerList(pubkey, serverList([]));
-		expect(get(blossomServer)?.href).toBe('https://cdn.example/');
+		expect(getBlossomServer()?.href).toBe('https://cdn.example/');
 		expect(get(preferencesByPubkey.get(pubkey)!)).toEqual({
 			mediaUploader: { type: 'blossom', server: 'https://cdn.example/' },
 			futurePreference: true
@@ -76,7 +80,7 @@ describe('Blossom server list state', () => {
 		});
 		preferencesByPubkey.set('alice', preferences);
 		updateBlossomServerList('alice', serverList([]));
-		expect(get(blossomServer)?.href).toBe('https://cdn.example/');
+		expect(getBlossomServer()?.href).toBe('https://cdn.example/');
 		expect(get(preferences)).toEqual({
 			mediaUploader: { type: 'nip96', server: 'https://nostr.build' }
 		});
@@ -87,9 +91,10 @@ describe('Blossom server list state', () => {
 			mediaUploader: { type: 'blossom', server: 'https://previous.example' }
 		});
 		preferencesByPubkey.set('alice', preferences);
-		blossomServer.set(new URL('https://current.example'));
+		getServersFromServerListEvent.mockReturnValue([new URL('https://current.example')]);
+		updateBlossomServerList('state-setup', serverList([]));
 		updateBlossomServerList('alice', undefined);
-		expect(get(blossomServer)).toBeUndefined();
+		expect(getBlossomServer()).toBeUndefined();
 		expect(get(preferences)).toEqual({
 			mediaUploader: { type: 'blossom', server: 'https://previous.example' }
 		});

--- a/web/src/lib/author/BlossomServerList.test.ts
+++ b/web/src/lib/author/BlossomServerList.test.ts
@@ -6,6 +6,9 @@ import type { AccountLocalPreferences } from '$lib/preferences/AccountLocalPrefe
 const { preferencesByPubkey } = vi.hoisted(() => ({
 	preferencesByPubkey: new Map<string, ReturnType<typeof writable<AccountLocalPreferences>>>()
 }));
+const { getServersFromServerListEvent } = vi.hoisted(() => ({
+	getServersFromServerListEvent: vi.fn()
+}));
 
 vi.mock('$lib/preferences/AccountLocalPreferences', () => ({
 	getAccountLocalPreferences: (pubkey: string) => {
@@ -17,32 +20,27 @@ vi.mock('$lib/preferences/AccountLocalPreferences', () => ({
 		return preferences;
 	}
 }));
+vi.mock(import('blossom-client-sdk/nostr'), () => ({ getServersFromServerListEvent }));
 
-import {
-	blossomServer,
-	resolveBlossomServer,
-	updateBlossomServerList,
-	withBlossomServer
-} from './BlossomServerList';
+import { blossomServer, resolveBlossomServer, updateBlossomServerList } from './BlossomServerList';
 
 const serverList = (tags: string[][]): Event =>
 	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
 
 describe('resolveBlossomServer', () => {
 	it('selects the first HTTPS server in SDK-parsed tag order', () => {
-		const event = serverList([
-			['server', 'not a URL'],
-			['server', 'http://insecure.example'],
-			['server', 'https://first.example/path'],
-			['server', 'https://second.example']
+		const event = serverList([]);
+		getServersFromServerListEvent.mockReturnValue([
+			new URL('http://insecure.example'),
+			new URL('https://first.example/path'),
+			new URL('https://second.example')
 		]);
-		expect(resolveBlossomServer(event).href).toBe('https://first.example/');
+		expect(resolveBlossomServer(event).href).toBe('https://first.example/path');
 	});
 
 	it('does not select HTTP and falls back when no HTTPS server exists', () => {
-		expect(resolveBlossomServer(serverList([['server', 'http://insecure.example']])).href).toBe(
-			'https://blossom.band/'
-		);
+		getServersFromServerListEvent.mockReturnValue([new URL('http://insecure.example')]);
+		expect(resolveBlossomServer(serverList([])).href).toBe('https://blossom.band/');
 	});
 });
 
@@ -50,66 +48,35 @@ describe('Blossom server list state', () => {
 	beforeEach(() => {
 		preferencesByPubkey.clear();
 		blossomServer.set(undefined);
+		getServersFromServerListEvent.mockReset();
 	});
 
-	it('updates the persisted server while Blossom is selected', () => {
-		expect(
-			withBlossomServer(
-				{
-					mediaUploader: { type: 'blossom', server: 'https://blossom.band' },
-					futurePreference: true
-				} as never,
-				new URL('https://cdn.example.com')
-			)
-		).toEqual({
-			mediaUploader: { type: 'blossom', server: 'https://cdn.example.com/' },
+	it('updates memory and persisted preferences while Blossom is selected', () => {
+		getServersFromServerListEvent.mockReturnValue([new URL('https://cdn.example')]);
+		const pubkey = 'alice';
+		preferencesByPubkey.set(
+			pubkey,
+			writable({
+				mediaUploader: { type: 'blossom', server: 'https://previous.example' },
+				futurePreference: true
+			} as never)
+		);
+		updateBlossomServerList(pubkey, serverList([]));
+		expect(get(blossomServer)?.href).toBe('https://cdn.example/');
+		expect(get(preferencesByPubkey.get(pubkey)!)).toEqual({
+			mediaUploader: { type: 'blossom', server: 'https://cdn.example/' },
 			futurePreference: true
 		});
 	});
 
-	it('persists the fallback after receiving a list with no valid HTTPS server', () => {
-		expect(
-			withBlossomServer(
-				{ mediaUploader: { type: 'blossom', server: 'https://previous.example' } },
-				resolveBlossomServer(
-					serverList([
-						['server', 'not a URL'],
-						['server', 'http://insecure.example']
-					])
-				)
-			).mediaUploader
-		).toEqual({ type: 'blossom', server: 'https://blossom.band/' });
-	});
-
-	it('does not switch a NIP-96 selection to Blossom', () => {
-		const preferences = {
-			mediaUploader: { type: 'nip96' as const, server: 'https://nostr.build' }
-		};
-		expect(withBlossomServer(preferences, new URL('https://cdn.example.com'))).toBe(
-			preferences
-		);
-	});
-
-	it.each(['cached', 'live'])('uses the same update entry point for a %s event', (source) => {
-		const pubkey = `${source}-account`;
-		preferencesByPubkey.set(
-			pubkey,
-			writable({ mediaUploader: { type: 'blossom', server: 'https://previous.example' } })
-		);
-		updateBlossomServerList(pubkey, serverList([['server', `https://${source}.example`]]));
-		expect(get(blossomServer)?.href).toBe(`https://${source}.example/`);
-		expect(get(preferencesByPubkey.get(pubkey)!)).toEqual({
-			mediaUploader: { type: 'blossom', server: `https://${source}.example/` }
-		});
-	});
-
 	it('updates memory but preserves a NIP-96 selection and server', () => {
+		getServersFromServerListEvent.mockReturnValue([new URL('https://cdn.example')]);
 		const preferences = writable<AccountLocalPreferences>({
 			mediaUploader: { type: 'nip96', server: 'https://nostr.build' }
 		});
 		preferencesByPubkey.set('alice', preferences);
-		updateBlossomServerList('alice', serverList([['server', 'https://cdn.example.com']]));
-		expect(get(blossomServer)?.href).toBe('https://cdn.example.com/');
+		updateBlossomServerList('alice', serverList([]));
+		expect(get(blossomServer)?.href).toBe('https://cdn.example/');
 		expect(get(preferences)).toEqual({
 			mediaUploader: { type: 'nip96', server: 'https://nostr.build' }
 		});

--- a/web/src/lib/author/BlossomServerList.test.ts
+++ b/web/src/lib/author/BlossomServerList.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { Event } from 'nostr-tools';
+import { withBlossomServer } from './BlossomServerList';
+
+const serverList = (tags: string[][]): Event =>
+	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
+
+describe('withBlossomServer', () => {
+	it('updates the persisted server while Blossom is selected', () => {
+		expect(
+			withBlossomServer(
+				{
+					mediaUploader: { type: 'blossom', server: 'https://blossom.band' },
+					futurePreference: true
+				} as never,
+				serverList([['server', 'https://cdn.example.com']])
+			)
+		).toEqual({
+			mediaUploader: { type: 'blossom', server: 'https://cdn.example.com/' },
+			futurePreference: true
+		});
+	});
+
+	it('persists the fallback after receiving a list with no valid HTTPS server', () => {
+		expect(
+			withBlossomServer(
+				{ mediaUploader: { type: 'blossom', server: 'https://previous.example' } },
+				serverList([
+					['server', 'not a URL'],
+					['server', 'http://insecure.example']
+				])
+			).mediaUploader
+		).toEqual({ type: 'blossom', server: 'https://blossom.band/' });
+	});
+
+	it('does not switch a NIP-96 selection to Blossom', () => {
+		const preferences = {
+			mediaUploader: { type: 'nip96' as const, server: 'https://nostr.build' }
+		};
+		expect(
+			withBlossomServer(preferences, serverList([['server', 'https://cdn.example.com']]))
+		).toBe(preferences);
+	});
+});

--- a/web/src/lib/author/BlossomServerList.ts
+++ b/web/src/lib/author/BlossomServerList.ts
@@ -1,5 +1,5 @@
 import type { Event } from 'nostr-tools';
-import { getServersFromServerListEvent } from 'blossom-client-sdk';
+import { getServersFromServerListEvent } from 'blossom-client-sdk/nostr';
 import { writable } from 'svelte/store';
 import { defaultBlossomServerUrl } from '$lib/Constants';
 import {

--- a/web/src/lib/author/BlossomServerList.ts
+++ b/web/src/lib/author/BlossomServerList.ts
@@ -17,7 +17,7 @@ export function resolveBlossomServer(event: Event): URL {
 	);
 }
 
-export function withBlossomServer(
+function withBlossomServer(
 	preferences: AccountLocalPreferences,
 	server: URL
 ): AccountLocalPreferences {

--- a/web/src/lib/author/BlossomServerList.ts
+++ b/web/src/lib/author/BlossomServerList.ts
@@ -1,0 +1,27 @@
+import type { Event } from 'nostr-tools';
+import { blossomServerListEvent } from '$lib/stores/Author';
+import { resolveBlossomServer } from '$lib/media/Blossom';
+import {
+	getAccountLocalPreferences,
+	type AccountLocalPreferences
+} from '$lib/preferences/AccountLocalPreferences';
+
+export function withBlossomServer(
+	preferences: AccountLocalPreferences,
+	event: Event
+): AccountLocalPreferences {
+	if (preferences.mediaUploader?.type !== 'blossom') return preferences;
+	return {
+		...preferences,
+		mediaUploader: { type: 'blossom', server: resolveBlossomServer(event).href }
+	};
+}
+
+export function updateBlossomServerList(pubkey: string, event: Event | undefined): void {
+	blossomServerListEvent.set(event);
+	if (event === undefined) return;
+
+	getAccountLocalPreferences(pubkey).update((preferences) =>
+		withBlossomServer(preferences, event)
+	);
+}

--- a/web/src/lib/author/BlossomServerList.ts
+++ b/web/src/lib/author/BlossomServerList.ts
@@ -1,27 +1,42 @@
 import type { Event } from 'nostr-tools';
-import { blossomServerListEvent } from '$lib/stores/Author';
-import { resolveBlossomServer } from '$lib/media/Blossom';
+import { getServersFromServerListEvent } from 'blossom-client-sdk';
+import { writable } from 'svelte/store';
+import { defaultBlossomServerUrl } from '$lib/Constants';
 import {
 	getAccountLocalPreferences,
 	type AccountLocalPreferences
 } from '$lib/preferences/AccountLocalPreferences';
 
+export { defaultBlossomServerUrl } from '$lib/Constants';
+export const blossomServer = writable<URL | undefined>();
+
+export function resolveBlossomServer(event: Event): URL {
+	return (
+		getServersFromServerListEvent(event).find((server) => server.protocol === 'https:') ??
+		new URL(defaultBlossomServerUrl)
+	);
+}
+
 export function withBlossomServer(
 	preferences: AccountLocalPreferences,
-	event: Event
+	server: URL
 ): AccountLocalPreferences {
 	if (preferences.mediaUploader?.type !== 'blossom') return preferences;
 	return {
 		...preferences,
-		mediaUploader: { type: 'blossom', server: resolveBlossomServer(event).href }
+		mediaUploader: { type: 'blossom', server: server.href }
 	};
 }
 
 export function updateBlossomServerList(pubkey: string, event: Event | undefined): void {
-	blossomServerListEvent.set(event);
-	if (event === undefined) return;
+	if (event === undefined) {
+		blossomServer.set(undefined);
+		return;
+	}
 
+	const server = resolveBlossomServer(event);
+	blossomServer.set(server);
 	getAccountLocalPreferences(pubkey).update((preferences) =>
-		withBlossomServer(preferences, event)
+		withBlossomServer(preferences, server)
 	);
 }

--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -6,7 +6,7 @@
 	import { createEventDispatcher, tick, untrack } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import { kinds as Kind, nip19, type Event as NostrEvent } from 'nostr-tools';
-	import { uploadFiles } from '$lib/media/FileStorageServer';
+	import { uploadFiles } from '$lib/media/Uploader';
 	import { complementPosition } from '$lib/styles/Complement';
 	import { adjustHeight } from '$lib/styles/Textarea';
 	import { getSeenOnRelays, rxNostr } from '$lib/timelines/MainTimeline';

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -137,7 +137,9 @@
 		"image_optimization": "Image size reduction",
 		"image_optimization_none": "None",
 		"media_uploader": {
-			"title": "Media uploader"
+			"title": "Media uploader",
+			"recommended_blossom": "Recommended (Blossom)",
+			"other": "Other"
 		},
 		"uri_scheme": "Open web+nostr: in nostter",
 		"enable_uri_scheme": "Enable",

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -136,7 +136,9 @@
 		"image_optimization": "画像軽量化",
 		"image_optimization_none": "なし",
 		"media_uploader": {
-			"title": "メディアのアップロード先"
+			"title": "メディアのアップロード先",
+			"recommended_blossom": "推奨 (Blossom)",
+			"other": "その他"
 		},
 		"uri_scheme": "web+nostr: を nostter で開く",
 		"enable_uri_scheme": "有効化",

--- a/web/src/lib/media/Blossom.test.ts
+++ b/web/src/lib/media/Blossom.test.ts
@@ -1,13 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Event } from 'nostr-tools';
-import {
-	Blossom,
-	createBlossomAuthorizationTemplate,
-	getBlossomUploadAction,
-	resolveBlossomServer
-} from './Blossom';
 
-const { signEvent } = vi.hoisted(() => ({
+const { uploadBlob, uploadMedia, createUploadAuth, signEvent } = vi.hoisted(() => ({
+	uploadBlob: vi.fn(),
+	uploadMedia: vi.fn(),
+	createUploadAuth: vi.fn(),
 	signEvent: vi.fn(async (template) => ({
 		...template,
 		id: 'id',
@@ -16,23 +13,37 @@ const { signEvent } = vi.hoisted(() => ({
 	}))
 }));
 
+vi.mock('blossom-client-sdk', async (importOriginal) => ({
+	...(await importOriginal<typeof import('blossom-client-sdk')>()),
+	Actions: { uploadBlob, uploadMedia },
+	createUploadAuth
+}));
 vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
 
+import { Blossom, resolveBlossomServer } from './Blossom';
+
+const descriptor = {
+	uploaded: 0,
+	type: 'image/png',
+	sha256: 'abc123',
+	size: 5,
+	url: 'https://cdn.example/abc123.png'
+};
 const serverList = (tags: string[][]): Event =>
 	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
 
 describe('resolveBlossomServer', () => {
-	it('uses the first valid HTTPS server in tag order', () => {
+	it('uses SDK parsing and selects the first HTTPS server in tag order', () => {
 		const event = serverList([
 			['server', 'not a url'],
 			['server', 'http://insecure.example'],
 			['server', 'https://first.example/path'],
 			['server', 'https://second.example']
 		]);
-		expect(resolveBlossomServer(event).href).toBe('https://first.example/path');
+		expect(resolveBlossomServer(event).href).toBe('https://first.example/');
 	});
 
-	it('falls back when no valid HTTPS server exists', () => {
+	it('falls back when the SDK-parsed list has no HTTPS server', () => {
 		expect(resolveBlossomServer(serverList([['server', 'http://insecure.example']])).href).toBe(
 			'https://blossom.band/'
 		);
@@ -40,61 +51,73 @@ describe('resolveBlossomServer', () => {
 	});
 });
 
-describe('Blossom authorization', () => {
-	it('scopes a media token to the hash, expiration, and lowercase server hostname', () => {
-		const template = createBlossomAuthorizationTemplate(
-			'media',
-			'abc123',
-			new URL('https://CDN.Example:443/path'),
-			1_000
-		);
-		expect(template.kind).toBe(24242);
-		expect(template.tags).toEqual([
-			['t', 'media'],
-			['x', 'abc123'],
-			['expiration', '1300'],
-			['server', 'cdn.example']
-		]);
-	});
+describe('Blossom SDK adapter', () => {
+	afterEach(() => vi.useRealTimers());
 
-	it('uses upload for non-media files', () => {
-		expect(getBlossomUploadAction('image/png')).toBe('media');
-		expect(getBlossomUploadAction('video/mp4')).toBe('media');
-		expect(getBlossomUploadAction('application/pdf')).toBe('upload');
-	});
-
-	it('uploads images directly to /media with BUD-11 authorization', async () => {
-		const fetchMock = vi.fn<
-			(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-		>(
-			async () =>
-				new Response(JSON.stringify({ url: 'https://cdn.example/hash.png' }), {
-					status: 201
-				})
-		);
-		vi.stubGlobal('fetch', fetchMock);
-		const file = new File(['image'], 'image.png', { type: 'image/png' });
-
-		await expect(
-			new Blossom(new URL('https://upload.example/path')).upload(file)
-		).resolves.toEqual(expect.objectContaining({ url: 'https://cdn.example/hash.png' }));
-
-		const [url, options] = fetchMock.mock.calls[0]!;
-		const headers = options!.headers as Record<string, string>;
-		expect(String(url)).toBe('https://upload.example/media');
-		expect(options!.method).toBe('PUT');
-		expect(options!.body).toBe(file);
-		expect(headers.Authorization).toMatch(/^Nostr [A-Za-z0-9_-]+$/);
-		expect(headers.Authorization).not.toContain('=');
-		expect(headers['X-SHA-256']).toMatch(/^[0-9a-f]{64}$/);
-		expect(signEvent).toHaveBeenCalledWith(
-			expect.objectContaining({
+	beforeEach(() => {
+		uploadBlob.mockReset().mockResolvedValue(descriptor);
+		uploadMedia.mockReset().mockResolvedValue(descriptor);
+		createUploadAuth.mockReset().mockImplementation(async (signer, _sha256, options) =>
+			signer({
 				kind: 24242,
-				tags: expect.arrayContaining([
-					['t', 'media'],
+				content: '',
+				created_at: Math.floor(Date.now() / 1000),
+				tags: [
+					['t', options.type],
+					['x', 'abc123'],
+					['expiration', String(options.expiration)],
 					['server', 'upload.example']
-				])
+				]
 			})
 		);
+		signEvent.mockClear();
+	});
+
+	it.each([
+		['image', 'image/png'],
+		['video', 'video/mp4']
+	])('uses uploadMedia for an %s', async (_name, type) => {
+		const file = new File(['media'], 'media', { type });
+		const blossom = new Blossom(new URL('https://upload.example/path'));
+		await expect(blossom.upload(file)).resolves.toEqual({
+			url: descriptor.url,
+			data: descriptor
+		});
+		expect(uploadMedia).toHaveBeenCalledWith(
+			new URL('https://upload.example/path'),
+			file,
+			expect.objectContaining({ onAuth: expect.any(Function) })
+		);
+		expect(uploadBlob).not.toHaveBeenCalled();
+	});
+
+	it('uses uploadBlob for other files', async () => {
+		const file = new File(['document'], 'document.pdf', { type: 'application/pdf' });
+		await new Blossom(new URL('https://upload.example')).upload(file);
+		expect(uploadBlob).toHaveBeenCalledWith(
+			new URL('https://upload.example'),
+			file,
+			expect.objectContaining({ onAuth: expect.any(Function) })
+		);
+		expect(uploadMedia).not.toHaveBeenCalled();
+	});
+
+	it('connects the nostter signer through the SDK auth callback', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-15T00:00:00Z'));
+		const file = new File(['document'], 'document.pdf', { type: 'application/pdf' });
+		uploadBlob.mockImplementation(async (server, _file, options) => {
+			await options.onAuth(server, 'abc123', 'upload', file);
+			return descriptor;
+		});
+
+		await new Blossom(new URL('https://upload.example')).upload(file);
+
+		expect(createUploadAuth).toHaveBeenCalledWith(expect.any(Function), 'abc123', {
+			type: 'upload',
+			servers: 'https://upload.example/',
+			expiration: 1_786_752_300
+		});
+		expect(signEvent).toHaveBeenCalledWith(expect.objectContaining({ kind: 24242 }));
 	});
 });

--- a/web/src/lib/media/Blossom.test.ts
+++ b/web/src/lib/media/Blossom.test.ts
@@ -12,11 +12,9 @@ const { uploadBlob, uploadMedia, createUploadAuth, signEvent } = vi.hoisted(() =
 	}))
 }));
 
-vi.mock('blossom-client-sdk', async (importOriginal) => ({
-	...(await importOriginal<typeof import('blossom-client-sdk')>()),
-	Actions: { uploadBlob, uploadMedia },
-	createUploadAuth
-}));
+vi.mock('blossom-client-sdk/actions/upload', () => ({ uploadBlob }));
+vi.mock('blossom-client-sdk/actions/media', () => ({ uploadMedia }));
+vi.mock('blossom-client-sdk/auth', () => ({ createUploadAuth }));
 vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
 
 import { Blossom } from './Blossom';

--- a/web/src/lib/media/Blossom.test.ts
+++ b/web/src/lib/media/Blossom.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Event } from 'nostr-tools';
+import {
+	Blossom,
+	createBlossomAuthorizationTemplate,
+	getBlossomUploadAction,
+	resolveBlossomServer
+} from './Blossom';
+
+const { signEvent } = vi.hoisted(() => ({
+	signEvent: vi.fn(async (template) => ({
+		...template,
+		id: 'id',
+		pubkey: 'pubkey',
+		sig: 'sig'
+	}))
+}));
+
+vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
+
+const serverList = (tags: string[][]): Event =>
+	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
+
+describe('resolveBlossomServer', () => {
+	it('uses the first valid HTTPS server in tag order', () => {
+		const event = serverList([
+			['server', 'not a url'],
+			['server', 'http://insecure.example'],
+			['server', 'https://first.example/path'],
+			['server', 'https://second.example']
+		]);
+		expect(resolveBlossomServer(event).href).toBe('https://first.example/path');
+	});
+
+	it('falls back when no valid HTTPS server exists', () => {
+		expect(resolveBlossomServer(serverList([['server', 'http://insecure.example']])).href).toBe(
+			'https://blossom.band/'
+		);
+		expect(resolveBlossomServer(undefined).href).toBe('https://blossom.band/');
+	});
+});
+
+describe('Blossom authorization', () => {
+	it('scopes a media token to the hash, expiration, and lowercase server hostname', () => {
+		const template = createBlossomAuthorizationTemplate(
+			'media',
+			'abc123',
+			new URL('https://CDN.Example:443/path'),
+			1_000
+		);
+		expect(template.kind).toBe(24242);
+		expect(template.tags).toEqual([
+			['t', 'media'],
+			['x', 'abc123'],
+			['expiration', '1300'],
+			['server', 'cdn.example']
+		]);
+	});
+
+	it('uses upload for non-media files', () => {
+		expect(getBlossomUploadAction('image/png')).toBe('media');
+		expect(getBlossomUploadAction('video/mp4')).toBe('media');
+		expect(getBlossomUploadAction('application/pdf')).toBe('upload');
+	});
+
+	it('uploads images directly to /media with BUD-11 authorization', async () => {
+		const fetchMock = vi.fn<
+			(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+		>(
+			async () =>
+				new Response(JSON.stringify({ url: 'https://cdn.example/hash.png' }), {
+					status: 201
+				})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const file = new File(['image'], 'image.png', { type: 'image/png' });
+
+		await expect(
+			new Blossom(new URL('https://upload.example/path')).upload(file)
+		).resolves.toEqual(expect.objectContaining({ url: 'https://cdn.example/hash.png' }));
+
+		const [url, options] = fetchMock.mock.calls[0]!;
+		const headers = options!.headers as Record<string, string>;
+		expect(String(url)).toBe('https://upload.example/media');
+		expect(options!.method).toBe('PUT');
+		expect(options!.body).toBe(file);
+		expect(headers.Authorization).toMatch(/^Nostr [A-Za-z0-9_-]+$/);
+		expect(headers.Authorization).not.toContain('=');
+		expect(headers['X-SHA-256']).toMatch(/^[0-9a-f]{64}$/);
+		expect(signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 24242,
+				tags: expect.arrayContaining([
+					['t', 'media'],
+					['server', 'upload.example']
+				])
+			})
+		);
+	});
+});

--- a/web/src/lib/media/Blossom.test.ts
+++ b/web/src/lib/media/Blossom.test.ts
@@ -12,9 +12,9 @@ const { uploadBlob, uploadMedia, createUploadAuth, signEvent } = vi.hoisted(() =
 	}))
 }));
 
-vi.mock('blossom-client-sdk/actions/upload', () => ({ uploadBlob }));
-vi.mock('blossom-client-sdk/actions/media', () => ({ uploadMedia }));
-vi.mock('blossom-client-sdk/auth', () => ({ createUploadAuth }));
+vi.mock(import('blossom-client-sdk/actions/upload'), () => ({ uploadBlob }));
+vi.mock(import('blossom-client-sdk/actions/media'), () => ({ uploadMedia }));
+vi.mock(import('blossom-client-sdk/auth'), () => ({ createUploadAuth }));
 vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
 
 import { Blossom } from './Blossom';
@@ -32,19 +32,7 @@ describe('Blossom SDK adapter', () => {
 	beforeEach(() => {
 		uploadBlob.mockReset().mockResolvedValue(descriptor);
 		uploadMedia.mockReset().mockResolvedValue(descriptor);
-		createUploadAuth.mockReset().mockImplementation(async (signer, _sha256, options) =>
-			signer({
-				kind: 24242,
-				content: '',
-				created_at: Math.floor(Date.now() / 1000),
-				tags: [
-					['t', options.type],
-					['x', 'abc123'],
-					['expiration', String(options.expiration)],
-					['server', 'upload.example']
-				]
-			})
-		);
+		createUploadAuth.mockReset().mockResolvedValue({ auth: true });
 		signEvent.mockClear();
 	});
 
@@ -81,18 +69,19 @@ describe('Blossom SDK adapter', () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-08-15T00:00:00Z'));
 		const file = new File(['document'], 'document.pdf', { type: 'application/pdf' });
-		uploadBlob.mockImplementation(async (server, _file, options) => {
-			await options.onAuth(server, 'abc123', 'upload', file);
-			return descriptor;
-		});
-
 		await new Blossom(new URL('https://upload.example')).upload(file);
+		const onAuth = uploadBlob.mock.calls[0][2].onAuth;
+		await onAuth(new URL('https://upload.example'), 'abc123', 'upload', file);
 
 		expect(createUploadAuth).toHaveBeenCalledWith(expect.any(Function), 'abc123', {
 			type: 'upload',
 			servers: 'https://upload.example/',
 			expiration: 1_786_752_300
 		});
-		expect(signEvent).toHaveBeenCalledWith(expect.objectContaining({ kind: 24242 }));
+
+		const sdkSigner = createUploadAuth.mock.calls[0][0];
+		const template = { kind: 1, content: 'test', created_at: 123, tags: [] };
+		await sdkSigner(template);
+		expect(signEvent).toHaveBeenCalledWith(template);
 	});
 });

--- a/web/src/lib/media/Blossom.test.ts
+++ b/web/src/lib/media/Blossom.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Event } from 'nostr-tools';
 
 const { uploadBlob, uploadMedia, createUploadAuth, signEvent } = vi.hoisted(() => ({
 	uploadBlob: vi.fn(),
@@ -20,7 +19,7 @@ vi.mock('blossom-client-sdk', async (importOriginal) => ({
 }));
 vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
 
-import { Blossom, resolveBlossomServer } from './Blossom';
+import { Blossom } from './Blossom';
 
 const descriptor = {
 	uploaded: 0,
@@ -29,28 +28,6 @@ const descriptor = {
 	size: 5,
 	url: 'https://cdn.example/abc123.png'
 };
-const serverList = (tags: string[][]): Event =>
-	({ kind: 10063, tags, content: '', created_at: 0, id: '', pubkey: '', sig: '' }) as Event;
-
-describe('resolveBlossomServer', () => {
-	it('uses SDK parsing and selects the first HTTPS server in tag order', () => {
-		const event = serverList([
-			['server', 'not a url'],
-			['server', 'http://insecure.example'],
-			['server', 'https://first.example/path'],
-			['server', 'https://second.example']
-		]);
-		expect(resolveBlossomServer(event).href).toBe('https://first.example/');
-	});
-
-	it('falls back when the SDK-parsed list has no HTTPS server', () => {
-		expect(resolveBlossomServer(serverList([['server', 'http://insecure.example']])).href).toBe(
-			'https://blossom.band/'
-		);
-		expect(resolveBlossomServer(undefined).href).toBe('https://blossom.band/');
-	});
-});
-
 describe('Blossom SDK adapter', () => {
 	afterEach(() => vi.useRealTimers());
 

--- a/web/src/lib/media/Blossom.ts
+++ b/web/src/lib/media/Blossom.ts
@@ -1,0 +1,80 @@
+import type { Event, EventTemplate } from 'nostr-tools';
+import { now } from 'rx-nostr';
+import { Signer } from '$lib/Signer';
+import type { Media, MediaResult } from './Media';
+
+export const defaultBlossomServer = new URL('https://blossom.band');
+
+export function resolveBlossomServer(event: Event | undefined): URL {
+	for (const [name, value] of event?.tags ?? []) {
+		if (name !== 'server' || value === undefined) continue;
+		try {
+			const url = new URL(value);
+			if (url.protocol === 'https:') return url;
+		} catch {
+			// Ignore malformed server tags.
+		}
+	}
+	return new URL(defaultBlossomServer);
+}
+
+export function createBlossomAuthorizationTemplate(
+	action: 'media' | 'upload',
+	hash: string,
+	server: URL,
+	issuedAt: number = now()
+): EventTemplate {
+	return {
+		kind: 24242,
+		content: action === 'media' ? 'Upload media' : 'Upload blob',
+		created_at: issuedAt,
+		tags: [
+			['t', action],
+			['x', hash],
+			['expiration', String(issuedAt + 5 * 60)],
+			['server', server.hostname.toLowerCase()]
+		]
+	};
+}
+
+export function encodeBlossomAuthorization(event: Event): string {
+	const bytes = new TextEncoder().encode(JSON.stringify(event));
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+export function getBlossomUploadAction(fileType: string): 'media' | 'upload' {
+	return fileType.startsWith('image/') || fileType.startsWith('video/') ? 'media' : 'upload';
+}
+
+async function sha256(file: File): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', await file.arrayBuffer());
+	return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export class Blossom implements Media {
+	constructor(private readonly server: URL) {}
+
+	async upload(file: File): Promise<MediaResult> {
+		const action = getBlossomUploadAction(file.type);
+		const hash = await sha256(file);
+		const event = await Signer.signEvent(
+			createBlossomAuthorizationTemplate(action, hash, this.server)
+		);
+		const response = await fetch(new URL(`/${action}`, this.server), {
+			method: 'PUT',
+			headers: {
+				Authorization: `Nostr ${encodeBlossomAuthorization(event)}`,
+				'Content-Type': file.type || 'application/octet-stream',
+				'X-SHA-256': hash
+			},
+			body: file
+		});
+		if (!response.ok) throw new Error(await response.text());
+
+		const data = await response.json();
+		if (typeof data.url !== 'string') throw new Error('Invalid Blossom response');
+		return { url: data.url, data };
+	}
+}

--- a/web/src/lib/media/Blossom.ts
+++ b/web/src/lib/media/Blossom.ts
@@ -1,11 +1,11 @@
-import {
-	Actions,
-	createUploadAuth,
-	type BlobDescriptor,
-	type Signer as BlossomSigner
-} from 'blossom-client-sdk';
+import { uploadMedia } from 'blossom-client-sdk/actions/media';
+import { uploadBlob } from 'blossom-client-sdk/actions/upload';
+import { createUploadAuth } from 'blossom-client-sdk/auth';
 import { Signer } from '$lib/Signer';
 import type { Media, MediaResult } from './Media';
+
+type BlobDescriptor = Awaited<ReturnType<typeof uploadBlob>>;
+type BlossomSigner = Parameters<typeof createUploadAuth>[0];
 
 const signer: BlossomSigner = (template) => Signer.signEvent(template);
 
@@ -22,8 +22,8 @@ export class Blossom implements Media {
 				})
 		};
 		const descriptor = await (file.type.startsWith('image/') || file.type.startsWith('video/')
-			? Actions.uploadMedia(this.server, file, options)
-			: Actions.uploadBlob(this.server, file, options));
+			? uploadMedia(this.server, file, options)
+			: uploadBlob(this.server, file, options));
 		return this.toMediaResult(descriptor);
 	}
 

--- a/web/src/lib/media/Blossom.ts
+++ b/web/src/lib/media/Blossom.ts
@@ -3,7 +3,8 @@ import { now } from 'rx-nostr';
 import { Signer } from '$lib/Signer';
 import type { Media, MediaResult } from './Media';
 
-export const defaultBlossomServer = new URL('https://blossom.band');
+export const defaultBlossomServerUrl = 'https://blossom.band';
+export const defaultBlossomServer = new URL(defaultBlossomServerUrl);
 
 export function resolveBlossomServer(event: Event | undefined): URL {
 	for (const [name, value] of event?.tags ?? []) {

--- a/web/src/lib/media/Blossom.ts
+++ b/web/src/lib/media/Blossom.ts
@@ -1,24 +1,11 @@
-import type { Event } from 'nostr-tools';
 import {
 	Actions,
 	createUploadAuth,
-	getServersFromServerListEvent,
 	type BlobDescriptor,
 	type Signer as BlossomSigner
 } from 'blossom-client-sdk';
 import { Signer } from '$lib/Signer';
 import type { Media, MediaResult } from './Media';
-
-export const defaultBlossomServerUrl = 'https://blossom.band';
-export const defaultBlossomServer = new URL(defaultBlossomServerUrl);
-
-export function resolveBlossomServer(event: Event | undefined): URL {
-	if (event === undefined) return new URL(defaultBlossomServer);
-	return (
-		getServersFromServerListEvent(event).find((server) => server.protocol === 'https:') ??
-		new URL(defaultBlossomServer)
-	);
-}
 
 const signer: BlossomSigner = (template) => Signer.signEvent(template);
 

--- a/web/src/lib/media/Blossom.ts
+++ b/web/src/lib/media/Blossom.ts
@@ -1,5 +1,11 @@
-import type { Event, EventTemplate } from 'nostr-tools';
-import { now } from 'rx-nostr';
+import type { Event } from 'nostr-tools';
+import {
+	Actions,
+	createUploadAuth,
+	getServersFromServerListEvent,
+	type BlobDescriptor,
+	type Signer as BlossomSigner
+} from 'blossom-client-sdk';
 import { Signer } from '$lib/Signer';
 import type { Media, MediaResult } from './Media';
 
@@ -7,75 +13,34 @@ export const defaultBlossomServerUrl = 'https://blossom.band';
 export const defaultBlossomServer = new URL(defaultBlossomServerUrl);
 
 export function resolveBlossomServer(event: Event | undefined): URL {
-	for (const [name, value] of event?.tags ?? []) {
-		if (name !== 'server' || value === undefined) continue;
-		try {
-			const url = new URL(value);
-			if (url.protocol === 'https:') return url;
-		} catch {
-			// Ignore malformed server tags.
-		}
-	}
-	return new URL(defaultBlossomServer);
+	if (event === undefined) return new URL(defaultBlossomServer);
+	return (
+		getServersFromServerListEvent(event).find((server) => server.protocol === 'https:') ??
+		new URL(defaultBlossomServer)
+	);
 }
 
-export function createBlossomAuthorizationTemplate(
-	action: 'media' | 'upload',
-	hash: string,
-	server: URL,
-	issuedAt: number = now()
-): EventTemplate {
-	return {
-		kind: 24242,
-		content: action === 'media' ? 'Upload media' : 'Upload blob',
-		created_at: issuedAt,
-		tags: [
-			['t', action],
-			['x', hash],
-			['expiration', String(issuedAt + 5 * 60)],
-			['server', server.hostname.toLowerCase()]
-		]
-	};
-}
-
-export function encodeBlossomAuthorization(event: Event): string {
-	const bytes = new TextEncoder().encode(JSON.stringify(event));
-	let binary = '';
-	for (const byte of bytes) binary += String.fromCharCode(byte);
-	return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
-}
-
-export function getBlossomUploadAction(fileType: string): 'media' | 'upload' {
-	return fileType.startsWith('image/') || fileType.startsWith('video/') ? 'media' : 'upload';
-}
-
-async function sha256(file: File): Promise<string> {
-	const digest = await crypto.subtle.digest('SHA-256', await file.arrayBuffer());
-	return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
-}
+const signer: BlossomSigner = (template) => Signer.signEvent(template);
 
 export class Blossom implements Media {
 	constructor(private readonly server: URL) {}
 
 	async upload(file: File): Promise<MediaResult> {
-		const action = getBlossomUploadAction(file.type);
-		const hash = await sha256(file);
-		const event = await Signer.signEvent(
-			createBlossomAuthorizationTemplate(action, hash, this.server)
-		);
-		const response = await fetch(new URL(`/${action}`, this.server), {
-			method: 'PUT',
-			headers: {
-				Authorization: `Nostr ${encodeBlossomAuthorization(event)}`,
-				'Content-Type': file.type || 'application/octet-stream',
-				'X-SHA-256': hash
-			},
-			body: file
-		});
-		if (!response.ok) throw new Error(await response.text());
+		const options = {
+			onAuth: (server: URL, sha256: string, type: 'upload' | 'media') =>
+				createUploadAuth(signer, sha256, {
+					type,
+					servers: server.href,
+					expiration: Math.floor(Date.now() / 1000) + 5 * 60
+				})
+		};
+		const descriptor = await (file.type.startsWith('image/') || file.type.startsWith('video/')
+			? Actions.uploadMedia(this.server, file, options)
+			: Actions.uploadBlob(this.server, file, options));
+		return this.toMediaResult(descriptor);
+	}
 
-		const data = await response.json();
-		if (typeof data.url !== 'string') throw new Error('Invalid Blossom response');
-		return { url: data.url, data };
+	private toMediaResult(descriptor: BlobDescriptor): MediaResult {
+		return { url: descriptor.url, data: descriptor };
 	}
 }

--- a/web/src/lib/media/FileStorageServer.ts
+++ b/web/src/lib/media/FileStorageServer.ts
@@ -1,7 +1,7 @@
 import { now } from 'rx-nostr';
 import { Signer } from '$lib/Signer';
 import { filterTags } from '$lib/EventHelper';
-import { getMediaUploader, type Media, type MediaResult } from './Media';
+import type { Media, MediaResult } from './Media';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function fetchNip96(origin: string): Promise<any> {
@@ -106,21 +106,4 @@ export class FileStorageServer implements Media {
 			data
 		};
 	}
-}
-
-export async function uploadFiles(
-	files: FileList | File[]
-): Promise<{ file: File; url: string | undefined }[]> {
-	const media = new FileStorageServer(getMediaUploader());
-	return await Promise.all(
-		[...files].map(async (file) => {
-			try {
-				const { url } = await media.upload(file);
-				return { file, url };
-			} catch (error) {
-				console.error('[media upload error]', error);
-				return { file, url: undefined };
-			}
-		})
-	);
 }

--- a/web/src/lib/media/Media.ts
+++ b/web/src/lib/media/Media.ts
@@ -1,7 +1,3 @@
-import { get } from 'svelte/store';
-import { fileStorageServers } from '$lib/Constants';
-import { preferencesStore } from '$lib/Preferences';
-
 export interface Media {
 	upload(file: File): Promise<MediaResult>;
 }
@@ -10,8 +6,3 @@ export type MediaResult = {
 	url: string;
 	data: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
-
-export function getMediaUploader(): string {
-	const $preferencesStore = get(preferencesStore);
-	return $preferencesStore.mediaUploader ?? fileStorageServers[0];
-}

--- a/web/src/lib/media/Uploader.test.ts
+++ b/web/src/lib/media/Uploader.test.ts
@@ -22,12 +22,14 @@ vi.mock('$lib/preferences/AccountLocalPreferences', () => ({
 	getAccountLocalPreferences: () => preferences
 }));
 vi.mock('./Blossom', () => ({
-	defaultBlossomServerUrl: 'https://blossom.band',
 	Blossom: class {
 		constructor(server: URL) {
 			blossomConstructor(server);
 		}
 	}
+}));
+vi.mock('$lib/Constants', () => ({
+	defaultBlossomServerUrl: 'https://blossom.band'
 }));
 vi.mock('./FileStorageServer', () => ({
 	FileStorageServer: class {
@@ -37,7 +39,14 @@ vi.mock('./FileStorageServer', () => ({
 	}
 }));
 
-import { getMediaUploader } from './Uploader';
+import { createMediaUploader, getMediaUploader } from './Uploader';
+
+describe('createMediaUploader', () => {
+	it('creates an uploader from an explicit preference', () => {
+		createMediaUploader({ type: 'blossom', server: 'https://cdn.example/path' });
+		expect(blossomConstructor).toHaveBeenCalledWith(new URL('https://cdn.example/path'));
+	});
+});
 
 describe('getMediaUploader', () => {
 	beforeEach(() => {

--- a/web/src/lib/media/Uploader.test.ts
+++ b/web/src/lib/media/Uploader.test.ts
@@ -39,14 +39,7 @@ vi.mock('./FileStorageServer', () => ({
 	}
 }));
 
-import { createMediaUploader, getMediaUploader } from './Uploader';
-
-describe('createMediaUploader', () => {
-	it('creates an uploader from an explicit preference', () => {
-		createMediaUploader({ type: 'blossom', server: 'https://cdn.example/path' });
-		expect(blossomConstructor).toHaveBeenCalledWith(new URL('https://cdn.example/path'));
-	});
-});
+import { getMediaUploader } from './Uploader';
 
 describe('getMediaUploader', () => {
 	beforeEach(() => {

--- a/web/src/lib/media/Uploader.test.ts
+++ b/web/src/lib/media/Uploader.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccountLocalPreferences } from '$lib/preferences/AccountLocalPreferences';
+
+const { preferences, blossomConstructor, fileStorageConstructor } = vi.hoisted(() => ({
+	preferences: (() => {
+		let value: AccountLocalPreferences = {};
+		return {
+			subscribe(run: (current: AccountLocalPreferences) => void) {
+				run(value);
+				return () => undefined;
+			},
+			set(next: AccountLocalPreferences) {
+				value = next;
+			}
+		};
+	})(),
+	blossomConstructor: vi.fn(),
+	fileStorageConstructor: vi.fn()
+}));
+
+vi.mock('$lib/preferences/AccountLocalPreferences', () => ({
+	getAccountLocalPreferences: () => preferences
+}));
+vi.mock('./Blossom', () => ({
+	defaultBlossomServerUrl: 'https://blossom.band',
+	Blossom: class {
+		constructor(server: URL) {
+			blossomConstructor(server);
+		}
+	}
+}));
+vi.mock('./FileStorageServer', () => ({
+	FileStorageServer: class {
+		constructor(server: string) {
+			fileStorageConstructor(server);
+		}
+	}
+}));
+
+import { getMediaUploader } from './Uploader';
+
+describe('getMediaUploader', () => {
+	beforeEach(() => {
+		blossomConstructor.mockClear();
+		fileStorageConstructor.mockClear();
+	});
+
+	it('uses the last persisted Blossom server immediately', () => {
+		preferences.set({
+			mediaUploader: { type: 'blossom', server: 'https://previous.example/path' }
+		});
+		getMediaUploader();
+		expect(blossomConstructor).toHaveBeenCalledWith(new URL('https://previous.example/path'));
+	});
+
+	it('uses a changed persisted server on the next upload', () => {
+		preferences.set({
+			mediaUploader: { type: 'blossom', server: 'https://first.example' }
+		});
+		getMediaUploader();
+		preferences.set({
+			mediaUploader: { type: 'blossom', server: 'https://updated.example' }
+		});
+		getMediaUploader();
+		expect(blossomConstructor.mock.calls.map(([server]) => server.href)).toEqual([
+			'https://first.example/',
+			'https://updated.example/'
+		]);
+	});
+
+	it('keeps using the persisted NIP-96 selection', () => {
+		preferences.set({
+			mediaUploader: { type: 'nip96', server: 'https://nostr.build' }
+		});
+		getMediaUploader();
+		expect(fileStorageConstructor).toHaveBeenCalledWith('https://nostr.build');
+		expect(blossomConstructor).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/media/Uploader.ts
+++ b/web/src/lib/media/Uploader.ts
@@ -1,15 +1,14 @@
 import { get } from 'svelte/store';
 import { auth } from '$lib/auth.svelte';
-import { blossomServerListEvent } from '$lib/stores/Author';
 import { getAccountLocalPreferences } from '$lib/preferences/AccountLocalPreferences';
-import { Blossom, resolveBlossomServer } from './Blossom';
+import { Blossom, defaultBlossomServerUrl } from './Blossom';
 import { FileStorageServer } from './FileStorageServer';
 import type { Media } from './Media';
 
 export function getMediaUploader(): Media {
 	const preference = get(getAccountLocalPreferences(auth.pubkey)).mediaUploader;
 	if (preference?.type === 'nip96') return new FileStorageServer(preference.server);
-	return new Blossom(resolveBlossomServer(get(blossomServerListEvent)));
+	return new Blossom(new URL(preference?.server ?? defaultBlossomServerUrl));
 }
 
 export async function uploadFiles(

--- a/web/src/lib/media/Uploader.ts
+++ b/web/src/lib/media/Uploader.ts
@@ -1,14 +1,25 @@
 import { get } from 'svelte/store';
 import { auth } from '$lib/auth.svelte';
-import { getAccountLocalPreferences } from '$lib/preferences/AccountLocalPreferences';
-import { Blossom, defaultBlossomServerUrl } from './Blossom';
+import {
+	getAccountLocalPreferences,
+	type MediaUploaderPreference
+} from '$lib/preferences/AccountLocalPreferences';
+import { defaultBlossomServerUrl } from '$lib/Constants';
+import { Blossom } from './Blossom';
 import { FileStorageServer } from './FileStorageServer';
 import type { Media } from './Media';
 
+export function createMediaUploader(preference: MediaUploaderPreference): Media {
+	if (preference.type === 'nip96') return new FileStorageServer(preference.server);
+	return new Blossom(new URL(preference.server));
+}
+
 export function getMediaUploader(): Media {
-	const preference = get(getAccountLocalPreferences(auth.pubkey)).mediaUploader;
-	if (preference?.type === 'nip96') return new FileStorageServer(preference.server);
-	return new Blossom(new URL(preference?.server ?? defaultBlossomServerUrl));
+	const preference = get(getAccountLocalPreferences(auth.pubkey)).mediaUploader ?? {
+		type: 'blossom',
+		server: defaultBlossomServerUrl
+	};
+	return createMediaUploader(preference);
 }
 
 export async function uploadFiles(

--- a/web/src/lib/media/Uploader.ts
+++ b/web/src/lib/media/Uploader.ts
@@ -9,7 +9,7 @@ import { Blossom } from './Blossom';
 import { FileStorageServer } from './FileStorageServer';
 import type { Media } from './Media';
 
-export function createMediaUploader(preference: MediaUploaderPreference): Media {
+function createMediaUploader(preference: MediaUploaderPreference): Media {
 	if (preference.type === 'nip96') return new FileStorageServer(preference.server);
 	return new Blossom(new URL(preference.server));
 }

--- a/web/src/lib/media/Uploader.ts
+++ b/web/src/lib/media/Uploader.ts
@@ -1,0 +1,30 @@
+import { get } from 'svelte/store';
+import { auth } from '$lib/auth.svelte';
+import { blossomServerListEvent } from '$lib/stores/Author';
+import { getAccountLocalPreferences } from '$lib/preferences/AccountLocalPreferences';
+import { Blossom, resolveBlossomServer } from './Blossom';
+import { FileStorageServer } from './FileStorageServer';
+import type { Media } from './Media';
+
+export function getMediaUploader(): Media {
+	const preference = get(getAccountLocalPreferences(auth.pubkey)).mediaUploader;
+	if (preference?.type === 'nip96') return new FileStorageServer(preference.server);
+	return new Blossom(resolveBlossomServer(get(blossomServerListEvent)));
+}
+
+export async function uploadFiles(
+	files: FileList | File[]
+): Promise<{ file: File; url: string | undefined }[]> {
+	const media = getMediaUploader();
+	return await Promise.all(
+		[...files].map(async (file) => {
+			try {
+				const { url } = await media.upload(file);
+				return { file, url };
+			} catch (error) {
+				console.error('[media upload error]', error);
+				return { file, url: undefined };
+			}
+		})
+	);
+}

--- a/web/src/lib/preferences/AccountLocalPreferences.test.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.test.ts
@@ -1,0 +1,54 @@
+import { get, writable } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import {
+	accountLocalPreferencesKey,
+	initializeMediaUploaderPreference,
+	mediaUploaderPreferenceValue,
+	setMediaUploaderPreference,
+	type AccountLocalPreferences
+} from './AccountLocalPreferences';
+
+describe('account-local media uploader preferences', () => {
+	it('initializes from the existing NIP-78 uploader', () => {
+		const store = writable<AccountLocalPreferences>({});
+		initializeMediaUploaderPreference(store, 'https://nostr.build');
+		expect(get(store).mediaUploader).toEqual({
+			type: 'nip96',
+			server: 'https://nostr.build'
+		});
+	});
+
+	it('initializes Blossom only after initialization is requested without a legacy uploader', () => {
+		const store = writable<AccountLocalPreferences>({});
+		expect(get(store).mediaUploader).toBeUndefined();
+		initializeMediaUploaderPreference(store, undefined);
+		expect(get(store).mediaUploader).toEqual({ type: 'blossom' });
+	});
+
+	it('does not overwrite an existing local uploader', () => {
+		const store = writable<AccountLocalPreferences>({ mediaUploader: { type: 'blossom' } });
+		initializeMediaUploaderPreference(store, 'https://nostr.build');
+		expect(get(store).mediaUploader).toEqual({ type: 'blossom' });
+	});
+
+	it('preserves other account preferences when changing uploader', () => {
+		const store = writable<AccountLocalPreferences>({
+			futurePreference: true
+		} as AccountLocalPreferences);
+		setMediaUploaderPreference(store, { type: 'blossom' });
+		expect(get(store)).toEqual({ futurePreference: true, mediaUploader: { type: 'blossom' } });
+	});
+
+	it('uses distinct persisted keys for each account', () => {
+		expect(accountLocalPreferencesKey('alice')).toBe('preferences:alice');
+		expect(accountLocalPreferencesKey('bob')).toBe('preferences:bob');
+		expect(accountLocalPreferencesKey('alice')).not.toBe(accountLocalPreferencesKey('bob'));
+	});
+
+	it('keeps Blossom and an existing uploader distinct at the same hostname', () => {
+		expect(mediaUploaderPreferenceValue({ type: 'blossom' })).toBe('blossom');
+		expect(
+			mediaUploaderPreferenceValue({ type: 'nip96', server: 'https://blossom.band' })
+		).toBe('nip96:https://blossom.band');
+	});
+});

--- a/web/src/lib/preferences/AccountLocalPreferences.test.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.test.ts
@@ -1,7 +1,6 @@
 import { get, writable } from 'svelte/store';
 import { describe, expect, it } from 'vitest';
 import {
-	accountLocalPreferencesKey,
 	initializeMediaUploaderPreference,
 	mediaUploaderPreferenceValue,
 	setMediaUploaderPreference,
@@ -39,17 +38,6 @@ describe('account-local media uploader preferences', () => {
 		});
 	});
 
-	it('supplements the server missing from the old Blossom shape', () => {
-		const store = writable<AccountLocalPreferences>({
-			mediaUploader: { type: 'blossom' }
-		} as AccountLocalPreferences);
-		initializeMediaUploaderPreference(store, 'https://nostr.build');
-		expect(get(store).mediaUploader).toEqual({
-			type: 'blossom',
-			server: 'https://blossom.band'
-		});
-	});
-
 	it('preserves other account preferences when changing uploader', () => {
 		const store = writable<AccountLocalPreferences>({
 			futurePreference: true
@@ -62,12 +50,6 @@ describe('account-local media uploader preferences', () => {
 			futurePreference: true,
 			mediaUploader: { type: 'blossom', server: 'https://blossom.band' }
 		});
-	});
-
-	it('uses distinct persisted keys for each account', () => {
-		expect(accountLocalPreferencesKey('alice')).toBe('preferences:alice');
-		expect(accountLocalPreferencesKey('bob')).toBe('preferences:bob');
-		expect(accountLocalPreferencesKey('alice')).not.toBe(accountLocalPreferencesKey('bob'));
 	});
 
 	it('keeps Blossom and an existing uploader distinct at the same hostname', () => {

--- a/web/src/lib/preferences/AccountLocalPreferences.test.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.test.ts
@@ -22,21 +22,46 @@ describe('account-local media uploader preferences', () => {
 		const store = writable<AccountLocalPreferences>({});
 		expect(get(store).mediaUploader).toBeUndefined();
 		initializeMediaUploaderPreference(store, undefined);
-		expect(get(store).mediaUploader).toEqual({ type: 'blossom' });
+		expect(get(store).mediaUploader).toEqual({
+			type: 'blossom',
+			server: 'https://blossom.band'
+		});
 	});
 
 	it('does not overwrite an existing local uploader', () => {
-		const store = writable<AccountLocalPreferences>({ mediaUploader: { type: 'blossom' } });
+		const store = writable<AccountLocalPreferences>({
+			mediaUploader: { type: 'blossom', server: 'https://cdn.example.com' }
+		});
 		initializeMediaUploaderPreference(store, 'https://nostr.build');
-		expect(get(store).mediaUploader).toEqual({ type: 'blossom' });
+		expect(get(store).mediaUploader).toEqual({
+			type: 'blossom',
+			server: 'https://cdn.example.com'
+		});
+	});
+
+	it('supplements the server missing from the old Blossom shape', () => {
+		const store = writable<AccountLocalPreferences>({
+			mediaUploader: { type: 'blossom' }
+		} as AccountLocalPreferences);
+		initializeMediaUploaderPreference(store, 'https://nostr.build');
+		expect(get(store).mediaUploader).toEqual({
+			type: 'blossom',
+			server: 'https://blossom.band'
+		});
 	});
 
 	it('preserves other account preferences when changing uploader', () => {
 		const store = writable<AccountLocalPreferences>({
 			futurePreference: true
 		} as AccountLocalPreferences);
-		setMediaUploaderPreference(store, { type: 'blossom' });
-		expect(get(store)).toEqual({ futurePreference: true, mediaUploader: { type: 'blossom' } });
+		setMediaUploaderPreference(store, {
+			type: 'blossom',
+			server: 'https://blossom.band'
+		});
+		expect(get(store)).toEqual({
+			futurePreference: true,
+			mediaUploader: { type: 'blossom', server: 'https://blossom.band' }
+		});
 	});
 
 	it('uses distinct persisted keys for each account', () => {
@@ -46,7 +71,9 @@ describe('account-local media uploader preferences', () => {
 	});
 
 	it('keeps Blossom and an existing uploader distinct at the same hostname', () => {
-		expect(mediaUploaderPreferenceValue({ type: 'blossom' })).toBe('blossom');
+		expect(
+			mediaUploaderPreferenceValue({ type: 'blossom', server: 'https://blossom.band' })
+		).toBe('blossom');
 		expect(
 			mediaUploaderPreferenceValue({ type: 'nip96', server: 'https://blossom.band' })
 		).toBe('nip96:https://blossom.band');

--- a/web/src/lib/preferences/AccountLocalPreferences.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.ts
@@ -1,5 +1,5 @@
 import { persistedStore } from '$lib/persisted-store';
-import { defaultBlossomServerUrl } from '$lib/media/Blossom';
+import { defaultBlossomServerUrl } from '$lib/Constants';
 import type { Persisted } from 'svelte-persisted-store';
 import type { Writable } from 'svelte/store';
 

--- a/web/src/lib/preferences/AccountLocalPreferences.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.ts
@@ -13,7 +13,7 @@ export type AccountLocalPreferences = {
 
 const stores = new Map<string, Persisted<AccountLocalPreferences>>();
 
-export const accountLocalPreferencesKey = (pubkey: string) => `preferences:${pubkey}`;
+const accountLocalPreferencesKey = (pubkey: string) => `preferences:${pubkey}`;
 
 export function getAccountLocalPreferences(pubkey: string): Persisted<AccountLocalPreferences> {
 	let store = stores.get(pubkey);

--- a/web/src/lib/preferences/AccountLocalPreferences.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.ts
@@ -1,8 +1,11 @@
 import { persistedStore } from '$lib/persisted-store';
+import { defaultBlossomServerUrl } from '$lib/media/Blossom';
 import type { Persisted } from 'svelte-persisted-store';
 import type { Writable } from 'svelte/store';
 
-export type MediaUploaderPreference = { type: 'blossom' } | { type: 'nip96'; server: string };
+export type MediaUploaderPreference =
+	| { type: 'blossom'; server: string }
+	| { type: 'nip96'; server: string };
 
 export type AccountLocalPreferences = {
 	mediaUploader?: MediaUploaderPreference;
@@ -16,9 +19,26 @@ export function getAccountLocalPreferences(pubkey: string): Persisted<AccountLoc
 	let store = stores.get(pubkey);
 	if (store === undefined) {
 		store = persistedStore(accountLocalPreferencesKey(pubkey), {});
+		store.update(normalizeAccountLocalPreferences);
 		stores.set(pubkey, store);
 	}
 	return store;
+}
+
+function normalizeAccountLocalPreferences(
+	preferences: AccountLocalPreferences
+): AccountLocalPreferences {
+	const mediaUploader = preferences.mediaUploader as
+		| MediaUploaderPreference
+		| { type: 'blossom'; server?: string }
+		| undefined;
+	if (mediaUploader?.type !== 'blossom' || typeof mediaUploader.server === 'string') {
+		return preferences;
+	}
+	return {
+		...preferences,
+		mediaUploader: { type: 'blossom', server: defaultBlossomServerUrl }
+	};
 }
 
 export function initializeMediaUploaderPreference(
@@ -27,13 +47,13 @@ export function initializeMediaUploaderPreference(
 ): void {
 	store.update((preferences) => {
 		if (preferences.mediaUploader !== undefined) {
-			return preferences;
+			return normalizeAccountLocalPreferences(preferences);
 		}
 		return {
 			...preferences,
 			mediaUploader:
 				legacyMediaUploader === undefined
-					? { type: 'blossom' }
+					? { type: 'blossom', server: defaultBlossomServerUrl }
 					: { type: 'nip96', server: legacyMediaUploader }
 		};
 	});

--- a/web/src/lib/preferences/AccountLocalPreferences.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.ts
@@ -1,0 +1,51 @@
+import { persistedStore } from '$lib/persisted-store';
+import type { Persisted } from 'svelte-persisted-store';
+import type { Writable } from 'svelte/store';
+
+export type MediaUploaderPreference = { type: 'blossom' } | { type: 'nip96'; server: string };
+
+export type AccountLocalPreferences = {
+	mediaUploader?: MediaUploaderPreference;
+};
+
+const stores = new Map<string, Persisted<AccountLocalPreferences>>();
+
+export const accountLocalPreferencesKey = (pubkey: string) => `preferences:${pubkey}`;
+
+export function getAccountLocalPreferences(pubkey: string): Persisted<AccountLocalPreferences> {
+	let store = stores.get(pubkey);
+	if (store === undefined) {
+		store = persistedStore(accountLocalPreferencesKey(pubkey), {});
+		stores.set(pubkey, store);
+	}
+	return store;
+}
+
+export function initializeMediaUploaderPreference(
+	store: Writable<AccountLocalPreferences>,
+	legacyMediaUploader: string | undefined
+): void {
+	store.update((preferences) => {
+		if (preferences.mediaUploader !== undefined) {
+			return preferences;
+		}
+		return {
+			...preferences,
+			mediaUploader:
+				legacyMediaUploader === undefined
+					? { type: 'blossom' }
+					: { type: 'nip96', server: legacyMediaUploader }
+		};
+	});
+}
+
+export function setMediaUploaderPreference(
+	store: Writable<AccountLocalPreferences>,
+	mediaUploader: MediaUploaderPreference
+): void {
+	store.update((preferences) => ({ ...preferences, mediaUploader }));
+}
+
+export function mediaUploaderPreferenceValue(preference: MediaUploaderPreference): string {
+	return preference.type === 'blossom' ? 'blossom' : `nip96:${preference.server}`;
+}

--- a/web/src/lib/preferences/AccountLocalPreferencesStore.test.ts
+++ b/web/src/lib/preferences/AccountLocalPreferencesStore.test.ts
@@ -1,30 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { persistedStore } = vi.hoisted(() => ({
-	persistedStore: vi.fn((_key: string, initialValue: object) => {
-		let value = initialValue;
-		return {
-			subscribe(run: (value: object) => void) {
-				run(value);
-				return () => undefined;
-			},
-			set(next: object) {
-				value = next;
-			},
-			update(update: (current: object) => object) {
-				value = update(value);
-			},
-			reset: vi.fn()
-		};
-	})
-}));
+const { persistedStore, storedValues } = vi.hoisted(() => {
+	const storedValues = new Map<string, object>();
+	return {
+		storedValues,
+		persistedStore: vi.fn((key: string, initialValue: object) => {
+			let value = storedValues.get(key) ?? initialValue;
+			return {
+				subscribe(run: (value: object) => void) {
+					run(value);
+					return () => undefined;
+				},
+				set(next: object) {
+					value = next;
+				},
+				update(update: (current: object) => object) {
+					value = update(value);
+				},
+				reset: vi.fn()
+			};
+		})
+	};
+});
 
 vi.mock('$lib/persisted-store', () => ({ persistedStore }));
 
 import { getAccountLocalPreferences } from './AccountLocalPreferences';
 
 describe('getAccountLocalPreferences', () => {
-	beforeEach(() => persistedStore.mockClear());
+	beforeEach(() => {
+		persistedStore.mockClear();
+		storedValues.clear();
+	});
 
 	it('creates one persisted preferences store per account', () => {
 		const alice = getAccountLocalPreferences('alice-store-test');
@@ -36,5 +43,17 @@ describe('getAccountLocalPreferences', () => {
 		expect(persistedStore).toHaveBeenCalledWith('preferences:alice-store-test', {});
 		expect(persistedStore).toHaveBeenCalledWith('preferences:bob-store-test', {});
 		expect(persistedStore).toHaveBeenCalledTimes(2);
+	});
+
+	it('normalizes the old persisted Blossom shape when reading it', () => {
+		storedValues.set('preferences:old-blossom-store-test', {
+			mediaUploader: { type: 'blossom' }
+		});
+		const store = getAccountLocalPreferences('old-blossom-store-test');
+		let value: object | undefined;
+		store.subscribe((current) => (value = current))();
+		expect(value).toEqual({
+			mediaUploader: { type: 'blossom', server: 'https://blossom.band' }
+		});
 	});
 });

--- a/web/src/lib/preferences/AccountLocalPreferencesStore.test.ts
+++ b/web/src/lib/preferences/AccountLocalPreferencesStore.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { persistedStore } = vi.hoisted(() => ({
+	persistedStore: vi.fn((_key: string, initialValue: object) => {
+		let value = initialValue;
+		return {
+			subscribe(run: (value: object) => void) {
+				run(value);
+				return () => undefined;
+			},
+			set(next: object) {
+				value = next;
+			},
+			update(update: (current: object) => object) {
+				value = update(value);
+			},
+			reset: vi.fn()
+		};
+	})
+}));
+
+vi.mock('$lib/persisted-store', () => ({ persistedStore }));
+
+import { getAccountLocalPreferences } from './AccountLocalPreferences';
+
+describe('getAccountLocalPreferences', () => {
+	beforeEach(() => persistedStore.mockClear());
+
+	it('creates one persisted preferences store per account', () => {
+		const alice = getAccountLocalPreferences('alice-store-test');
+		const sameAlice = getAccountLocalPreferences('alice-store-test');
+		const bob = getAccountLocalPreferences('bob-store-test');
+
+		expect(alice).toBe(sameAlice);
+		expect(alice).not.toBe(bob);
+		expect(persistedStore).toHaveBeenCalledWith('preferences:alice-store-test', {});
+		expect(persistedStore).toHaveBeenCalledWith('preferences:bob-store-test', {});
+		expect(persistedStore).toHaveBeenCalledTimes(2);
+	});
+});

--- a/web/src/lib/shims/cashu-disabled.ts
+++ b/web/src/lib/shims/cashu-disabled.ts
@@ -1,0 +1,2 @@
+// Work around blossom-client-sdk resolving its optional Cashu peer dependency during Wrangler bundling.
+throw new Error('Cashu payment support is not enabled');

--- a/web/src/lib/stores/Author.ts
+++ b/web/src/lib/stores/Author.ts
@@ -14,6 +14,7 @@ export const pubkey = toStore(() => auth.pubkey);
 export const author: Writable<Author | undefined> = writable();
 export const authorProfile: Writable<User> = writable();
 export const metadataEvent: Writable<Event | undefined> = writable();
+export const blossomServerListEvent: Writable<Event | undefined> = writable();
 export const followees = toStore(() => auth.followees);
 export const originalFollowees = toStore(() => auth.originalFollowees);
 export const muteEvent = writable<Event | undefined>();

--- a/web/src/lib/stores/Author.ts
+++ b/web/src/lib/stores/Author.ts
@@ -14,7 +14,6 @@ export const pubkey = toStore(() => auth.pubkey);
 export const author: Writable<Author | undefined> = writable();
 export const authorProfile: Writable<User> = writable();
 export const metadataEvent: Writable<Event | undefined> = writable();
-export const blossomServerListEvent: Writable<Event | undefined> = writable();
 export const followees = toStore(() => auth.followees);
 export const originalFollowees = toStore(() => auth.originalFollowees);
 export const muteEvent = writable<Event | undefined>();

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -51,7 +51,8 @@ import {
 	updateRelays,
 	followees,
 	storeMutedPubkeysByKind,
-	storeMutedTagsByEvent
+	storeMutedTagsByEvent,
+	blossomServerListEvent
 } from '../stores/Author';
 import { lastReadAt, notifiedEventItems } from '../author/Notifications';
 import { saveLastNote } from '../stores/LastNotes';
@@ -138,6 +139,9 @@ export class HomeTimeline extends NewTimeline {
 			customEmojiListEvent.set(event);
 			storeCustomEmojis(event);
 		});
+		replaceable$
+			.pipe(filterByKind(Kind.BlossomServerList))
+			.subscribe(({ event }) => blossomServerListEvent.set(event));
 		const addressable$ = author$.pipe(
 			filterByKinds(parameterizedReplaceableKinds),
 			latestEach(({ event }) => `${event.kind}:${findIdentifier(event.tags) ?? ''}`),

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -61,7 +61,7 @@ import { NewTimeline } from './Timeline.svelte';
 import { excludeKinds } from '$lib/TimelineFilter';
 import { fetchMinutes } from '$lib/Helper';
 import { isVisibleNotification } from '$lib/preferences/NotificationVisibility.svelte';
-import { updateBlossomServerList } from '$lib/author/BlossomServerList';
+import { updateBlossomServerList } from '$lib/author/BlossomServerList.svelte';
 
 const maxTimelineLength = minTimelineLength * 2;
 

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -51,8 +51,7 @@ import {
 	updateRelays,
 	followees,
 	storeMutedPubkeysByKind,
-	storeMutedTagsByEvent,
-	blossomServerListEvent
+	storeMutedTagsByEvent
 } from '../stores/Author';
 import { lastReadAt, notifiedEventItems } from '../author/Notifications';
 import { saveLastNote } from '../stores/LastNotes';
@@ -62,6 +61,7 @@ import { NewTimeline } from './Timeline.svelte';
 import { excludeKinds } from '$lib/TimelineFilter';
 import { fetchMinutes } from '$lib/Helper';
 import { isVisibleNotification } from '$lib/preferences/NotificationVisibility.svelte';
+import { updateBlossomServerList } from '$lib/author/BlossomServerList';
 
 const maxTimelineLength = minTimelineLength * 2;
 
@@ -141,7 +141,7 @@ export class HomeTimeline extends NewTimeline {
 		});
 		replaceable$
 			.pipe(filterByKind(Kind.BlossomServerList))
-			.subscribe(({ event }) => blossomServerListEvent.set(event));
+			.subscribe(({ event }) => updateBlossomServerList($pubkey, event));
 		const addressable$ = author$.pipe(
 			filterByKinds(parameterizedReplaceableKinds),
 			latestEach(({ event }) => `${event.kind}:${findIdentifier(event.tags) ?? ''}`),

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -9,7 +9,7 @@
 	import { NoteComposer } from '$lib/NoteComposer';
 	import { Content } from '$lib/Content';
 	import { rxNostr } from '$lib/timelines/MainTimeline';
-	import { uploadFiles } from '$lib/media/FileStorageServer';
+	import { uploadFiles } from '$lib/media/Uploader';
 	import { findCustomEmojiSetAddress } from '$lib/author/CustomEmojis';
 	import { metadataStore } from '$lib/cache/Events';
 	import { alternativeName } from '$lib/Items';

--- a/web/src/routes/(app)/preferences/MediaUploader.svelte
+++ b/web/src/routes/(app)/preferences/MediaUploader.svelte
@@ -1,29 +1,50 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
+	import { get } from 'svelte/store';
 	import { fileStorageServers } from '$lib/Constants';
-	import { getMediaUploader } from '$lib/media/Media';
-	import { preferencesStore, savePreferences } from '$lib/Preferences';
+	import { auth } from '$lib/auth.svelte';
+	import { blossomServerListEvent } from '$lib/stores/Author';
+	import { resolveBlossomServer } from '$lib/media/Blossom';
+	import {
+		getAccountLocalPreferences,
+		mediaUploaderPreferenceValue,
+		setMediaUploaderPreference,
+		type MediaUploaderPreference
+	} from '$lib/preferences/AccountLocalPreferences';
 	import { fetchNip96 } from '$lib/media/FileStorageServer';
 
-	let server = $state(getMediaUploader());
+	const accountLocalPreferences = getAccountLocalPreferences(auth.pubkey);
+	const blossomServer = $derived(resolveBlossomServer($blossomServerListEvent));
+	let selection = $state(
+		mediaUploaderPreferenceValue(
+			get(accountLocalPreferences).mediaUploader ?? { type: 'blossom' }
+		)
+	);
 
 	async function save(): Promise<void> {
-		console.debug('[preferences media uploader changed]', server);
+		const preference: MediaUploaderPreference = selection.startsWith('nip96:')
+			? { type: 'nip96', server: selection.slice('nip96:'.length) }
+			: { type: 'blossom' };
+		console.debug('[preferences media uploader changed]', preference);
 		try {
-			await fetchNip96(server);
-			$preferencesStore.mediaUploader = server;
-			savePreferences();
+			if (preference.type === 'nip96') await fetchNip96(preference.server);
+			setMediaUploaderPreference(accountLocalPreferences, preference);
 		} catch (error) {
-			console.error('[preferences media uploader not found]', server, error);
+			console.error('[preferences media uploader not found]', preference, error);
 		}
 	}
 </script>
 
 <label for="file-storage-server">{$_('preferences.media_uploader.title')}</label>
-<select id="file-storage-server" bind:value={server} onchange={save}>
-	{#each fileStorageServers as server}
-		<option value={server}>{new URL(server).hostname}</option>
-	{/each}
+<select id="file-storage-server" bind:value={selection} onchange={save}>
+	<optgroup label="Recommended (Blossom)">
+		<option value="blossom">{blossomServer.hostname}</option>
+	</optgroup>
+	<optgroup label="Other">
+		{#each fileStorageServers as server}
+			<option value={`nip96:${server}`}>{new URL(server).hostname}</option>
+		{/each}
+	</optgroup>
 </select>
 
 <style>

--- a/web/src/routes/(app)/preferences/MediaUploader.svelte
+++ b/web/src/routes/(app)/preferences/MediaUploader.svelte
@@ -17,14 +17,17 @@
 	const blossomServer = $derived(resolveBlossomServer($blossomServerListEvent));
 	let selection = $state(
 		mediaUploaderPreferenceValue(
-			get(accountLocalPreferences).mediaUploader ?? { type: 'blossom' }
+			get(accountLocalPreferences).mediaUploader ?? {
+				type: 'blossom',
+				server: resolveBlossomServer(get(blossomServerListEvent)).href
+			}
 		)
 	);
 
 	async function save(): Promise<void> {
 		const preference: MediaUploaderPreference = selection.startsWith('nip96:')
 			? { type: 'nip96', server: selection.slice('nip96:'.length) }
-			: { type: 'blossom' };
+			: { type: 'blossom', server: blossomServer.href };
 		console.debug('[preferences media uploader changed]', preference);
 		try {
 			if (preference.type === 'nip96') await fetchNip96(preference.server);
@@ -37,10 +40,10 @@
 
 <label for="file-storage-server">{$_('preferences.media_uploader.title')}</label>
 <select id="file-storage-server" bind:value={selection} onchange={save}>
-	<optgroup label="Recommended (Blossom)">
+	<optgroup label={$_('preferences.media_uploader.recommended_blossom')}>
 		<option value="blossom">{blossomServer.hostname}</option>
 	</optgroup>
-	<optgroup label="Other">
+	<optgroup label={$_('preferences.media_uploader.other')}>
 		{#each fileStorageServers as server}
 			<option value={`nip96:${server}`}>{new URL(server).hostname}</option>
 		{/each}

--- a/web/src/routes/(app)/preferences/MediaUploader.svelte
+++ b/web/src/routes/(app)/preferences/MediaUploader.svelte
@@ -3,8 +3,7 @@
 	import { get } from 'svelte/store';
 	import { fileStorageServers } from '$lib/Constants';
 	import { auth } from '$lib/auth.svelte';
-	import { blossomServerListEvent } from '$lib/stores/Author';
-	import { defaultBlossomServerUrl, resolveBlossomServer } from '$lib/media/Blossom';
+	import { blossomServer, defaultBlossomServerUrl } from '$lib/author/BlossomServerList';
 	import {
 		getAccountLocalPreferences,
 		mediaUploaderPreferenceValue,
@@ -14,14 +13,13 @@
 	import { fetchNip96 } from '$lib/media/FileStorageServer';
 
 	const accountLocalPreferences = getAccountLocalPreferences(auth.pubkey);
-	const blossomServer = $derived(
-		$blossomServerListEvent !== undefined
-			? resolveBlossomServer($blossomServerListEvent)
-			: new URL(
-					$accountLocalPreferences.mediaUploader?.type === 'blossom'
-						? $accountLocalPreferences.mediaUploader.server
-						: defaultBlossomServerUrl
-				)
+	const displayedBlossomServer = $derived(
+		$blossomServer ??
+			new URL(
+				$accountLocalPreferences.mediaUploader?.type === 'blossom'
+					? $accountLocalPreferences.mediaUploader.server
+					: defaultBlossomServerUrl
+			)
 	);
 	let selection = $state(
 		mediaUploaderPreferenceValue(
@@ -35,7 +33,10 @@
 	async function save(): Promise<void> {
 		const preference: MediaUploaderPreference = selection.startsWith('nip96:')
 			? { type: 'nip96', server: selection.slice('nip96:'.length) }
-			: { type: 'blossom', server: blossomServer.href };
+			: {
+					type: 'blossom',
+					server: ($blossomServer ?? new URL(defaultBlossomServerUrl)).href
+				};
 		console.debug('[preferences media uploader changed]', preference);
 		try {
 			if (preference.type === 'nip96') await fetchNip96(preference.server);
@@ -49,7 +50,7 @@
 <label for="file-storage-server">{$_('preferences.media_uploader.title')}</label>
 <select id="file-storage-server" bind:value={selection} onchange={save}>
 	<optgroup label={$_('preferences.media_uploader.recommended_blossom')}>
-		<option value="blossom">{blossomServer.hostname}</option>
+		<option value="blossom">{displayedBlossomServer.hostname}</option>
 	</optgroup>
 	<optgroup label={$_('preferences.media_uploader.other')}>
 		{#each fileStorageServers as server}

--- a/web/src/routes/(app)/preferences/MediaUploader.svelte
+++ b/web/src/routes/(app)/preferences/MediaUploader.svelte
@@ -3,7 +3,10 @@
 	import { get } from 'svelte/store';
 	import { fileStorageServers } from '$lib/Constants';
 	import { auth } from '$lib/auth.svelte';
-	import { blossomServer, defaultBlossomServerUrl } from '$lib/author/BlossomServerList';
+	import {
+		getBlossomServer,
+		defaultBlossomServerUrl
+	} from '$lib/author/BlossomServerList.svelte';
 	import {
 		getAccountLocalPreferences,
 		mediaUploaderPreferenceValue,
@@ -14,7 +17,7 @@
 
 	const accountLocalPreferences = getAccountLocalPreferences(auth.pubkey);
 	const displayedBlossomServer = $derived(
-		$blossomServer ??
+		getBlossomServer() ??
 			new URL(
 				$accountLocalPreferences.mediaUploader?.type === 'blossom'
 					? $accountLocalPreferences.mediaUploader.server
@@ -35,7 +38,7 @@
 			? { type: 'nip96', server: selection.slice('nip96:'.length) }
 			: {
 					type: 'blossom',
-					server: ($blossomServer ?? new URL(defaultBlossomServerUrl)).href
+					server: (getBlossomServer() ?? new URL(defaultBlossomServerUrl)).href
 				};
 		console.debug('[preferences media uploader changed]', preference);
 		try {

--- a/web/src/routes/(app)/preferences/MediaUploader.svelte
+++ b/web/src/routes/(app)/preferences/MediaUploader.svelte
@@ -4,7 +4,7 @@
 	import { fileStorageServers } from '$lib/Constants';
 	import { auth } from '$lib/auth.svelte';
 	import { blossomServerListEvent } from '$lib/stores/Author';
-	import { resolveBlossomServer } from '$lib/media/Blossom';
+	import { defaultBlossomServerUrl, resolveBlossomServer } from '$lib/media/Blossom';
 	import {
 		getAccountLocalPreferences,
 		mediaUploaderPreferenceValue,
@@ -14,12 +14,20 @@
 	import { fetchNip96 } from '$lib/media/FileStorageServer';
 
 	const accountLocalPreferences = getAccountLocalPreferences(auth.pubkey);
-	const blossomServer = $derived(resolveBlossomServer($blossomServerListEvent));
+	const blossomServer = $derived(
+		$blossomServerListEvent !== undefined
+			? resolveBlossomServer($blossomServerListEvent)
+			: new URL(
+					$accountLocalPreferences.mediaUploader?.type === 'blossom'
+						? $accountLocalPreferences.mediaUploader.server
+						: defaultBlossomServerUrl
+				)
+	);
 	let selection = $state(
 		mediaUploaderPreferenceValue(
 			get(accountLocalPreferences).mediaUploader ?? {
 				type: 'blossom',
-				server: resolveBlossomServer(get(blossomServerListEvent)).href
+				server: defaultBlossomServerUrl
 			}
 		)
 	);

--- a/web/src/routes/(app)/profile/+page.svelte
+++ b/web/src/routes/(app)/profile/+page.svelte
@@ -3,8 +3,7 @@
 	import { _ } from 'svelte-i18n';
 	import Cropper from 'svelte-easy-crop';
 	import { goto } from '$app/navigation';
-	import { FileStorageServer } from '$lib/media/FileStorageServer';
-	import { getMediaUploader } from '$lib/media/Media';
+	import { getMediaUploader } from '$lib/media/Uploader';
 	import { appName } from '$lib/Constants';
 	import { pubkey, author, authorProfile, metadataEvent } from '$lib/stores/Author';
 	import MediaPicker from '$lib/components/MediaPicker.svelte';
@@ -101,7 +100,7 @@
 		console.debug('[profile picture cropped file]', croppedFile);
 
 		try {
-			const media = new FileStorageServer(getMediaUploader());
+			const media = getMediaUploader();
 			const { url } = await media.upload(croppedFile);
 			if (url) {
 				$authorProfile.picture = url;
@@ -120,7 +119,7 @@
 
 		const file = files[0];
 		try {
-			const media = new FileStorageServer(getMediaUploader());
+			const media = getMediaUploader();
 			const { url } = await media.upload(file);
 			if (url) {
 				$authorProfile.banner = url;

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -14,6 +14,9 @@
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"
 	},
+	"alias": {
+		"@cashu/cashu-ts": "./src/lib/shims/cashu-disabled.ts"
+	},
 	"kv_namespaces": [
 		{
 			"binding": "RESTRICTION",


### PR DESCRIPTION
## Summary

- Add Blossom as the recommended media upload destination while retaining every existing upload server under `Other`.
- Use `blossom-client-sdk` for Blossom server-list parsing, upload flows, authorization, hashing, response parsing, and HTTP errors.
- Persist the last-known Blossom server per account so uploads can safely use stale data while kind `10063` is revalidated.
- Keep kind `10063` interpretation in the `BlossomServerList` feature; the settings UI and upload adapter do not handle raw server-list events.

## Responsibility boundaries

`Author.fetchEvents()` and the HomeTimeline live/revalidation subscription pass cached and live kind `10063` events through the same `updateBlossomServerList(pubkey, event)` entry point.

`author/BlossomServerList.ts` owns User Server List interpretation and state:

1. Delegate parsing to the SDK's `getServersFromServerListEvent()`.
2. Preserve the SDK-returned URL order.
3. Select the first HTTPS URL as nostter's upload target.
4. Fall back to `https://blossom.band` only when a received event has no HTTPS server.
5. Publish the resolved URL as in-memory state and update the persisted server only when Blossom is selected.

The generic Author store no longer retains a raw Blossom server-list event. An undefined event clears only the in-memory resolved server, so account switching cannot leak the previous account's resolved value while the persisted last-known server remains intact.

`media/Blossom.ts` is a focused SDK upload adapter. It accepts a server URL, selects `uploadMedia()` for images/videos or `uploadBlob()` for other files, connects nostter's `Signer.signEvent()` to SDK authorization, and maps the SDK `BlobDescriptor` to `MediaResult`. It has no kind `10063`, Nostr Event, server-list parser, resolution policy, or server-list state dependency.

## Blossom SDK integration

The Blossom adapter delegates images and videos to the SDK's `uploadMedia()` action and other files to `uploadBlob()`. The SDK owns the BUD-05/BUD-02 request flows, including its HEAD preflight behavior, PUT requests, Blob Descriptor parsing, and HTTP error handling. nostter does not add a `/media` to `/upload` fallback, payment UI, mirroring, or multi-server upload.

BUD-11 authorization is created with the SDK's `createUploadAuth()`. The SDK handles SHA-256 calculation, kind `24242` event construction, and authorization-header encoding. nostter connects the existing `Signer.signEvent()` through the SDK signer callback and supplies the selected target server plus an expiration approximately five minutes after issuance. No new private-key handling is introduced.

The SDK `BlobDescriptor` is adapted to the existing `MediaResult` shape as `{ url: descriptor.url, data: descriptor }`.

## Account-local preference

The selected uploader is stored in `AccountLocalPreferences` through the existing `persistedStore()` wrapper. Blossom stores `{ type: "blossom", server }`; existing upload servers store `{ type: "nip96", server }`. The Blossom `server` is the last-known resolution of the account's kind `10063`, not a directly editable setting. Its initial value is `https://blossom.band`. The development-only legacy shape `{ type: "blossom" }` is normalized to include that default server.

Updates merge the existing preferences object so other account-local fields are preserved. No existing NIP-78 value is changed.

## Migration from NIP-78

Initialization runs only after the existing `nostter-preferences` kind `30078` event loading flow completes. An existing local uploader is never overwritten. When local state is absent, legacy `preferences.mediaUploader` becomes `{ type: "nip96", server }`; otherwise Blossom is initialized as `{ type: "blossom", server: "https://blossom.band" }`. Later NIP-78 changes do not replace local state, and settings changes do not write NIP-78.

## kind 10063 and stale-while-revalidate

`Kind.BlossomServerList` remains integrated into the existing author replaceable-event cache and HomeTimeline forward subscription. There is no dedicated request, lazy upload-time fetch, revalidation wait, cache version, or cache scope.

When a cached or live kind `10063` event is received while Blossom is selected, the resolved HTTPS URL updates both the in-memory resolved store and the persisted Blossom `server`. An absent event clears the resolved store but does not reset a previously persisted server.

When NIP-96 is selected, kind `10063` still updates the in-memory resolved Blossom server but never changes the uploader selection or overwrites the NIP-96 server. Blossom uploads use the account-local persisted server, making the last-known value immediately available after startup.

Switching from NIP-96 to Blossom uses the currently resolved in-memory Blossom server, or `https://blossom.band` when none is available.

## Settings UI

The existing single `<select>` keeps `Recommended (Blossom)` first and `Other` second. Both optgroup labels use the existing i18n system:

- English: `Recommended (Blossom)` / `Other`
- Japanese: `推奨 (Blossom)` / `その他`

The UI reads only the resolved Blossom URL and account-local preference. It has no knowledge of kind `10063`, `server` tags, SDK server-list parsing, or HTTPS filtering. While resolved state is unavailable, the Blossom option displays the persisted last-known hostname when Blossom is selected; otherwise it displays `blossom.band`. Its internal value remains distinct from existing uploader values, including when hostnames match. The UI does not expose the term NIP-96.

## Validation

- `npm test -- --run` — passed (25 files, 281 tests)
- focused Blossom server-list / SDK adapter / uploader / account preference tests — passed (5 files, 26 tests)
- `npm run check` — passed (0 errors, 0 warnings)
- `npm run lint` — passed (Prettier and ESLint)
- `git diff --check` — passed
- `npm run build` — retried twice; both runs completed SSR transformation and were terminated externally with exit 143 during client chunk rendering, without a code diagnostic

Closes #2221
