### PR TITLE
Contain Spotify embed stacking on mobile

### DIFF
--- a/web/src/lib/components/content/Spotify.svelte
+++ b/web/src/lib/components/content/Spotify.svelte
@@ -50,6 +50,7 @@
 <style>
 	.spotify-embed-card {
 		position: relative;
+		isolation: isolate;
 		width: 100%;
 		max-width: 100%;
 		border-radius: 12px;


### PR DESCRIPTION
## Summary

The touch-first Spotify cover uses `z-index: 10`, but its card did not establish a stacking context. As a result, the internal cover could compete with fixed application navigation and open menus outside the embed.

Add `isolation: isolate` to `.spotify-embed-card` so the cover remains above its iframe while its z-index is contained within the Spotify component. This preserves the mobile external-link behavior and desktop iframe interaction without increasing any global z-index.

Closes #2314

## Verification

- `npm run check`
- `npm run lint`
- `npm test -- --run src/lib/Spotify.test.ts` (5 tests passed)