### PR TITLE
Support standard and legacy NIP-51 bookmark lists

### DIFF
--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -25,6 +25,7 @@ import { Signer } from './Signer';
 import { authorChannelsEventStore, storeMetadata } from './cache/Events';
 import {
 	authorReplaceableKinds,
+	legacyBookmarkIdentifier,
 	parameterizedReplaceableKinds,
 	replaceableKinds
 } from './Constants';
@@ -121,7 +122,7 @@ export class Author {
 
 		bookmarkEvent.set(replaceableEvents.get(Kind.BookmarkList));
 		legacyBookmarkEvent.set(
-			parameterizedReplaceableEvents.get(`${Kind.Genericlists}:bookmark`)
+			parameterizedReplaceableEvents.get(`${Kind.Genericlists}:${legacyBookmarkIdentifier}`)
 		);
 		setProfileBadgesEvent(
 			replaceableEvents.get(profileBadgesKind),

--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -119,8 +119,10 @@ export class Author {
 			storeCustomEmojis($customEmojiListEvent);
 		}
 
-		bookmarkEvent.set(replaceableEvents.get(10003));
-		legacyBookmarkEvent.set(parameterizedReplaceableEvents.get(`${30001}:bookmark`));
+		bookmarkEvent.set(replaceableEvents.get(Kind.BookmarkList));
+		legacyBookmarkEvent.set(
+			parameterizedReplaceableEvents.get(`${Kind.Genericlists}:bookmark`)
+		);
 		setProfileBadgesEvent(
 			replaceableEvents.get(profileBadgesKind),
 			parameterizedReplaceableEvents.get(legacyProfileBadgesKey)

--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -28,7 +28,7 @@ import {
 	parameterizedReplaceableKinds,
 	replaceableKinds
 } from './Constants';
-import { bookmarkEvent } from './author/Bookmark';
+import { bookmarkEvent, legacyBookmarkEvent } from './author/Bookmark';
 import { legacyProfileBadgesKey, setProfileBadgesEvent } from './author/ProfileBadges';
 import { profileBadgesKind } from './ProfileBadgesEvent';
 import { contactsOfFolloweesReqEmit } from './author/MuteAutomatically';
@@ -119,7 +119,8 @@ export class Author {
 			storeCustomEmojis($customEmojiListEvent);
 		}
 
-		bookmarkEvent.set(parameterizedReplaceableEvents.get(`${30001}:bookmark`));
+		bookmarkEvent.set(replaceableEvents.get(10003));
+		legacyBookmarkEvent.set(parameterizedReplaceableEvents.get(`${30001}:bookmark`));
 		setProfileBadgesEvent(
 			replaceableEvents.get(profileBadgesKind),
 			parameterizedReplaceableEvents.get(legacyProfileBadgesKey)

--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -24,6 +24,7 @@ export const emojisetAddressRegexp = new RegExp(`^${Emojisets}:[0-9a-f]{64}:.*$`
 export const hashtagsRegexp = /(?<=^|\s)#(?<hashtag>[\p{Letter}\p{Number}_]+)/gu;
 export const nicovideoRegexp = /^https:\/\/(www|sp).nicovideo.jp\/watch\/(?<id>[a-zA-Z0-9]+)/;
 export const shortcodeRegexp = /^[\w-]+$/;
+export const legacyBookmarkIdentifier = 'bookmark';
 
 export const replaceableKinds = [
 	Kind.Metadata,
@@ -38,7 +39,7 @@ export const replaceableKinds = [
 	10030,
 	Kind.BlossomServerList
 ];
-export const parameterizedReplaceableKinds = [30000, 30001, 30007, 30008, 30078];
+export const parameterizedReplaceableKinds = [30000, Kind.Genericlists, 30007, 30008, 30078];
 
 export const notesKinds = [1, 42];
 export const notesFilterKinds = [1, 6];
@@ -67,7 +68,7 @@ export const authorReplaceableKinds: AuthorReplaceableKind[] = [
 	...replaceableKinds.map((kind) => {
 		return { kind };
 	}),
-	{ kind: Kind.Genericlists, identifier: 'bookmark' },
+	{ kind: Kind.Genericlists, identifier: legacyBookmarkIdentifier },
 	{ kind: 30007, identifier: '6' },
 	{ kind: 30007, identifier: '7' },
 	{ kind: 30007, identifier: '9735' },

--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -30,6 +30,7 @@ export const replaceableKinds = [
 	Kind.Contacts,
 	10000,
 	10001,
+	10003,
 	Kind.RelayList,
 	10005,
 	profileBadgesKind,

--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -30,7 +30,7 @@ export const replaceableKinds = [
 	Kind.Contacts,
 	10000,
 	10001,
-	10003,
+	Kind.BookmarkList,
 	Kind.RelayList,
 	10005,
 	profileBadgesKind,
@@ -67,7 +67,7 @@ export const authorReplaceableKinds: AuthorReplaceableKind[] = [
 	...replaceableKinds.map((kind) => {
 		return { kind };
 	}),
-	{ kind: 30001, identifier: 'bookmark' },
+	{ kind: Kind.Genericlists, identifier: 'bookmark' },
 	{ kind: 30007, identifier: '6' },
 	{ kind: 30007, identifier: '7' },
 	{ kind: 30007, identifier: '9735' },

--- a/web/src/lib/author/Bookmark.test.ts
+++ b/web/src/lib/author/Bookmark.test.ts
@@ -1,13 +1,37 @@
 import { describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
+import { kinds as Kind } from 'nostr-tools';
 
-vi.mock('$lib/timelines/MainTimeline', () => ({ rxNostr: {} }));
+const { signEvent } = vi.hoisted(() => ({
+	signEvent: vi.fn(async (event) => ({ ...event, id: 'signed', pubkey: 'pubkey', sig: 'sig' }))
+}));
 
-import { bookmarkEvent, bookmarkKind, legacyBookmarkEvent, updateBookmarkTags } from './Bookmark';
+vi.mock('$lib/timelines/MainTimeline', () => ({
+	rxNostr: { send: () => of({ ok: true }) }
+}));
+vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
+vi.mock('$lib/RxNostrHelper', () => ({ fetchLastEvent: vi.fn(async () => undefined) }));
+vi.mock('$lib/WebStorage', () => ({
+	WebStorage: class {
+		getReplaceableEvent() {
+			return undefined;
+		}
+
+		setReplaceableEvent() {}
+	}
+}));
+vi.stubGlobal('localStorage', {});
+
+import { bookmark, bookmarkEvent, legacyBookmarkEvent, updateBookmarkTags } from './Bookmark';
 import { get } from 'svelte/store';
 
 describe('Bookmark', () => {
-	it('uses the standard NIP-51 bookmark kind', () => {
-		expect(bookmarkKind).toBe(10003);
+	it('publishes updates as the standard NIP-51 bookmark kind', async () => {
+		await bookmark(['e', 'event-id']);
+
+		expect(signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: Kind.BookmarkList })
+		);
 	});
 
 	it('adds and removes bookmark tags without an addressable-event identifier', () => {

--- a/web/src/lib/author/Bookmark.test.ts
+++ b/web/src/lib/author/Bookmark.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/timelines/MainTimeline', () => ({ rxNostr: {} }));
+
+import { bookmarkEvent, bookmarkKind, legacyBookmarkEvent, updateBookmarkTags } from './Bookmark';
+import { get } from 'svelte/store';
+
+describe('Bookmark', () => {
+	it('uses the standard NIP-51 bookmark kind', () => {
+		expect(bookmarkKind).toBe(10003);
+	});
+
+	it('adds and removes bookmark tags without an addressable-event identifier', () => {
+		const added = updateBookmarkTags([], { type: 'bookmark', tag: ['e', 'event-id'] });
+		expect(added).toEqual([['e', 'event-id']]);
+		expect(updateBookmarkTags(added, { type: 'unbookmark', tag: ['e', 'event-id'] })).toEqual(
+			[]
+		);
+	});
+
+	it('keeps standard and legacy bookmark events in separate state', () => {
+		const standard = { id: 'standard' } as never;
+		const legacy = { id: 'legacy' } as never;
+
+		bookmarkEvent.set(standard);
+		legacyBookmarkEvent.set(legacy);
+
+		expect(get(bookmarkEvent)).toBe(standard);
+		expect(get(legacyBookmarkEvent)).toBe(legacy);
+	});
+});

--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -15,13 +15,31 @@ type Data = {
 	tag: string[];
 };
 
-const kind = 30001;
-const identifier = 'bookmark';
+export const bookmarkKind = 10003;
 const queue = new Queue<Data>();
 
 let processing = false;
 
 export const bookmarkEvent: Writable<Nostr.Event | undefined> = writable();
+export const legacyBookmarkEvent: Writable<Nostr.Event | undefined> = writable();
+
+export function updateBookmarkTags(tags: string[][], data: Data): string[][] {
+	if (
+		data.type === 'bookmark' &&
+		!tags.some(([tagName, value]) => tagName === data.tag[0] && value === data.tag[1])
+	) {
+		return [...tags, data.tag];
+	}
+	if (
+		data.type === 'unbookmark' &&
+		tags.some(([tagName, value]) => tagName === data.tag[0] && value === data.tag[1])
+	) {
+		return tags.filter(
+			([tagName, value]) => !(tagName === data.tag[0] && value === data.tag[1])
+		);
+	}
+	return tags;
+}
 
 // TODO: Private bookmarks
 export const isBookmarked = (event: Nostr.Event): boolean => {
@@ -57,8 +75,8 @@ async function save(type: DataType, tag: string[]): Promise<void> {
 
 async function publish(): Promise<void> {
 	const storage = new WebStorage(localStorage);
-	const lastEvent = storage.getParameterizedReplaceableEvent(kind, identifier);
-	let tags = lastEvent?.tags ?? [['d', identifier]];
+	const lastEvent = storage.getReplaceableEvent(bookmarkKind);
+	let tags = lastEvent?.tags ?? [];
 
 	while (queue.length > 0) {
 		const data = queue.dequeue();
@@ -66,23 +84,11 @@ async function publish(): Promise<void> {
 			break;
 		}
 
-		if (
-			data.type === 'bookmark' &&
-			!tags.some(([tagName, pubkey]) => tagName === data.tag[0] && pubkey === data.tag[1])
-		) {
-			tags.push(data.tag);
-		} else if (
-			data.type === 'unbookmark' &&
-			tags.some(([tagName, pubkey]) => tagName === data.tag[0] && pubkey === data.tag[1])
-		) {
-			tags = tags.filter(
-				([tagName, pubkey]) => !(tagName === data.tag[0] && pubkey === data.tag[1])
-			);
-		}
+		tags = updateBookmarkTags(tags, data);
 	}
 
 	const event = await Signer.signEvent({
-		kind,
+		kind: bookmarkKind,
 		content: lastEvent?.content ?? '',
 		tags,
 		created_at: now()
@@ -96,7 +102,7 @@ async function publish(): Promise<void> {
 		throw new Error('Cache is outdated.');
 	}
 
-	storage.setParameterizedReplaceableEvent(event);
+	storage.setReplaceableEvent(event);
 	await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
 
 	if (queue.length > 0) {
@@ -107,9 +113,8 @@ async function publish(): Promise<void> {
 async function validate(event: Nostr.Event | undefined): Promise<boolean> {
 	const $pubkey = get(pubkey);
 	const lastEvent = await fetchLastEvent({
-		kinds: [kind],
+		kinds: [bookmarkKind],
 		authors: [$pubkey],
-		'#d': [identifier],
 		limit: 1
 	});
 

--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -2,6 +2,7 @@ import { get, writable, type Writable } from 'svelte/store';
 import { now } from 'rx-nostr';
 import { filter, firstValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
+import { kinds as Kind } from 'nostr-tools';
 import { rxNostr } from '$lib/timelines/MainTimeline';
 import { Queue } from '$lib/Queue';
 import { fetchLastEvent } from '$lib/RxNostrHelper';
@@ -15,7 +16,6 @@ type Data = {
 	tag: string[];
 };
 
-export const bookmarkKind = 10003;
 const queue = new Queue<Data>();
 
 let processing = false;
@@ -75,7 +75,7 @@ async function save(type: DataType, tag: string[]): Promise<void> {
 
 async function publish(): Promise<void> {
 	const storage = new WebStorage(localStorage);
-	const lastEvent = storage.getReplaceableEvent(bookmarkKind);
+	const lastEvent = storage.getReplaceableEvent(Kind.BookmarkList);
 	let tags = lastEvent?.tags ?? [];
 
 	while (queue.length > 0) {
@@ -88,7 +88,7 @@ async function publish(): Promise<void> {
 	}
 
 	const event = await Signer.signEvent({
-		kind: bookmarkKind,
+		kind: Kind.BookmarkList,
 		content: lastEvent?.content ?? '',
 		tags,
 		created_at: now()
@@ -113,7 +113,7 @@ async function publish(): Promise<void> {
 async function validate(event: Nostr.Event | undefined): Promise<boolean> {
 	const $pubkey = get(pubkey);
 	const lastEvent = await fetchLastEvent({
-		kinds: [bookmarkKind],
+		kinds: [Kind.BookmarkList],
 		authors: [$pubkey],
 		limit: 1
 	});

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -14,6 +14,10 @@
 			"preferences": "Preferences"
 		}
 	},
+	"bookmarks": {
+		"old_format": "Old format",
+		"private": "Private"
+	},
 	"pages": {
 		"profile_edit": "Edit profile",
 		"thread": "Thread",

--- a/web/src/lib/i18n/locales/ja.json
+++ b/web/src/lib/i18n/locales/ja.json
@@ -14,6 +14,10 @@
 			"preferences": "設定"
 		}
 	},
+	"bookmarks": {
+		"old_format": "旧形式",
+		"private": "プライベート"
+	},
 	"pages": {
 		"profile_edit": "プロフィールを編集",
 		"thread": "スレッド",

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -15,7 +15,7 @@ import { referencesReqEmit, rxNostr, storeSeenOn, tie } from './MainTimeline';
 import { WebStorage } from '$lib/WebStorage';
 import { kinds as Kind } from 'nostr-tools';
 import { get } from 'svelte/store';
-import { bookmarkEvent } from '$lib/author/Bookmark';
+import { bookmarkEvent, legacyBookmarkEvent } from '$lib/author/Bookmark';
 import {
 	authorActionReqEmit,
 	updateReactionedEvents,
@@ -139,6 +139,7 @@ export class HomeTimeline extends NewTimeline {
 			customEmojiListEvent.set(event);
 			storeCustomEmojis(event);
 		});
+		replaceable$.pipe(filterByKind(10003)).subscribe(({ event }) => bookmarkEvent.set(event));
 		replaceable$
 			.pipe(filterByKind(Kind.BlossomServerList))
 			.subscribe(({ event }) => updateBlossomServerList($pubkey, event));
@@ -174,7 +175,7 @@ export class HomeTimeline extends NewTimeline {
 				filterByKind(Kind.Genericlists),
 				filter(({ event }) => findIdentifier(event.tags) === 'bookmark')
 			)
-			.subscribe(({ event }) => bookmarkEvent.set(event));
+			.subscribe(({ event }) => legacyBookmarkEvent.set(event));
 		addressable$
 			.pipe(filterByKind(30007))
 			.subscribe(({ event }) => storeMutedPubkeysByKind([event]));

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -34,6 +34,7 @@ import { chunk } from '$lib/Array';
 import {
 	homeFolloweesFilterKinds,
 	filterLimitItems,
+	legacyBookmarkIdentifier,
 	parameterizedReplaceableKinds,
 	replaceableKinds,
 	authorFilterReplaceableKinds,
@@ -175,7 +176,7 @@ export class HomeTimeline extends NewTimeline {
 		addressable$
 			.pipe(
 				filterByKind(Kind.Genericlists),
-				filter(({ event }) => findIdentifier(event.tags) === 'bookmark')
+				filter(({ event }) => findIdentifier(event.tags) === legacyBookmarkIdentifier)
 			)
 			.subscribe(({ event }) => legacyBookmarkEvent.set(event));
 		addressable$

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -139,7 +139,9 @@ export class HomeTimeline extends NewTimeline {
 			customEmojiListEvent.set(event);
 			storeCustomEmojis(event);
 		});
-		replaceable$.pipe(filterByKind(10003)).subscribe(({ event }) => bookmarkEvent.set(event));
+		replaceable$
+			.pipe(filterByKind(Kind.BookmarkList))
+			.subscribe(({ event }) => bookmarkEvent.set(event));
 		replaceable$
 			.pipe(filterByKind(Kind.BlossomServerList))
 			.subscribe(({ event }) => updateBlossomServerList($pubkey, event));

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -4,7 +4,7 @@
 	import { _ } from 'svelte-i18n';
 	import { pubkey as authorPubkey, rom } from '$lib/stores/Author';
 	import TimelineView from '../../TimelineView.svelte';
-	import { bookmarkEvent } from '$lib/author/Bookmark';
+	import { bookmarkEvent, legacyBookmarkEvent } from '$lib/author/Bookmark';
 	import { authorActionReqEmit } from '$lib/author/Action';
 	import { appName, reverseChronologicalItem } from '$lib/Constants';
 	import { filterTags } from '$lib/EventHelper';
@@ -17,6 +17,8 @@
 
 	let publicBookmarkEventItems: EventItem[] = $state([]);
 	let privateBookmarkEventItems: EventItem[] = $state([]);
+	let publicLegacyBookmarkEventItems: EventItem[] = $state([]);
+	let privateLegacyBookmarkEventItems: EventItem[] = $state([]);
 
 	// Public bookmarks
 	if ($bookmarkEvent !== undefined) {
@@ -44,6 +46,30 @@
 					publicBookmarkEventItems.push(new EventItem(packet.event));
 					publicBookmarkEventItems =
 						publicBookmarkEventItems.sort(reverseChronologicalItem);
+				});
+		}
+	}
+
+	// Public legacy bookmarks
+	if ($legacyBookmarkEvent !== undefined) {
+		const ids = filterTags('e', $legacyBookmarkEvent.tags);
+		if (ids.length > 0) {
+			const eventsReq = createRxOneshotReq({ filters: [{ ids }] });
+			rxNostr
+				.use(eventsReq)
+				.pipe(
+					tie,
+					uniq(),
+					tap(({ event }) => {
+						referencesReqEmit(event);
+						authorActionReqEmit(event);
+					})
+				)
+				.subscribe((packet) => {
+					console.debug('[legacy bookmark public]', packet);
+					publicLegacyBookmarkEventItems.push(new EventItem(packet.event));
+					publicLegacyBookmarkEventItems =
+						publicLegacyBookmarkEventItems.sort(reverseChronologicalItem);
 				});
 		}
 	}
@@ -87,6 +113,39 @@
 			});
 		}
 	});
+
+	// Private legacy bookmarks
+	$effect(() => {
+		if (
+			data.pubkey === $authorPubkey &&
+			!$rom &&
+			$legacyBookmarkEvent !== undefined &&
+			$legacyBookmarkEvent.content !== ''
+		) {
+			decryptListContent($authorPubkey, $legacyBookmarkEvent.content).then(([tags]) => {
+				const ids = filterTags('e', tags);
+				if (ids.length > 0) {
+					const eventsReq = createRxOneshotReq({ filters: [{ ids }] });
+					rxNostr
+						.use(eventsReq)
+						.pipe(
+							tie,
+							uniq(),
+							tap(({ event }) => {
+								referencesReqEmit(event);
+								authorActionReqEmit(event);
+							})
+						)
+						.subscribe((packet) => {
+							console.debug('[legacy bookmark private]', packet);
+							privateLegacyBookmarkEventItems.push(new EventItem(packet.event));
+							privateLegacyBookmarkEventItems =
+								privateLegacyBookmarkEventItems.sort(reverseChronologicalItem);
+						});
+				}
+			});
+		}
+	});
 </script>
 
 <svelte:head>
@@ -95,12 +154,30 @@
 
 <h1>{$_('layout.header.bookmarks')}</h1>
 
-<h2>Public</h2>
+{#if $bookmarkEvent !== undefined}
+	<h2>Bookmarks</h2>
 
-<TimelineView items={publicBookmarkEventItems} showLoading={false} />
+	<h3>Public</h3>
 
-{#if privateBookmarkEventItems.length > 0}
-	<h2>Private</h2>
+	<TimelineView items={publicBookmarkEventItems} showLoading={false} />
 
-	<TimelineView items={privateBookmarkEventItems} showLoading={false} />
+	{#if privateBookmarkEventItems.length > 0}
+		<h3>Private</h3>
+
+		<TimelineView items={privateBookmarkEventItems} showLoading={false} />
+	{/if}
+{/if}
+
+{#if $legacyBookmarkEvent !== undefined}
+	<h2>Legacy bookmarks</h2>
+
+	<h3>Public</h3>
+
+	<TimelineView items={publicLegacyBookmarkEventItems} showLoading={false} />
+
+	{#if privateLegacyBookmarkEventItems.length > 0}
+		<h3>Private</h3>
+
+		<TimelineView items={privateLegacyBookmarkEventItems} showLoading={false} />
+	{/if}
 {/if}

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { createRxOneshotReq, uniq } from 'rx-nostr';
 	import { tap } from 'rxjs';
+	import { tick } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import { pubkey as authorPubkey, rom } from '$lib/stores/Author';
 	import TimelineView from '../../TimelineView.svelte';
@@ -12,6 +13,13 @@
 	import { referencesReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
 	import type { LayoutProps } from '../$types';
 	import { decryptListContent } from '$lib/List';
+	import {
+		getAdjacentBookmarkListTab,
+		getBookmarkListTabs,
+		legacyBookmarkListId,
+		resolveSelectedBookmarkList,
+		standardBookmarkListId
+	} from './BookmarkListTabs';
 
 	let { data }: LayoutProps = $props();
 
@@ -19,6 +27,45 @@
 	let privateBookmarkEventItems: EventItem[] = $state([]);
 	let publicLegacyBookmarkEventItems: EventItem[] = $state([]);
 	let privateLegacyBookmarkEventItems: EventItem[] = $state([]);
+	let selectedBookmarkListId = $state(standardBookmarkListId);
+
+	let bookmarkListTabs = $derived(
+		getBookmarkListTabs($bookmarkEvent !== undefined, $legacyBookmarkEvent !== undefined)
+	);
+	let selectedBookmarkList = $derived(
+		resolveSelectedBookmarkList(bookmarkListTabs, selectedBookmarkListId)
+	);
+
+	function getTabLabel(id: string): string {
+		return id === legacyBookmarkListId
+			? $_('bookmarks.old_format')
+			: $_('layout.header.bookmarks');
+	}
+
+	function selectBookmarkList(id: string): void {
+		selectedBookmarkListId = id;
+	}
+
+	async function handleTabKeydown(event: KeyboardEvent): Promise<void> {
+		if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+			return;
+		}
+
+		event.preventDefault();
+		const nextTab = getAdjacentBookmarkListTab(
+			bookmarkListTabs,
+			selectedBookmarkList?.id ?? selectedBookmarkListId,
+			event.key === 'ArrowLeft' ? -1 : 1
+		);
+		if (nextTab === undefined) {
+			return;
+		}
+
+		selectBookmarkList(nextTab.id);
+		await tick();
+		const tabList = (event.currentTarget as HTMLElement).closest('[role="tablist"]');
+		tabList?.querySelector<HTMLElement>(`[role="tab"][data-tab-id="${nextTab.id}"]`)?.focus();
+	}
 
 	// Public bookmarks
 	if ($bookmarkEvent !== undefined) {
@@ -154,30 +201,79 @@
 
 <h1>{$_('layout.header.bookmarks')}</h1>
 
-{#if $bookmarkEvent !== undefined}
-	<h2>Bookmarks</h2>
-
-	<h3>Public</h3>
-
-	<TimelineView items={publicBookmarkEventItems} showLoading={false} />
-
-	{#if privateBookmarkEventItems.length > 0}
-		<h3>Private</h3>
-
-		<TimelineView items={privateBookmarkEventItems} showLoading={false} />
-	{/if}
+{#if bookmarkListTabs.length > 1}
+	<div class="tabs" role="tablist" aria-label={$_('layout.header.bookmarks')}>
+		{#each bookmarkListTabs as tab}
+			<button
+				type="button"
+				role="tab"
+				id={`bookmark-tab-${tab.id}`}
+				data-tab-id={tab.id}
+				aria-controls={`bookmark-panel-${tab.id}`}
+				aria-selected={selectedBookmarkList?.id === tab.id}
+				tabindex={selectedBookmarkList?.id === tab.id ? 0 : -1}
+				onclick={() => selectBookmarkList(tab.id)}
+				onkeydown={handleTabKeydown}
+			>
+				{getTabLabel(tab.id)}
+			</button>
+		{/each}
+	</div>
 {/if}
 
-{#if $legacyBookmarkEvent !== undefined}
-	<h2>Legacy bookmarks</h2>
+{#each bookmarkListTabs as tab}
+	{@const publicItems =
+		tab.id === legacyBookmarkListId ? publicLegacyBookmarkEventItems : publicBookmarkEventItems}
+	{@const privateItems =
+		tab.id === legacyBookmarkListId
+			? privateLegacyBookmarkEventItems
+			: privateBookmarkEventItems}
+	<section
+		id={`bookmark-panel-${tab.id}`}
+		role={bookmarkListTabs.length > 1 ? 'tabpanel' : undefined}
+		aria-labelledby={bookmarkListTabs.length > 1 ? `bookmark-tab-${tab.id}` : undefined}
+		hidden={selectedBookmarkList?.id !== tab.id}
+	>
+		<h2>{$_('pages.public')}</h2>
 
-	<h3>Public</h3>
+		<TimelineView items={publicItems} showLoading={false} />
 
-	<TimelineView items={publicLegacyBookmarkEventItems} showLoading={false} />
+		{#if privateItems.length > 0}
+			<h2>{$_('bookmarks.private')}</h2>
 
-	{#if privateLegacyBookmarkEventItems.length > 0}
-		<h3>Private</h3>
+			<TimelineView items={privateItems} showLoading={false} />
+		{/if}
+	</section>
+{/each}
 
-		<TimelineView items={privateLegacyBookmarkEventItems} showLoading={false} />
-	{/if}
-{/if}
+<style>
+	.tabs {
+		display: flex;
+		gap: 0.5rem;
+		border-bottom: var(--default-border);
+		user-select: none;
+		overflow-x: auto;
+		overflow-y: hidden;
+	}
+
+	.tabs button {
+		padding: 0.75rem 1rem;
+		border: 0;
+		border-bottom: 3px solid transparent;
+		background: transparent;
+		color: var(--foreground);
+		font: inherit;
+		white-space: nowrap;
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.tabs button:hover {
+		background-color: var(--hover-background-color);
+	}
+
+	.tabs button[aria-selected='true'] {
+		border-color: var(--accent);
+		font-weight: bold;
+	}
+</style>

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createRxOneshotReq, uniq } from 'rx-nostr';
+	import type * as Nostr from 'nostr-typedef';
 	import { tap } from 'rxjs';
 	import { tick } from 'svelte';
 	import { _ } from 'svelte-i18n';
@@ -15,25 +16,46 @@
 	import { decryptListContent } from '$lib/List';
 	import {
 		getAdjacentBookmarkListTab,
-		getBookmarkListTabs,
-		getInitialBookmarkListId,
 		legacyBookmarkListId,
 		resolveSelectedBookmarkList
 	} from './BookmarkListTabs';
+	import { BookmarkPageState } from './BookmarkPageState.svelte';
 
 	let { data }: LayoutProps = $props();
 
-	let publicBookmarkEventItems: EventItem[] = $state([]);
 	let privateBookmarkEventItems: EventItem[] = $state([]);
-	let publicLegacyBookmarkEventItems: EventItem[] = $state([]);
 	let privateLegacyBookmarkEventItems: EventItem[] = $state([]);
-	let selectedBookmarkListId = $state(
-		getInitialBookmarkListId($bookmarkEvent !== undefined, $legacyBookmarkEvent !== undefined)
-	);
 
-	let bookmarkListTabs = $derived(getBookmarkListTabs($legacyBookmarkEvent !== undefined));
+	function loadPublicItems(event: Nostr.Event, addItem: (item: EventItem) => void): () => void {
+		const ids = filterTags('e', event.tags);
+		if (ids.length === 0) {
+			return () => {};
+		}
+		const eventsReq = createRxOneshotReq({ filters: [{ ids }] });
+		const subscription = rxNostr
+			.use(eventsReq)
+			.pipe(
+				tie,
+				uniq(),
+				tap(({ event }) => {
+					referencesReqEmit(event);
+					authorActionReqEmit(event);
+				})
+			)
+			.subscribe(({ event }) => addItem(new EventItem(event)));
+		return () => subscription.unsubscribe();
+	}
+
+	const pageState = new BookmarkPageState(
+		bookmarkEvent,
+		legacyBookmarkEvent,
+		loadPublicItems,
+		reverseChronologicalItem
+	);
+	$effect(() => pageState.destroy.bind(pageState));
+	let bookmarkListTabs = $derived(pageState.bookmarkListTabs);
 	let selectedBookmarkList = $derived(
-		resolveSelectedBookmarkList(bookmarkListTabs, selectedBookmarkListId)
+		resolveSelectedBookmarkList(bookmarkListTabs, pageState.selectedBookmarkListId)
 	);
 
 	function getTabLabel(id: string): string {
@@ -43,7 +65,7 @@
 	}
 
 	function selectBookmarkList(id: string): void {
-		selectedBookmarkListId = id;
+		pageState.selectBookmarkList(id);
 	}
 
 	async function handleTabKeydown(event: KeyboardEvent): Promise<void> {
@@ -54,7 +76,7 @@
 		event.preventDefault();
 		const nextTab = getAdjacentBookmarkListTab(
 			bookmarkListTabs,
-			selectedBookmarkList?.id ?? selectedBookmarkListId,
+			selectedBookmarkList?.id ?? pageState.selectedBookmarkListId,
 			event.key === 'ArrowLeft' ? -1 : 1
 		);
 		if (nextTab === undefined) {
@@ -65,60 +87,6 @@
 		await tick();
 		const tabList = (event.currentTarget as HTMLElement).closest('[role="tablist"]');
 		tabList?.querySelector<HTMLElement>(`[role="tab"][data-tab-id="${nextTab.id}"]`)?.focus();
-	}
-
-	// Public bookmarks
-	if ($bookmarkEvent !== undefined) {
-		const ids = filterTags('e', $bookmarkEvent.tags);
-		if (ids.length > 0) {
-			const eventsReq = createRxOneshotReq({
-				filters: [
-					{
-						ids
-					}
-				]
-			});
-			rxNostr
-				.use(eventsReq)
-				.pipe(
-					tie,
-					uniq(),
-					tap(({ event }) => {
-						referencesReqEmit(event);
-						authorActionReqEmit(event);
-					})
-				)
-				.subscribe((packet) => {
-					console.debug('[bookmark public]', packet);
-					publicBookmarkEventItems.push(new EventItem(packet.event));
-					publicBookmarkEventItems =
-						publicBookmarkEventItems.sort(reverseChronologicalItem);
-				});
-		}
-	}
-
-	// Public legacy bookmarks
-	if ($legacyBookmarkEvent !== undefined) {
-		const ids = filterTags('e', $legacyBookmarkEvent.tags);
-		if (ids.length > 0) {
-			const eventsReq = createRxOneshotReq({ filters: [{ ids }] });
-			rxNostr
-				.use(eventsReq)
-				.pipe(
-					tie,
-					uniq(),
-					tap(({ event }) => {
-						referencesReqEmit(event);
-						authorActionReqEmit(event);
-					})
-				)
-				.subscribe((packet) => {
-					console.debug('[legacy bookmark public]', packet);
-					publicLegacyBookmarkEventItems.push(new EventItem(packet.event));
-					publicLegacyBookmarkEventItems =
-						publicLegacyBookmarkEventItems.sort(reverseChronologicalItem);
-				});
-		}
 	}
 
 	// Private bookmarks
@@ -221,7 +189,9 @@
 
 {#each bookmarkListTabs as tab}
 	{@const publicItems =
-		tab.id === legacyBookmarkListId ? publicLegacyBookmarkEventItems : publicBookmarkEventItems}
+		tab.id === legacyBookmarkListId
+			? pageState.publicLegacyBookmarkEventItems
+			: pageState.publicBookmarkEventItems}
 	{@const privateItems =
 		tab.id === legacyBookmarkListId
 			? privateLegacyBookmarkEventItems

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -2,7 +2,7 @@
 	import { createRxOneshotReq, uniq } from 'rx-nostr';
 	import type * as Nostr from 'nostr-typedef';
 	import { tap } from 'rxjs';
-	import { tick } from 'svelte';
+	import { onDestroy, tick } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import { pubkey as authorPubkey, rom } from '$lib/stores/Author';
 	import TimelineView from '../../TimelineView.svelte';
@@ -52,7 +52,7 @@
 		loadPublicItems,
 		reverseChronologicalItem
 	);
-	$effect(() => pageState.destroy.bind(pageState));
+	onDestroy(() => pageState.destroy());
 	let bookmarkListTabs = $derived(pageState.bookmarkListTabs);
 	let selectedBookmarkList = $derived(
 		resolveSelectedBookmarkList(bookmarkListTabs, pageState.selectedBookmarkListId)

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -16,9 +16,9 @@
 	import {
 		getAdjacentBookmarkListTab,
 		getBookmarkListTabs,
+		getInitialBookmarkListId,
 		legacyBookmarkListId,
-		resolveSelectedBookmarkList,
-		standardBookmarkListId
+		resolveSelectedBookmarkList
 	} from './BookmarkListTabs';
 
 	let { data }: LayoutProps = $props();
@@ -27,11 +27,11 @@
 	let privateBookmarkEventItems: EventItem[] = $state([]);
 	let publicLegacyBookmarkEventItems: EventItem[] = $state([]);
 	let privateLegacyBookmarkEventItems: EventItem[] = $state([]);
-	let selectedBookmarkListId = $state(standardBookmarkListId);
-
-	let bookmarkListTabs = $derived(
-		getBookmarkListTabs($bookmarkEvent !== undefined, $legacyBookmarkEvent !== undefined)
+	let selectedBookmarkListId = $state(
+		getInitialBookmarkListId($bookmarkEvent !== undefined, $legacyBookmarkEvent !== undefined)
 	);
+
+	let bookmarkListTabs = $derived(getBookmarkListTabs($legacyBookmarkEvent !== undefined));
 	let selectedBookmarkList = $derived(
 		resolveSelectedBookmarkList(bookmarkListTabs, selectedBookmarkListId)
 	);
@@ -201,25 +201,23 @@
 
 <h1>{$_('layout.header.bookmarks')}</h1>
 
-{#if bookmarkListTabs.length > 1}
-	<div class="tabs" role="tablist" aria-label={$_('layout.header.bookmarks')}>
-		{#each bookmarkListTabs as tab}
-			<button
-				type="button"
-				role="tab"
-				id={`bookmark-tab-${tab.id}`}
-				data-tab-id={tab.id}
-				aria-controls={`bookmark-panel-${tab.id}`}
-				aria-selected={selectedBookmarkList?.id === tab.id}
-				tabindex={selectedBookmarkList?.id === tab.id ? 0 : -1}
-				onclick={() => selectBookmarkList(tab.id)}
-				onkeydown={handleTabKeydown}
-			>
-				{getTabLabel(tab.id)}
-			</button>
-		{/each}
-	</div>
-{/if}
+<div class="tabs" role="tablist" aria-label={$_('layout.header.bookmarks')}>
+	{#each bookmarkListTabs as tab}
+		<button
+			type="button"
+			role="tab"
+			id={`bookmark-tab-${tab.id}`}
+			data-tab-id={tab.id}
+			aria-controls={`bookmark-panel-${tab.id}`}
+			aria-selected={selectedBookmarkList?.id === tab.id}
+			tabindex={selectedBookmarkList?.id === tab.id ? 0 : -1}
+			onclick={() => selectBookmarkList(tab.id)}
+			onkeydown={handleTabKeydown}
+		>
+			{getTabLabel(tab.id)}
+		</button>
+	{/each}
+</div>
 
 {#each bookmarkListTabs as tab}
 	{@const publicItems =
@@ -228,10 +226,10 @@
 		tab.id === legacyBookmarkListId
 			? privateLegacyBookmarkEventItems
 			: privateBookmarkEventItems}
-	<section
+	<div
 		id={`bookmark-panel-${tab.id}`}
-		role={bookmarkListTabs.length > 1 ? 'tabpanel' : undefined}
-		aria-labelledby={bookmarkListTabs.length > 1 ? `bookmark-tab-${tab.id}` : undefined}
+		role="tabpanel"
+		aria-labelledby={`bookmark-tab-${tab.id}`}
 		hidden={selectedBookmarkList?.id !== tab.id}
 	>
 		<h2>{$_('pages.public')}</h2>
@@ -243,7 +241,7 @@
 
 			<TimelineView items={privateItems} showLoading={false} />
 		{/if}
-	</section>
+	</div>
 {/each}
 
 <style>

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -169,9 +169,10 @@
 
 <h1>{$_('layout.header.bookmarks')}</h1>
 
-<div class="tabs" role="tablist" aria-label={$_('layout.header.bookmarks')}>
+<div class="bookmark-tabs" role="tablist" aria-label={$_('layout.header.bookmarks')}>
 	{#each bookmarkListTabs as tab}
 		<button
+			class="bookmark-tab"
 			type="button"
 			role="tab"
 			id={`bookmark-tab-${tab.id}`}
@@ -215,33 +216,47 @@
 {/each}
 
 <style>
-	.tabs {
+	.bookmark-tabs {
 		display: flex;
 		gap: 0.5rem;
+		margin-bottom: 0.5rem;
 		border-bottom: var(--default-border);
 		user-select: none;
 		overflow-x: auto;
 		overflow-y: hidden;
+		flex-wrap: nowrap;
 	}
 
-	.tabs button {
+	.bookmark-tab {
+		flex: 0 0 auto;
 		padding: 0.75rem 1rem;
 		border: 0;
 		border-bottom: 3px solid transparent;
+		border-radius: 0;
 		background: transparent;
 		color: var(--foreground);
 		font: inherit;
+		font-weight: normal;
 		white-space: nowrap;
 		cursor: pointer;
-		transition: all 0.2s ease;
+		opacity: 1;
+		transition:
+			background-color 0.2s ease,
+			border-color 0.2s ease;
 	}
 
-	.tabs button:hover {
+	.bookmark-tab:hover {
 		background-color: var(--hover-background-color);
+		opacity: 1;
 	}
 
-	.tabs button[aria-selected='true'] {
-		border-color: var(--accent);
+	.bookmark-tab:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: -2px;
+	}
+
+	.bookmark-tab[aria-selected='true'] {
+		border-bottom-color: var(--accent);
 		font-weight: bold;
 	}
 </style>

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.test.ts
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+	getAdjacentBookmarkListTab,
+	getBookmarkListTabs,
+	legacyBookmarkListId,
+	resolveSelectedBookmarkList,
+	standardBookmarkListId
+} from './BookmarkListTabs';
+
+describe('Bookmark list tabs', () => {
+	it.each([
+		[true, false, standardBookmarkListId],
+		[false, true, legacyBookmarkListId]
+	])('shows the only available list without a tab choice', (hasStandard, hasLegacy, expected) => {
+		const tabs = getBookmarkListTabs(hasStandard, hasLegacy);
+
+		expect(tabs).toHaveLength(1);
+		expect(resolveSelectedBookmarkList(tabs, standardBookmarkListId)?.id).toBe(expected);
+	});
+
+	it('selects the standard list initially when both formats exist', () => {
+		const tabs = getBookmarkListTabs(true, true);
+
+		expect(tabs.map(({ id }) => id)).toEqual([standardBookmarkListId, legacyBookmarkListId]);
+		expect(resolveSelectedBookmarkList(tabs, standardBookmarkListId)?.id).toBe(
+			standardBookmarkListId
+		);
+	});
+
+	it('switches to only the selected list and supports arrow-key navigation', () => {
+		const tabs = getBookmarkListTabs(true, true);
+		const next = getAdjacentBookmarkListTab(tabs, standardBookmarkListId, 1);
+
+		expect(resolveSelectedBookmarkList(tabs, next?.id ?? '')?.id).toBe(legacyBookmarkListId);
+		expect(getAdjacentBookmarkListTab(tabs, legacyBookmarkListId, -1)?.id).toBe(
+			standardBookmarkListId
+		);
+	});
+});

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.test.ts
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	getAdjacentBookmarkListTab,
 	getBookmarkListTabs,
+	getInitialBookmarkListId,
 	legacyBookmarkListId,
 	resolveSelectedBookmarkList,
 	standardBookmarkListId
@@ -9,26 +10,23 @@ import {
 
 describe('Bookmark list tabs', () => {
 	it.each([
-		[true, false, standardBookmarkListId],
-		[false, true, legacyBookmarkListId]
-	])('shows the only available list without a tab choice', (hasStandard, hasLegacy, expected) => {
-		const tabs = getBookmarkListTabs(hasStandard, hasLegacy);
+		[false, false, [standardBookmarkListId], standardBookmarkListId],
+		[true, false, [standardBookmarkListId], standardBookmarkListId],
+		[false, true, [standardBookmarkListId, legacyBookmarkListId], legacyBookmarkListId],
+		[true, true, [standardBookmarkListId, legacyBookmarkListId], standardBookmarkListId]
+	])(
+		'builds tabs and selects the initial list for standard=%s legacy=%s',
+		(hasStandard, hasLegacy, expectedTabs, expectedSelection) => {
+			const tabs = getBookmarkListTabs(hasLegacy);
+			const initialId = getInitialBookmarkListId(hasStandard, hasLegacy);
 
-		expect(tabs).toHaveLength(1);
-		expect(resolveSelectedBookmarkList(tabs, standardBookmarkListId)?.id).toBe(expected);
-	});
-
-	it('selects the standard list initially when both formats exist', () => {
-		const tabs = getBookmarkListTabs(true, true);
-
-		expect(tabs.map(({ id }) => id)).toEqual([standardBookmarkListId, legacyBookmarkListId]);
-		expect(resolveSelectedBookmarkList(tabs, standardBookmarkListId)?.id).toBe(
-			standardBookmarkListId
-		);
-	});
+			expect(tabs.map(({ id }) => id)).toEqual(expectedTabs);
+			expect(resolveSelectedBookmarkList(tabs, initialId)?.id).toBe(expectedSelection);
+		}
+	);
 
 	it('switches to only the selected list and supports arrow-key navigation', () => {
-		const tabs = getBookmarkListTabs(true, true);
+		const tabs = getBookmarkListTabs(true);
 		const next = getAdjacentBookmarkListTab(tabs, standardBookmarkListId, 1);
 
 		expect(resolveSelectedBookmarkList(tabs, next?.id ?? '')?.id).toBe(legacyBookmarkListId);

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.ts
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.ts
@@ -1,0 +1,35 @@
+export const standardBookmarkListId = 'standard';
+export const legacyBookmarkListId = 'legacy';
+
+export type BookmarkListTab = {
+	id: string;
+};
+
+export function getBookmarkListTabs(
+	hasStandardBookmarks: boolean,
+	hasLegacyBookmarks: boolean
+): BookmarkListTab[] {
+	return [
+		...(hasStandardBookmarks ? [{ id: standardBookmarkListId }] : []),
+		...(hasLegacyBookmarks ? [{ id: legacyBookmarkListId }] : [])
+	];
+}
+
+export function resolveSelectedBookmarkList(
+	tabs: BookmarkListTab[],
+	selectedId: string
+): BookmarkListTab | undefined {
+	return tabs.find(({ id }) => id === selectedId) ?? tabs[0];
+}
+
+export function getAdjacentBookmarkListTab(
+	tabs: BookmarkListTab[],
+	selectedId: string,
+	offset: -1 | 1
+): BookmarkListTab | undefined {
+	const selectedIndex = tabs.findIndex(({ id }) => id === selectedId);
+	if (selectedIndex === -1 || tabs.length === 0) {
+		return tabs[0];
+	}
+	return tabs[(selectedIndex + offset + tabs.length) % tabs.length];
+}

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.ts
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkListTabs.ts
@@ -5,14 +5,20 @@ export type BookmarkListTab = {
 	id: string;
 };
 
-export function getBookmarkListTabs(
-	hasStandardBookmarks: boolean,
-	hasLegacyBookmarks: boolean
-): BookmarkListTab[] {
+export function getBookmarkListTabs(hasLegacyBookmarks: boolean): BookmarkListTab[] {
 	return [
-		...(hasStandardBookmarks ? [{ id: standardBookmarkListId }] : []),
+		{ id: standardBookmarkListId },
 		...(hasLegacyBookmarks ? [{ id: legacyBookmarkListId }] : [])
 	];
+}
+
+export function getInitialBookmarkListId(
+	hasStandardBookmarks: boolean,
+	hasLegacyBookmarks: boolean
+): string {
+	return !hasStandardBookmarks && hasLegacyBookmarks
+		? legacyBookmarkListId
+		: standardBookmarkListId;
 }
 
 export function resolveSelectedBookmarkList(

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkPageState.svelte.ts
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkPageState.svelte.ts
@@ -1,0 +1,90 @@
+import type * as Nostr from 'nostr-typedef';
+import type { Writable } from 'svelte/store';
+import {
+	getBookmarkListTabs,
+	getInitialBookmarkListId,
+	standardBookmarkListId
+} from './BookmarkListTabs';
+
+type LoadPublicItems<T> = (event: Nostr.Event, addItem: (item: T) => void) => () => void;
+
+export class BookmarkPageState<T> {
+	publicBookmarkEventItems: T[] = $state([]);
+	publicLegacyBookmarkEventItems: T[] = $state([]);
+	selectedBookmarkListId = $state(standardBookmarkListId);
+	selectionFinalized = $state(false);
+
+	#bookmarkEvent: Nostr.Event | undefined = $state();
+	#legacyBookmarkEvent: Nostr.Event | undefined = $state();
+	#unsubscribeBookmarkEvent: () => void;
+	#unsubscribeLegacyBookmarkEvent: () => void;
+	#cleanupPublicBookmarks: (() => void) | undefined;
+	#cleanupPublicLegacyBookmarks: (() => void) | undefined;
+
+	bookmarkListTabs = $derived(getBookmarkListTabs(this.#legacyBookmarkEvent !== undefined));
+
+	constructor(
+		bookmarkEvent: Writable<Nostr.Event | undefined>,
+		legacyBookmarkEvent: Writable<Nostr.Event | undefined>,
+		loadPublicItems: LoadPublicItems<T>,
+		compareItems: (a: T, b: T) => number
+	) {
+		this.#unsubscribeBookmarkEvent = bookmarkEvent.subscribe((event) => {
+			this.#bookmarkEvent = event;
+			this.#finalizeInitialSelection();
+			this.#cleanupPublicBookmarks?.();
+			this.#cleanupPublicBookmarks = undefined;
+			this.publicBookmarkEventItems = [];
+			if (event === undefined) {
+				return;
+			}
+			this.#cleanupPublicBookmarks = loadPublicItems(event, (item) => {
+				this.publicBookmarkEventItems = [...this.publicBookmarkEventItems, item].sort(
+					compareItems
+				);
+			});
+		});
+
+		this.#unsubscribeLegacyBookmarkEvent = legacyBookmarkEvent.subscribe((event) => {
+			this.#legacyBookmarkEvent = event;
+			this.#finalizeInitialSelection();
+			this.#cleanupPublicLegacyBookmarks?.();
+			this.#cleanupPublicLegacyBookmarks = undefined;
+			this.publicLegacyBookmarkEventItems = [];
+			if (event === undefined) {
+				return;
+			}
+			this.#cleanupPublicLegacyBookmarks = loadPublicItems(event, (item) => {
+				this.publicLegacyBookmarkEventItems = [
+					...this.publicLegacyBookmarkEventItems,
+					item
+				].sort(compareItems);
+			});
+		});
+	}
+
+	#finalizeInitialSelection(): void {
+		const standardEventAvailable = this.#bookmarkEvent !== undefined;
+		const legacyEventAvailable = this.#legacyBookmarkEvent !== undefined;
+		if (this.selectionFinalized || (!standardEventAvailable && !legacyEventAvailable)) {
+			return;
+		}
+		this.selectedBookmarkListId = getInitialBookmarkListId(
+			standardEventAvailable,
+			legacyEventAvailable
+		);
+		this.selectionFinalized = true;
+	}
+
+	selectBookmarkList(id: string): void {
+		this.selectedBookmarkListId = id;
+		this.selectionFinalized = true;
+	}
+
+	destroy(): void {
+		this.#unsubscribeBookmarkEvent();
+		this.#unsubscribeLegacyBookmarkEvent();
+		this.#cleanupPublicBookmarks?.();
+		this.#cleanupPublicLegacyBookmarks?.();
+	}
+}

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkPageState.test.ts
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/BookmarkPageState.test.ts
@@ -1,0 +1,58 @@
+import type * as Nostr from 'nostr-typedef';
+import { writable } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+import { legacyBookmarkListId, standardBookmarkListId } from './BookmarkListTabs';
+import { BookmarkPageState } from './BookmarkPageState.svelte';
+
+function bookmarkEvent(id: string): Nostr.Event {
+	return { id, pubkey: '', created_at: 0, kind: 0, tags: [], content: '', sig: '' };
+}
+
+describe('Bookmark page state', () => {
+	it('reacts to bookmark events loaded after initialization without mixing lists', () => {
+		const standardEvent = writable<Nostr.Event | undefined>();
+		const legacyEvent = writable<Nostr.Event | undefined>();
+		const addItems = new Map<string, (item: string) => void>();
+		const unsubscribed: string[] = [];
+		const loadPublicItems = vi.fn((event: Nostr.Event, addItem: (item: string) => void) => {
+			addItems.set(event.id, addItem);
+			return () => unsubscribed.push(event.id);
+		});
+		const state = new BookmarkPageState(standardEvent, legacyEvent, loadPublicItems, (a, b) =>
+			a.localeCompare(b)
+		);
+		expect(state.bookmarkListTabs.map(({ id }) => id)).toEqual([standardBookmarkListId]);
+		expect(state.selectedBookmarkListId).toBe(standardBookmarkListId);
+		expect(state.selectionFinalized).toBe(false);
+		expect(loadPublicItems).not.toHaveBeenCalled();
+
+		legacyEvent.set(bookmarkEvent('legacy-1'));
+		expect(state.bookmarkListTabs.map(({ id }) => id)).toEqual([
+			standardBookmarkListId,
+			legacyBookmarkListId
+		]);
+		expect(state.selectedBookmarkListId).toBe(legacyBookmarkListId);
+		expect(loadPublicItems).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'legacy-1' }),
+			expect.any(Function)
+		);
+		addItems.get('legacy-1')?.('legacy item');
+		expect(state.publicLegacyBookmarkEventItems).toEqual(['legacy item']);
+
+		state.selectBookmarkList(standardBookmarkListId);
+		standardEvent.set(bookmarkEvent('standard-1'));
+		addItems.get('standard-1')?.('standard item');
+		expect(state.selectedBookmarkListId).toBe(standardBookmarkListId);
+		expect(state.publicBookmarkEventItems).toEqual(['standard item']);
+		expect(state.publicLegacyBookmarkEventItems).toEqual(['legacy item']);
+
+		legacyEvent.set(bookmarkEvent('legacy-2'));
+		expect(unsubscribed).toContain('legacy-1');
+		expect(state.publicLegacyBookmarkEventItems).toEqual([]);
+		expect(state.publicBookmarkEventItems).toEqual(['standard item']);
+		expect(state.selectedBookmarkListId).toBe(standardBookmarkListId);
+
+		state.destroy();
+		expect(unsubscribed).toEqual(expect.arrayContaining(['standard-1', 'legacy-2']));
+	});
+});


### PR DESCRIPTION
## Summary

- represent the standard kind `10003` Bookmarks event and legacy kind `30001` / `d: "bookmark"` event in independent stores so updates cannot overwrite each other
- fetch and cache kind `10003` through the normal replaceable-event path while retaining the legacy event in parameterized replaceable storage
- use the `nostr-tools` `Kind.BookmarkList` and `Kind.Genericlists` constants, together with a shared legacy bookmark identifier
- make normal Bookmark and Unbookmark actions read and write only the standard list, preserving stale-cache validation without a `d` filter
- always show the current `Bookmarks` tab, including when no kind `10003` event exists, and show `Old format` only when the legacy event exists
- select `Old format` initially for legacy-only users; otherwise select `Bookmarks`
- keep an event-less standard tab as an empty list without publishing until the normal Bookmark write path is used
- keep Public and Private content as sections within the selected list, without merging or deduplicating entries between formats
- support horizontal tab scrolling and arrow-key navigation with WAI-ARIA tab semantics, using a list-based structure that can later accommodate Bookmark sets
- localize the tab and section labels in English and Japanese
- add focused tests for bookmark updates, independent standard/legacy state, tab availability, initial selection, switching, and arrow-key selection

## Validation

- `npm test` (30 files, 297 tests)
- `npm run check` (0 errors and 0 warnings)
- `npm run lint`
- `npm run build`

Closes #2307