### PR TITLE
Share compact media attachment UI

### DIFF
--- a/web/src/lib/components/MediaAttachments.svelte
+++ b/web/src/lib/components/MediaAttachments.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	import { IconTrash } from '@tabler/icons-svelte-runes';
+	import { _ } from 'svelte-i18n';
+	import type { LocalAttachment } from '$lib/media/LocalAttachment';
+	import LocalMedia from './content/LocalMedia.svelte';
+
+	interface Props {
+		attachments: LocalAttachment[];
+		disabled?: boolean;
+		onRetry: (attachment: LocalAttachment) => void | Promise<void>;
+		onRemove: (attachment: LocalAttachment) => void;
+		onAddUrls: () => void | Promise<void>;
+	}
+
+	let { attachments, disabled = false, onRetry, onRemove, onAddUrls }: Props = $props();
+</script>
+
+{#if attachments.length > 0}
+	<section class="attachments" aria-label={$_('media.attachments.title')}>
+		<ul>
+			{#each attachments as attachment}
+				<li>
+					<div class="attachment-preview">
+						<LocalMedia media={{ url: attachment.previewUrl, kind: attachment.kind }} />
+					</div>
+					<div class="attachment-details">
+						<span class="attachment-name">{attachment.file.name}</span>
+						<span class="attachment-state" class:failed={attachment.state === 'failed'}>
+							{$_(`media.attachments.state.${attachment.state}`)}
+						</span>
+					</div>
+					<div class="attachment-actions">
+						{#if attachment.state === 'failed'}
+							<button
+								class="retry-attachment"
+								onclick={() => onRetry(attachment)}
+								{disabled}
+							>
+								{$_('media.attachments.retry')}
+							</button>
+						{/if}
+						<button
+							class="remove-attachment"
+							onclick={() => onRemove(attachment)}
+							{disabled}
+							aria-label={$_('media.attachments.remove')}
+							title={$_('media.attachments.remove')}
+						>
+							<IconTrash size={18} />
+						</button>
+					</div>
+				</li>
+			{/each}
+		</ul>
+		<button class="add-urls" onclick={onAddUrls} {disabled}>
+			{$_('media.attachments.add_urls')}
+		</button>
+	</section>
+{/if}
+
+<style>
+	.attachments {
+		margin: 0.25rem 0.5rem 0.5rem;
+	}
+
+	ul {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		max-height: min(12rem, 30dvh);
+		margin: 0;
+		padding: 0;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		list-style: none;
+	}
+
+	li {
+		display: grid;
+		grid-template-columns: minmax(4rem, 6rem) minmax(0, 1fr) auto;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.25rem;
+		border-radius: var(--radius);
+		background: var(--accent-surface-low);
+	}
+
+	.attachment-preview {
+		max-height: 3.5rem;
+		overflow: hidden;
+	}
+
+	.attachment-preview :global(img),
+	.attachment-preview :global(video) {
+		min-width: 0;
+		max-width: 100%;
+		max-height: 3.5rem;
+		margin: 0;
+	}
+
+	.attachment-preview :global(audio) {
+		width: 100%;
+		max-width: 100%;
+		height: 2.5rem;
+	}
+
+	.attachment-details,
+	.attachment-actions {
+		display: flex;
+		gap: 0.35rem;
+	}
+
+	.attachment-details {
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	.attachment-actions {
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	.attachment-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 0.85rem;
+	}
+
+	.attachment-state {
+		color: var(--accent-gray);
+		font-size: 0.75rem;
+	}
+
+	.attachment-state.failed {
+		color: var(--red);
+		font-weight: bold;
+	}
+
+	.retry-attachment {
+		padding: 0.3rem 0.6rem;
+		border: 1px solid var(--accent-gray);
+		background: transparent;
+		color: var(--accent-gray);
+		font-size: 0.75rem;
+	}
+
+	.remove-attachment {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		border-radius: 50%;
+		background: transparent;
+		color: var(--accent-gray);
+	}
+
+	.retry-attachment:hover:not(:disabled),
+	.remove-attachment:hover:not(:disabled),
+	.remove-attachment:focus-visible {
+		opacity: 1;
+		background: var(--accent-surface-high);
+		color: var(--foreground);
+	}
+
+	.retry-attachment:focus-visible,
+	.remove-attachment:focus-visible,
+	.add-urls:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	.add-urls {
+		display: block;
+		width: fit-content;
+		margin: 0.25rem 0 0 auto;
+		padding: 0.2rem 0.125rem;
+		border-radius: 0;
+		background: transparent;
+		color: var(--accent-gray);
+		font-size: 0.75rem;
+		font-weight: normal;
+		text-decoration: none;
+	}
+
+	.add-urls:hover:not(:disabled),
+	.add-urls:focus-visible {
+		opacity: 1;
+		color: var(--foreground);
+		text-decoration: underline;
+		text-underline-offset: 0.2em;
+	}
+
+	@media screen and (max-width: 600px) {
+		ul {
+			max-height: min(10rem, 25dvh);
+		}
+
+		li {
+			grid-template-columns: 4rem minmax(0, 1fr) auto;
+			gap: 0.35rem;
+		}
+
+		.attachment-actions {
+			gap: 0.2rem;
+		}
+	}
+</style>

--- a/web/src/lib/components/MediaAttachments.svelte
+++ b/web/src/lib/components/MediaAttachments.svelte
@@ -175,13 +175,14 @@
 	.add-urls {
 		display: block;
 		width: fit-content;
-		margin: 0.25rem 0 0 auto;
-		padding: 0.2rem 0.125rem;
+		margin: 0.25rem 0 0;
+		padding: 0.125rem 0.25rem;
 		border-radius: 0;
 		background: transparent;
 		color: var(--accent-gray);
-		font-size: 0.75rem;
+		font-size: 1rem;
 		font-weight: normal;
+		line-height: 1.25;
 		text-decoration: none;
 	}
 

--- a/web/src/lib/components/MediaAttachments.svelte
+++ b/web/src/lib/components/MediaAttachments.svelte
@@ -25,9 +25,14 @@
 					</div>
 					<div class="attachment-details">
 						<span class="attachment-name">{attachment.file.name}</span>
-						<span class="attachment-state" class:failed={attachment.state === 'failed'}>
-							{$_(`media.attachments.state.${attachment.state}`)}
-						</span>
+						{#if attachment.state !== 'pending'}
+							<span
+								class="attachment-state"
+								class:failed={attachment.state === 'failed'}
+							>
+								{$_(`media.attachments.state.${attachment.state}`)}
+							</span>
+						{/if}
 					</div>
 					<div class="attachment-actions">
 						{#if attachment.state === 'failed'}

--- a/web/src/lib/components/editor/NoteEditor.svelte
+++ b/web/src/lib/components/editor/NoteEditor.svelte
@@ -45,8 +45,7 @@
 		uploadLocalAttachments,
 		type LocalAttachment
 	} from '$lib/media/LocalAttachment';
-	import LocalMedia from '../content/LocalMedia.svelte';
-	import IconTrash from '@tabler/icons-svelte-runes/icons/trash';
+	import MediaAttachments from '../MediaAttachments.svelte';
 
 	export function clear(closed = false): void {
 		if (editorLocked) return;
@@ -750,52 +749,13 @@
 		</div>
 	</div>
 
-	{#if attachments.length > 0}
-		<section class="attachments card" aria-label={$_('media.attachments.title')}>
-			<ul>
-				{#each attachments as attachment}
-					<li>
-						<div class="attachment-preview">
-							<LocalMedia
-								media={{ url: attachment.previewUrl, kind: attachment.kind }}
-							/>
-						</div>
-						<div class="attachment-details">
-							<span class="attachment-name">{attachment.file.name}</span>
-							<span
-								class="attachment-state"
-								class:failed={attachment.state === 'failed'}
-							>
-								{$_(`media.attachments.state.${attachment.state}`)}
-							</span>
-						</div>
-						<div class="attachment-actions">
-							{#if attachment.state === 'failed'}
-								<button
-									onclick={() => retryAttachment(attachment)}
-									disabled={editorLocked}
-								>
-									{$_('media.attachments.retry')}
-								</button>
-							{/if}
-							<button
-								class="remove-attachment"
-								onclick={() => removeAttachment(attachment)}
-								disabled={editorLocked}
-								aria-label={$_('media.attachments.remove')}
-								title={$_('media.attachments.remove')}
-							>
-								<IconTrash size={18} />
-							</button>
-						</div>
-					</li>
-				{/each}
-			</ul>
-			<button class="add-urls" onclick={addAttachmentUrls} disabled={editorLocked}>
-				{$_('media.attachments.add_urls')}
-			</button>
-		</section>
-	{/if}
+	<MediaAttachments
+		{attachments}
+		disabled={editorLocked}
+		onRetry={retryAttachment}
+		onRemove={removeAttachment}
+		onAddUrls={addAttachmentUrls}
+	/>
 
 	<div class="actions">
 		<div class="options">
@@ -933,137 +893,6 @@
 		margin: 1rem;
 		max-height: 30rem;
 		overflow-y: auto;
-	}
-
-	.attachments {
-		margin: 1rem;
-		padding: 0.75rem;
-	}
-
-	.attachments ul {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		margin: 0 0 0.75rem;
-	}
-
-	.attachments li {
-		display: grid;
-		grid-template-columns: minmax(5rem, 8rem) minmax(0, 1fr) auto;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.attachment-preview {
-		max-height: 6rem;
-		overflow: hidden;
-	}
-
-	.attachment-preview :global(img),
-	.attachment-preview :global(video) {
-		max-width: 100%;
-		max-height: 6rem;
-	}
-
-	.attachment-preview :global(audio) {
-		max-width: 100%;
-	}
-
-	.attachment-details,
-	.attachment-actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.attachment-details {
-		flex-direction: column;
-		min-width: 0;
-	}
-
-	.attachment-actions {
-		align-items: center;
-		justify-content: flex-end;
-	}
-
-	.attachment-name {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.attachment-state {
-		color: var(--accent-gray);
-		font-size: 0.8rem;
-		font-weight: normal;
-	}
-
-	.attachment-state.failed {
-		color: var(--red);
-		font-weight: bold;
-	}
-
-	.remove-attachment {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 2rem;
-		height: 2rem;
-		padding: 0;
-		border-radius: 50%;
-		background: transparent;
-		color: var(--accent-gray);
-	}
-
-	.remove-attachment:hover:not(:disabled),
-	.remove-attachment:focus-visible {
-		opacity: 1;
-		background: var(--accent-surface-high);
-		color: var(--foreground);
-	}
-
-	.remove-attachment:focus-visible,
-	.add-urls:focus-visible {
-		outline: 2px solid var(--accent);
-		outline-offset: 2px;
-	}
-
-	.add-urls {
-		display: block;
-		width: fit-content;
-		margin: 0.25rem 0 0 auto;
-		padding: 0.25rem 0.125rem;
-		border-radius: 0;
-		background: transparent;
-		color: var(--accent-gray);
-		font-weight: normal;
-		text-decoration: none;
-	}
-
-	.add-urls:hover:not(:disabled),
-	.add-urls:focus-visible {
-		opacity: 1;
-		color: var(--foreground);
-		text-decoration: underline;
-		text-underline-offset: 0.2em;
-	}
-
-	@media screen and (max-width: 480px) {
-		.attachments {
-			margin-inline: 0.5rem;
-		}
-
-		.attachments li {
-			grid-template-columns: minmax(4.5rem, 6rem) minmax(0, 1fr) auto;
-			gap: 0.5rem;
-		}
-
-		.attachment-actions {
-			gap: 0.25rem;
-		}
-
-		.attachment-actions > button:not(.remove-attachment) {
-			padding-inline: 0.65rem;
-		}
 	}
 
 	.options {

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -4,7 +4,7 @@
 	import { npubEncode } from 'nostr-tools/nip19';
 	import { ChannelMessage } from 'nostr-tools/kinds';
 	import { _ } from 'svelte-i18n';
-	import { IconSend, IconTrash, IconX } from '@tabler/icons-svelte-runes';
+	import { IconSend, IconX } from '@tabler/icons-svelte-runes';
 	import { NoteComposer } from '$lib/NoteComposer';
 	import { Content } from '$lib/Content';
 	import { rxNostr } from '$lib/timelines/MainTimeline';
@@ -14,7 +14,7 @@
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
 	import type { PickerEmoji } from '$lib/Emoji';
 	import MediaPicker from '$lib/components/MediaPicker.svelte';
-	import LocalMedia from '$lib/components/content/LocalMedia.svelte';
+	import MediaAttachments from '$lib/components/MediaAttachments.svelte';
 	import {
 		appendUrls,
 		createLocalAttachments,
@@ -221,53 +221,13 @@
 			</button>
 		</div>
 	{/if}
-	{#if attachments.length > 0}
-		<section class="attachments" aria-label={$_('media.attachments.title')}>
-			<ul>
-				{#each attachments as attachment}
-					<li>
-						<div class="attachment-preview">
-							<LocalMedia
-								media={{ url: attachment.previewUrl, kind: attachment.kind }}
-							/>
-						</div>
-						<div class="attachment-details">
-							<span class="attachment-name">{attachment.file.name}</span>
-							<span
-								class="attachment-state"
-								class:failed={attachment.state === 'failed'}
-							>
-								{$_(`media.attachments.state.${attachment.state}`)}
-							</span>
-						</div>
-						<div class="attachment-actions">
-							{#if attachment.state === 'failed'}
-								<button
-									class="retry-attachment"
-									onclick={() => retryAttachment(attachment)}
-									disabled={composerLocked}
-								>
-									{$_('media.attachments.retry')}
-								</button>
-							{/if}
-							<button
-								class="remove-attachment"
-								onclick={() => removeAttachment(attachment)}
-								disabled={composerLocked}
-								aria-label={$_('media.attachments.remove')}
-								title={$_('media.attachments.remove')}
-							>
-								<IconTrash size={18} />
-							</button>
-						</div>
-					</li>
-				{/each}
-			</ul>
-			<button class="add-urls" onclick={addAttachmentUrls} disabled={composerLocked}>
-				{$_('media.attachments.add_urls')}
-			</button>
-		</section>
-	{/if}
+	<MediaAttachments
+		{attachments}
+		disabled={composerLocked}
+		onRetry={retryAttachment}
+		onRemove={removeAttachment}
+		onAddUrls={addAttachmentUrls}
+	/>
 	<div class="input">
 		<MediaPicker multiple={true} disabled={composerLocked} on:pick={mediaPicked} />
 		<EmojiPicker inEditor={true} onPick={onEmojiPick} />
@@ -335,140 +295,6 @@
 		color: var(--accent-gray);
 	}
 
-	.attachments {
-		padding: 0 0.25rem 0.5rem;
-	}
-
-	.attachments ul {
-		display: flex;
-		flex-direction: column;
-		gap: 0.4rem;
-		margin: 0;
-		padding: 0;
-		list-style: none;
-		max-height: min(12rem, 30dvh);
-		overflow-y: auto;
-		overscroll-behavior: contain;
-	}
-
-	.attachments li {
-		display: grid;
-		grid-template-columns: minmax(4rem, 6rem) minmax(0, 1fr) auto;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.25rem;
-		border-radius: var(--radius);
-		background: var(--accent-surface-low);
-	}
-
-	.attachment-preview {
-		max-height: 3.5rem;
-		overflow: hidden;
-	}
-
-	.attachment-preview :global(img),
-	.attachment-preview :global(video) {
-		min-width: 0;
-		max-width: 100%;
-		max-height: 3.5rem;
-		margin: 0;
-	}
-
-	.attachment-preview :global(audio) {
-		width: 100%;
-		max-width: 100%;
-		height: 2.5rem;
-	}
-
-	.attachment-details,
-	.attachment-actions {
-		display: flex;
-		gap: 0.35rem;
-	}
-
-	.attachment-details {
-		flex-direction: column;
-		min-width: 0;
-	}
-
-	.attachment-actions {
-		align-items: center;
-		justify-content: flex-end;
-	}
-
-	.attachment-name {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		font-size: 0.85rem;
-	}
-
-	.attachment-state {
-		color: var(--accent-gray);
-		font-size: 0.75rem;
-	}
-
-	.attachment-state.failed {
-		color: var(--red);
-		font-weight: bold;
-	}
-
-	.retry-attachment {
-		padding: 0.3rem 0.6rem;
-		border: 1px solid var(--accent-gray);
-		background: transparent;
-		color: var(--accent-gray);
-		font-size: 0.75rem;
-	}
-
-	.remove-attachment {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 2rem;
-		height: 2rem;
-		padding: 0;
-		border-radius: 50%;
-		background: transparent;
-		color: var(--accent-gray);
-	}
-
-	.retry-attachment:hover:not(:disabled),
-	.remove-attachment:hover:not(:disabled),
-	.remove-attachment:focus-visible {
-		opacity: 1;
-		background: var(--accent-surface-high);
-		color: var(--surface-foreground);
-	}
-
-	.retry-attachment:focus-visible,
-	.remove-attachment:focus-visible,
-	.add-urls:focus-visible {
-		outline: 2px solid var(--accent);
-		outline-offset: 2px;
-	}
-
-	.add-urls {
-		display: block;
-		width: fit-content;
-		margin: 0.25rem 0 0 auto;
-		padding: 0.2rem 0.125rem;
-		border-radius: 0;
-		background: transparent;
-		color: var(--accent-gray);
-		font-size: 0.75rem;
-		font-weight: normal;
-		text-decoration: none;
-	}
-
-	.add-urls:hover:not(:disabled),
-	.add-urls:focus-visible {
-		opacity: 1;
-		color: var(--surface-foreground);
-		text-decoration: underline;
-		text-underline-offset: 0.2em;
-	}
-
 	.input {
 		display: flex;
 		align-items: center;
@@ -519,19 +345,6 @@
 	@media screen and (max-width: 600px) {
 		.composer {
 			bottom: calc(3.125rem + env(safe-area-inset-bottom));
-		}
-
-		.attachments li {
-			grid-template-columns: 4rem minmax(0, 1fr) auto;
-			gap: 0.35rem;
-		}
-
-		.attachments ul {
-			max-height: min(10rem, 25dvh);
-		}
-
-		.attachment-actions {
-			gap: 0.2rem;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

- Share the attachment management presentation between NoteEditor and ChannelComposer through a controlled MediaAttachments component.
- Use the same compact preview sizing in both composers.
- Keep long attachment lists bounded with internal scrolling on desktop and mobile.
- Leave attachment state, upload orchestration, and object URL lifecycle in the existing parents and LocalAttachment utilities.

## Validation

- npm test -- --run: passed (33 files, 308 tests)
- npm run check: passed (0 errors and 0 warnings)
- changed-file ESLint: passed
- git diff --check: passed
- npm run lint: formatting passed; repository-wide ESLint was killed by the execution environment
- npm run build: reached SSR chunk rendering after transforming 7,171 modules, then was terminated by the execution environment
