### PR TITLE
ci: run svelte check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           node-version: "24.x"
       - run: npm ci
+      - run: npm run check
       - run: npm run lint
 
   unit-test:


### PR DESCRIPTION
### Motivation

Run Svelte and TypeScript diagnostics in pull request CI so new `svelte-check` errors are caught automatically.

### Description

- Add `npm run check` to the existing `lint` job before `npm run lint`.
- Keep the existing CI job structure unchanged.

### Testing

- CI will run `npm run check` as part of the `lint` job for this pull request.