### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - id: publish
-        uses: snow-actions/nostr@v1.8.3
+        uses: snow-actions/nostr@c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3
         with:
           relays: ${{ vars.NOSTR_RELAYS }}
           private-key: ${{ secrets.NOSTR_PRIVATE_KEY }}
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - id: publish
-        uses: snow-actions/nostr@v1.8.3
+        uses: snow-actions/nostr@c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3
         with:
           relays: ${{ vars.NOSTR_RELAYS }}
           private-key: ${{ secrets.NOSTR_PRIVATE_KEY }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - run: echo "expiration=$(date +%s --date '12 hours')" >> $GITHUB_ENV
       - id: publish
-        uses: snow-actions/nostr@v1.8.3
+        uses: snow-actions/nostr@c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3
         with:
           relays: ${{ vars.NOSTR_RELAYS }}
           private-key: ${{ secrets.NOSTR_PRIVATE_KEY }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -13,8 +13,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.x"
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.x"
       - run: npm ci
@@ -26,8 +26,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.x"
       - run: npm ci
@@ -40,8 +40,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.x"
       - run: npm ci


### PR DESCRIPTION
### Motivation
- Improve GitHub Actions supply-chain security by pinning all external Actions referenced under `/.github/workflows/` to immutable, full-length commit SHAs while preserving the original release tags as inline comments.
- Apply this pinning to every external `uses:` reference (not local actions or reusable workflows) without changing workflow behavior or Action versions.

### Description
- Replace external Action references to use 40-character commit SHAs with the original tag preserved as an inline comment on the same line in the affected workflows.
- Modified files: `/.github/workflows/notify.yml`, `/.github/workflows/stats.yml`, and `/.github/workflows/test.yml`.
- Pinned Actions: `actions/checkout@v7.0.1` → `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`, `actions/setup-node@v7.0.0` → `820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`, and `snow-actions/nostr@v1.8.3` → `c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3`.
- No other changes to job logic, steps ordering, Node versions, npm dependencies, or Dependabot configuration were made.

### Testing
- Verified tag-to-SHA resolution via the GitHub API for each Action tag, and confirmed the returned SHAs match the ones used in the changes (`actions/checkout`, `actions/setup-node`, `snow-actions/nostr`).
- Ran a repository-wide validation script that inspects `uses:` lines under `/.github/workflows/` and confirmed all external Actions now use full 40-character SHAs with inline version comments.
- Ran `git diff --check` and `git diff` to ensure the diff is limited to Action reference format changes and reports no whitespace or YAML problems.
- Ran the web test suite with `cd web && npm test` and observed all tests pass (`25` test files, `274` tests passed); the attempt to push the branch to the remote failed due to missing GitHub credentials in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8051cd6204832e93f6b3cbdcf6639e)