### PR TITLE
Remove obsolete esnext build target

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
 	define: {
 		__APP_NAME__: JSON.stringify(name)
 	},
-	build: {
-		target: 'esnext'
-	},
 	plugins: [
 		sveltekit(),
 		esbuildCssMinifier,


### PR DESCRIPTION
## Summary
- Remove the explicit esnext build target added in #1322 for the former top-level await initialization.
- That top-level await was removed in #1325, and the current source contains no ECMAScript top-level await.
- Use Vite 8's default baseline-widely-available target.

## Verification
- npm run check — passed (0 errors, 0 warnings)
- npm run lint — passed
- npm test — passed (35 files, 320 tests)
- npm run build — passed; no build.target-related errors or warnings