### PR TITLE
Restore the official gtag dataLayer queue format

### DIFF
--- a/web/src/lib/components/Gdpr.svelte
+++ b/web/src/lib/components/Gdpr.svelte
@@ -30,9 +30,9 @@
 		console.debug('[analytics init]');
 
 		window.dataLayer = window.dataLayer || [];
-		function gtag(...args: unknown[]) {
-			window.dataLayer.push(args);
-		}
+		const gtag: (...args: unknown[]) => void = function () {
+			window.dataLayer.push(arguments);
+		};
 		gtag('js', new Date());
 
 		gtag('config', 'G-G1WMSV0PBP');


### PR DESCRIPTION
## Summary

- PR #2164 changed the `gtag` wrapper from `dataLayer.push(arguments)` to `dataLayer.push(args)` while adding rest-parameter typing.
- Restore the queue entry to the `arguments` object used by Google's official `gtag.js` implementation.
- Keep TypeScript-compatible variadic calls without changing the Measurement ID, GDPR consent flow, or `gtag.js` loading behavior.

## Validation

- `npm run check`
- `npm run lint`
- `npm test -- --run` (30 files, 297 tests)