### PR TITLE
Update blossom-client-sdk to 5.1.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
 				"@rust-nostr/nostr-sdk": "^0.44.0",
 				"@tabler/icons-svelte-runes": "^3.46.0",
 				"async-lock": "^1.4.1",
-				"blossom-client-sdk": "^5.0.0",
+				"blossom-client-sdk": "^5.1.0",
 				"dexie": "^4.4.2",
 				"emoji-kitchen-mart": "^6.0.5",
 				"escape-string-regexp": "^5.0.0",
@@ -3276,9 +3276,9 @@
 			"license": "MIT"
 		},
 		"node_modules/blossom-client-sdk": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/blossom-client-sdk/-/blossom-client-sdk-5.0.0.tgz",
-			"integrity": "sha512-xz7w6eBQv6uiNK9ogh5AymnzCAohiU029XySpKxJyG7RsDHkoru+xoZhY55tiIOyWFX/5s8pip4hVh5hO1PN/Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/blossom-client-sdk/-/blossom-client-sdk-5.1.0.tgz",
+			"integrity": "sha512-LINszlSe2ehQ9yzFdBbdFYKja+UR0YP//66e2XZaAUFRwexb3faRMQ2PArliqoSlrWY6g5kkaCCL58NUxEFfNA==",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/hashes": "^1.8.0"
@@ -3287,13 +3287,9 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@cashu/cashu-ts": "^2.4.3",
 				"hls.js": "^1.6.16"
 			},
 			"peerDependenciesMeta": {
-				"@cashu/cashu-ts": {
-					"optional": true
-				},
 				"hls.js": {
 					"optional": true
 				}

--- a/web/package.json
+++ b/web/package.json
@@ -55,7 +55,7 @@
 		"@rust-nostr/nostr-sdk": "^0.44.0",
 		"@tabler/icons-svelte-runes": "^3.46.0",
 		"async-lock": "^1.4.1",
-		"blossom-client-sdk": "^5.0.0",
+		"blossom-client-sdk": "^5.1.0",
 		"dexie": "^4.4.2",
 		"emoji-kitchen-mart": "^6.0.5",
 		"escape-string-regexp": "^5.0.0",

--- a/web/src/lib/shims/cashu-disabled.ts
+++ b/web/src/lib/shims/cashu-disabled.ts
@@ -1,2 +1,0 @@
-// Work around blossom-client-sdk resolving its optional Cashu peer dependency during Wrangler bundling.
-throw new Error('Cashu payment support is not enabled');

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -14,9 +14,6 @@
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"
 	},
-	"alias": {
-		"@cashu/cashu-ts": "./src/lib/shims/cashu-disabled.ts"
-	},
 	"kv_namespaces": [
 		{
 			"binding": "RESTRICTION",


### PR DESCRIPTION
## Summary

- update `blossom-client-sdk` to 5.1.0
- remove the temporary Cashu Wrangler alias and runtime-error shim added in #2298
- use the upstream fix that removes the optional `@cashu/cashu-ts` peer dependency
- leave `web/.npmrc` and its `min-release-age=14` policy unchanged

The dependency update was intentionally performed once with `npm install blossom-client-sdk@^5.1.0 --min-release-age=0`. No equivalent configuration was persisted.

Upstream: https://github.com/hzrd149/blossom-client-sdk/pull/18

## Validation

- `npm ls blossom-client-sdk` — passed; resolved 5.1.0
- installed package metadata inspection — passed; `@cashu/cashu-ts` is absent from peer dependencies
- `npm ci` — passed without `--min-release-age=0`
- `npm test -- --run` — passed; 30 files and 297 tests
- `npm run check` — passed; 0 errors and 0 warnings
- `npm run lint` — passed
- `npm run build` — passed
- `npx wrangler versions upload --dry-run` — passed; bundling succeeds without the Cashu alias/shim and without the previous resolution error
- `git diff --check` — passed