### PR TITLE
Use esbuild for production JavaScript minification

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
 	define: {
 		__APP_NAME__: JSON.stringify(name)
 	},
+	build: {
+		minify: 'esbuild'
+	},
 	plugins: [
 		sveltekit(),
 		esbuildCssMinifier,


### PR DESCRIPTION
## Summary
- Switch the Vite 8 production JavaScript minifier from the default Oxc minifier to esbuild.
- Keep the default build target and the existing CSS minification setup unchanged.
- This helps isolate the client-side module load failure seen on iPad Safari detail pages without assuming the minifier is the confirmed cause.

## Verification
- npm run check — passed (0 errors, 0 warnings)
- npm run lint — passed
- npm test — passed (35 files, 320 tests)
- npm run test:e2e — passed (1 test)
- npm run build — passed
- Production client build logs used the vite:esbuild-transpile path.