### PR TITLE
Show NIP-05 in mention complement

### DIFF
--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -888,6 +888,7 @@
 
 	ul.complement li.mention-complement {
 		display: flex;
+		align-items: baseline;
 		gap: 0.5rem;
 		min-width: 0;
 	}

--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -662,12 +662,18 @@
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 						<li
+							class="mention-complement"
 							class:selected={i === mentionComplementIndex}
 							onclick={stopPropagation(
 								async () => await replaceMentionComplement(mentionComplementList[i])
 							)}
 						>
-							<OnelineProfile pubkey={metadata.event.pubkey} />
+							<span class="mention-profile">
+								<OnelineProfile pubkey={metadata.event.pubkey} />
+							</span>
+							{#if metadata.normalizedNip05 && metadata.normalizedNip05 !== metadata.displayName}
+								<span class="mention-nip05">{metadata.normalizedNip05}</span>
+							{/if}
 						</li>
 					{/each}
 				</ul>
@@ -878,6 +884,30 @@
 	ul.complement li.selected {
 		border: solid 1px var(--accent-surface);
 		background-color: var(--accent-foreground);
+	}
+
+	ul.complement li.mention-complement {
+		display: flex;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.mention-profile,
+	.mention-nip05 {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.mention-profile {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.mention-nip05 {
+		color: var(--accent-gray);
+		font-size: 0.8rem;
+		max-width: 50%;
 	}
 
 	ul.complement li.add-custom-emojis {


### PR DESCRIPTION
## Summary

- Display each profile's NIP-05 identifier as secondary information in the mention complement.
- Reuse the existing `Metadata.normalizedNip05` value, including root identifier normalization.
- Avoid duplicate display when the existing profile name falls back to the same NIP-05 identifier.
- Leave mention search logic and the identifier inserted after completion unchanged.

## Checks

- `npm run check` — passed
- `npm run lint` — passed
- `npm test` — passed (25 files, 274 tests)

Closes #1289