### PR TITLE
Separate theme bootstrap from the Svelte-managed head

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -7,6 +7,7 @@
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="theme-color" content="#f9f5f1" />
+		%sveltekit.head%
 		<script>
 			(() => {
 				const theme = localStorage.getItem('nostter:theme') ?? 'system';
@@ -17,9 +18,16 @@
 				) {
 					document.documentElement.classList.add('dark');
 				}
+
+				const color = getComputedStyle(document.documentElement).getPropertyValue(
+					'--background'
+				);
+				const themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
+				if (themeColorMetaTag !== null) {
+					themeColorMetaTag.content = color;
+				}
 			})();
 		</script>
-		%sveltekit.head%
 	</head>
 
 	<body data-sveltekit-preload-data="hover">

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -7,6 +7,18 @@
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="theme-color" content="#f9f5f1" />
+		<script>
+			(() => {
+				const theme = localStorage.getItem('nostter:theme') ?? 'system';
+				if (
+					theme === 'dark' ||
+					(theme === 'system' &&
+						window.matchMedia('(prefers-color-scheme: dark)').matches)
+				) {
+					document.documentElement.classList.add('dark');
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 

--- a/web/src/lib/Theme.ts
+++ b/web/src/lib/Theme.ts
@@ -1,0 +1,21 @@
+export type Theme = 'system' | 'light' | 'dark';
+
+export function resolveTheme(theme: Theme): 'light' | 'dark' {
+	if (theme === 'system') {
+		return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+	}
+	return theme;
+}
+
+export function updateThemeColor(): void {
+	const color = getComputedStyle(document.documentElement).getPropertyValue('--background');
+	const themeColorMetaTag = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+	if (themeColorMetaTag !== null) {
+		themeColorMetaTag.content = color;
+	}
+}
+
+export function applyTheme(theme: Theme): void {
+	document.documentElement.classList.toggle('dark', resolveTheme(theme) === 'dark');
+	updateThemeColor();
+}

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -11,6 +11,7 @@
 	import Gdpr from '$lib/components/Gdpr.svelte';
 	import '$lib/styles/menu.css';
 	import { fetchMinutes } from '$lib/Helper';
+	import { applyTheme } from '$lib/Theme';
 	import { author, followees } from '$lib/stores/Author';
 	import { composerFocus } from './channels/[nevent=note]/ComposerFocus.svelte';
 	interface Props {
@@ -129,23 +130,15 @@
 
 	function subscribeSystemTheme(): void {
 		const storage = new WebStorage(localStorage);
-		window
-			.matchMedia('(prefers-color-scheme: dark)')
-			.addEventListener('change', (e: MediaQueryList | MediaQueryListEvent) => {
-				const t = storage.get('theme') ?? 'system';
+		window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+			const t = storage.get('theme') ?? 'system';
 
-				if (t !== 'system') {
-					return;
-				}
+			if (t !== 'system') {
+				return;
+			}
 
-				if (e.matches) {
-					console.debug('[theme system]', 'dark');
-					document.documentElement.classList.add('dark');
-				} else {
-					console.debug('[theme system]', 'light');
-					document.documentElement.classList.remove('dark');
-				}
-			});
+			applyTheme('system');
+		});
 	}
 </script>
 

--- a/web/src/routes/(app)/preferences/Theme.svelte
+++ b/web/src/routes/(app)/preferences/Theme.svelte
@@ -2,38 +2,17 @@
 	import { _ } from 'svelte-i18n';
 	import { writable, type Writable } from 'svelte/store';
 	import { browser } from '$app/environment';
+	import { applyTheme, type Theme } from '$lib/Theme';
 	import { WebStorage } from '$lib/WebStorage';
 
-	let theme: Writable<'system' | 'light' | 'dark'>;
+	let theme: Writable<Theme>;
 	if (browser) {
 		const storage = new WebStorage(localStorage);
-		theme = writable((storage.get('theme') as 'system' | 'light' | 'dark' | null) ?? 'system');
+		theme = writable((storage.get('theme') as Theme | null) ?? 'system');
 		theme.subscribe((v) => {
 			console.log('[theme]', v);
 			storage.set('theme', v);
-			if (v === 'dark') {
-				console.log('[theme local]', 'dark');
-				document.documentElement.classList.add('dark');
-			} else if (v === 'light') {
-				console.log('[theme local]', 'light');
-				document.documentElement.classList.remove('dark');
-			} else {
-				if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-					console.log('[theme system]', 'dark');
-					document.documentElement.classList.add('dark');
-				} else {
-					console.log('[theme system]', 'light');
-					document.documentElement.classList.remove('dark');
-				}
-			}
-
-			const color = getComputedStyle(document.documentElement).getPropertyValue(
-				'--background'
-			);
-			let themeColorMetaTag: HTMLMetaElement = document.querySelector(
-				'meta[name="theme-color"]'
-			) as HTMLMetaElement;
-			themeColorMetaTag.content = color;
+			applyTheme(v);
 		});
 	}
 </script>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -6,7 +6,6 @@
 	import LoginStatus from '$lib/components/LoginStatus.svelte';
 	import { onMount } from 'svelte';
 	import { tryLogin } from '$lib/Login';
-	import { updateThemeColor } from '$lib/Theme';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
@@ -14,7 +13,6 @@
 	let { children }: Props = $props();
 
 	onMount(() => {
-		updateThemeColor();
 		void tryLogin();
 	});
 </script>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import LoginStatus from '$lib/components/LoginStatus.svelte';
 	import { onMount } from 'svelte';
 	import { tryLogin } from '$lib/Login';
+	import { updateThemeColor } from '$lib/Theme';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
@@ -13,6 +14,7 @@
 	let { children }: Props = $props();
 
 	onMount(() => {
+		updateThemeColor();
 		void tryLogin();
 	});
 </script>
@@ -40,20 +42,6 @@
 			}
 		}
 	</style>
-	<script>
-		const theme = localStorage.getItem('nostter:theme') ?? 'system';
-		console.log('[theme]', theme);
-		if (
-			theme === 'dark' ||
-			(theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-		) {
-			document.documentElement.classList.add('dark');
-		}
-
-		const color = getComputedStyle(document.documentElement).getPropertyValue('--background');
-		let themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
-		themeColorMetaTag.content = color;
-	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-G1WMSV0PBP"></script>
 </svelte:head>
 


### PR DESCRIPTION
## Summary

- move the initial theme bootstrap from the root layout head to an IIFE in `app.html`
- centralize runtime theme resolution, dark class updates, and theme-color updates
- keep the existing theme storage key and CSS custom properties as the color source of truth

## Verification

- `npm run check`
- `npm run lint`
- `npm run build`
- verified the production output contains the bootstrap only in the app HTML template, not as a Svelte-managed layout head script