### PR TITLE
Open timeline posts in new tabs with Ctrl/Cmd or middle click

### DIFF
--- a/web/src/lib/EventNavigation.ts
+++ b/web/src/lib/EventNavigation.ts
@@ -17,7 +17,12 @@ const getTargetETag = (tags: string[][]): string => {
 };
 
 const shouldSkipNavigation = (e: MouseEvent | KeyboardEvent): boolean => {
-	if ((e instanceof MouseEvent && e.button !== MouseButton.Left) || emojiPickerOpen) {
+	if (
+		(e instanceof MouseEvent &&
+			e.button !== MouseButton.Left &&
+			e.button !== MouseButton.Middle) ||
+		emojiPickerOpen
+	) {
 		return true;
 	}
 
@@ -89,5 +94,14 @@ export async function navigateTo(
 	if (!canTransition) {
 		return;
 	}
-	await goto(resolveDestination(nostrEvent));
+	const destination = resolveDestination(nostrEvent);
+	if (
+		e instanceof MouseEvent &&
+		(e.button === MouseButton.Middle ||
+			(e.button === MouseButton.Left && (e.ctrlKey || e.metaKey)))
+	) {
+		window.open(destination, '_blank');
+		return;
+	}
+	await goto(destination);
 }

--- a/web/src/lib/EventNavigation.ts
+++ b/web/src/lib/EventNavigation.ts
@@ -83,6 +83,12 @@ const resolveDestination = (nostrEvent: Nostr.Event): string =>
 	resolveProfileDestination(nostrEvent) ??
 	resolveEventDestination(nostrEvent);
 
+export function preventMiddleClickDefault(e: MouseEvent, canTransition: boolean = true): void {
+	if (e.button === MouseButton.Middle && canTransition && !shouldSkipNavigation(e)) {
+		e.preventDefault();
+	}
+}
+
 export async function navigateTo(
 	e: MouseEvent | KeyboardEvent,
 	nostrEvent: Nostr.Event,

--- a/web/src/lib/components/Timeline.svelte
+++ b/web/src/lib/components/Timeline.svelte
@@ -14,7 +14,7 @@
 	import { scrollY } from 'svelte/reactivity/window';
 	import { isVisibleNotification } from '$lib/preferences/NotificationVisibility.svelte';
 	import { onTimelineScrollToTop } from '$lib/timelines/ScrollToTop';
-	import { navigateTo } from '$lib/EventNavigation';
+	import { navigateTo, preventMiddleClickDefault } from '$lib/EventNavigation';
 
 	interface Props {
 		timeline: NewTimeline;
@@ -183,6 +183,7 @@
 			id={item.id}
 			class={canTransition ? 'canTransition-post' : ''}
 			class:related={$author?.isNotified(item.event)}
+			onmousedown={(e) => preventMiddleClickDefault(e, canTransition)}
 			onmouseup={(e) => navigateTo(e, item.event, canTransition)}
 		>
 			<EventComponent {item} {readonly} {createdAtFormat} {full} />

--- a/web/src/lib/components/items/PinnedNote.svelte
+++ b/web/src/lib/components/items/PinnedNote.svelte
@@ -72,7 +72,11 @@
 				onmousedown={preventMiddleClickDefault}
 				onclick={(e) => navigateTo(e, $state.snapshot(event!))}
 				onauxclick={(e) => navigateTo(e, $state.snapshot(event!))}
-				onkeydown={(e) => navigateTo(e, $state.snapshot(event!))}
+				onkeydown={(e) => {
+					if (e.key === 'Enter') {
+						navigateTo(e, $state.snapshot(event!));
+					}
+				}}
 			>
 				<EventComponent item={new EventItem(event)} readonly={false} />
 			</div>

--- a/web/src/lib/components/items/PinnedNote.svelte
+++ b/web/src/lib/components/items/PinnedNote.svelte
@@ -11,7 +11,7 @@
 	import EventComponent from './EventComponent.svelte';
 	import { EventItem } from '$lib/Items';
 	import NoteLink from './NoteLink.svelte';
-	import { navigateTo } from '$lib/EventNavigation';
+	import { navigateTo, preventMiddleClickDefault } from '$lib/EventNavigation';
 
 	interface Props {
 		pubkey: string;
@@ -69,7 +69,9 @@
 				role="link"
 				tabindex="0"
 				class="navigation"
+				onmousedown={preventMiddleClickDefault}
 				onclick={(e) => navigateTo(e, $state.snapshot(event!))}
+				onauxclick={(e) => navigateTo(e, $state.snapshot(event!))}
 				onkeydown={(e) => navigateTo(e, $state.snapshot(event!))}
 			>
 				<EventComponent item={new EventItem(event)} readonly={false} />

--- a/web/src/routes/(app)/TimelineView.svelte
+++ b/web/src/routes/(app)/TimelineView.svelte
@@ -6,7 +6,7 @@
 	import EventComponent from '$lib/components/items/EventComponent.svelte';
 	import { innerHeight, scrollY } from 'svelte/reactivity/window';
 	import { WindowVirtualizer } from 'virtua/svelte';
-	import { navigateTo } from '$lib/EventNavigation';
+	import { navigateTo, preventMiddleClickDefault } from '$lib/EventNavigation';
 
 	interface Props {
 		items?: Item[];
@@ -62,6 +62,7 @@
 				<div
 					class={canTransition ? 'canTransition-post' : ''}
 					class:related={$author?.isNotified(data.event)}
+					onmousedown={(e) => preventMiddleClickDefault(e, canTransition)}
 					onmouseup={(e) => navigateTo(e, data.event, canTransition)}
 				>
 					<EventComponent item={data} {readonly} {createdAtFormat} {full} />


### PR DESCRIPTION
## Summary

- open timeline posts in a new tab with Ctrl/Cmd + left click
- open timeline posts in a new tab with middle click
- preserve existing SvelteKit `goto()` navigation for normal left clicks and skip navigation for right clicks or interactive post content

## Validation

- `npm run check`
- `npm run lint`

Fixes #643