### PR TITLE
Unify mixed Tabler icon imports

### DIFF
--- a/web/src/lib/components/MenuButton.svelte
+++ b/web/src/lib/components/MenuButton.svelte
@@ -11,18 +11,20 @@
 	import { shareUrl } from '$lib/Share';
 	import { rom, pubkey as authorPubkey, mutePubkeys, muteEventIds } from '$lib/stores/Author';
 	import { developerMode } from '$lib/stores/Preference';
-	import IconDots from '@tabler/icons-svelte-runes/icons/dots';
-	import IconBookmark from '@tabler/icons-svelte-runes/icons/bookmark';
-	import IconBookmarkFilled from '@tabler/icons-svelte-runes/icons/bookmark-filled';
-	import IconClipboard from '@tabler/icons-svelte-runes/icons/clipboard';
-	import IconLink from '@tabler/icons-svelte-runes/icons/link';
-	import IconCode from '@tabler/icons-svelte-runes/icons/code';
-	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
-	import IconBroadcast from '@tabler/icons-svelte-runes/icons/broadcast';
-	import IconTrash from '@tabler/icons-svelte-runes/icons/trash';
-	import IconVolumeOff from '@tabler/icons-svelte-runes/icons/volume-off';
-	import IconExternalLink from '@tabler/icons-svelte-runes/icons/external-link';
-	import { IconLanguage } from '@tabler/icons-svelte-runes';
+	import {
+		IconBookmark,
+		IconBookmarkFilled,
+		IconBroadcast,
+		IconClipboard,
+		IconCode,
+		IconCodeDots,
+		IconDots,
+		IconExternalLink,
+		IconLanguage,
+		IconLink,
+		IconTrash,
+		IconVolumeOff
+	} from '@tabler/icons-svelte-runes';
 	import { deleteEvent } from '$lib/author/Delete';
 	import { mute, unmute } from '$lib/author/Mute';
 	import { referTags } from '$lib/EventHelper';

--- a/web/src/lib/components/actions/CustomEmojiMenuButton.svelte
+++ b/web/src/lib/components/actions/CustomEmojiMenuButton.svelte
@@ -3,8 +3,12 @@
 	import { nip19 } from 'nostr-tools';
 	import type * as Nostr from 'nostr-typedef';
 	import { aTagContent, findIdentifier } from '$lib/EventHelper';
-	import { IconDots, IconLibraryMinus, IconLibraryPlus } from '@tabler/icons-svelte-runes';
-	import IconExternalLink from '@tabler/icons-svelte-runes/icons/external-link';
+	import {
+		IconDots,
+		IconExternalLink,
+		IconLibraryMinus,
+		IconLibraryPlus
+	} from '@tabler/icons-svelte-runes';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import { createDropdownMenu, melt } from '@melt-ui/svelte';
 	import {

--- a/web/src/routes/(app)/[slug=note]/+page.svelte
+++ b/web/src/routes/(app)/[slug=note]/+page.svelte
@@ -26,14 +26,11 @@
 	} from '$lib/Constants';
 	import { onDestroy, onMount, tick } from 'svelte';
 	import CustomEmojiPopup from '$lib/components/content/CustomEmojiPopup.svelte';
-	import IconRepeat from '@tabler/icons-svelte-runes/icons/repeat';
-	import IconHeart from '@tabler/icons-svelte-runes/icons/heart';
-	import IconBolt from '@tabler/icons-svelte-runes/icons/bolt';
+	import { IconBolt, IconHeart, IconHeartBroken, IconRepeat } from '@tabler/icons-svelte-runes';
 	import NotFound from '$lib/components/items/NotFound.svelte';
 	import DateLink from '$lib/components/DateLink.svelte';
 	import EventComponent from '$lib/components/items/EventComponent.svelte';
 	import BackButton from '$lib/components/BackButton.svelte';
-	import { IconHeartBroken } from '@tabler/icons-svelte-runes';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	interface Props {

--- a/web/src/routes/(app)/notifications/+page.svelte
+++ b/web/src/routes/(app)/notifications/+page.svelte
@@ -12,12 +12,15 @@
 	import { pubkey, author } from '$lib/stores/Author';
 	import { isReady } from '$lib/auth.svelte';
 	import TimelineView from '../TimelineView.svelte';
-	import IconAt from '@tabler/icons-svelte-runes/icons/at';
-	import IconRepeat from '@tabler/icons-svelte-runes/icons/repeat';
-	import IconHeart from '@tabler/icons-svelte-runes/icons/heart';
-	import IconBolt from '@tabler/icons-svelte-runes/icons/bolt';
+	import {
+		IconAsterisk,
+		IconAt,
+		IconBell,
+		IconBolt,
+		IconHeart,
+		IconRepeat
+	} from '@tabler/icons-svelte-runes';
 	import { Signer } from '$lib/Signer';
-	import { IconAsterisk, IconBell } from '@tabler/icons-svelte-runes';
 	import { createTabs, melt } from '@melt-ui/svelte';
 	import { crossfade } from 'svelte/transition';
 	import { cubicInOut } from 'svelte/easing';


### PR DESCRIPTION
## Summary

- unify Tabler icon imports in the four affected Svelte files
- replace deep imports with named imports from `@tabler/icons-svelte-runes`
- preserve the existing icons and behavior

## Verification

- `npm run check`
- `npm run lint`
- `npm run build`