### PR TITLE
Reset partial state after failed login restoration

### DIFF
--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -168,6 +168,12 @@ export class Login {
 	}
 }
 
+function resetLoginState(): void {
+	loginType.set(undefined);
+	author.set(undefined);
+	auth.reset();
+}
+
 export async function tryLogin(): Promise<boolean> {
 	try {
 		const storage = new WebStorage(localStorage);
@@ -207,10 +213,14 @@ export async function tryLogin(): Promise<boolean> {
 			return false;
 		}
 
-		return true;
+		return auth.status === 'authenticated';
+	} catch (error) {
+		console.error('[tryLogin()]', error);
+		setLoginStatus('failed', 'error');
+		return false;
 	} finally {
 		if (auth.status !== 'authenticated') {
-			auth.setAnonymous();
+			resetLoginState();
 		}
 	}
 }

--- a/web/src/lib/Login.ts
+++ b/web/src/lib/Login.ts
@@ -168,7 +168,7 @@ export class Login {
 	}
 }
 
-function resetLoginState(): void {
+export function resetLoginState(): void {
 	loginType.set(undefined);
 	author.set(undefined);
 	auth.reset();

--- a/web/src/lib/auth.svelte.test.ts
+++ b/web/src/lib/auth.svelte.test.ts
@@ -101,3 +101,22 @@ describe('Auth status machine', () => {
 		expect(auth.isAuthenticated).toBe(false);
 	});
 });
+
+describe('Auth.reset', () => {
+	it('clears authentication state and becomes anonymous', () => {
+		const auth = new Auth();
+		auth.pubkey = me;
+		auth.updateFollowees([
+			['p', a],
+			['p', b]
+		]);
+		auth.setAuthenticated();
+
+		auth.reset();
+
+		expect(auth.pubkey).toBe('');
+		expect(auth.followees).toEqual([]);
+		expect(auth.originalFollowees).toEqual([]);
+		expect(auth.status).toBe('anonymous');
+	});
+});

--- a/web/src/lib/auth.svelte.ts
+++ b/web/src/lib/auth.svelte.ts
@@ -48,6 +48,13 @@ export class Auth {
 	setAnonymous(): void {
 		this.#status = 'anonymous';
 	}
+
+	reset(): void {
+		this.pubkey = '';
+		this.#followees = [];
+		this.#originalFollowees = [];
+		this.#status = 'anonymous';
+	}
 }
 
 export const auth = new Auth();

--- a/web/src/routes/(app)/Login.svelte
+++ b/web/src/routes/(app)/Login.svelte
@@ -3,7 +3,7 @@
 	import { _ } from 'svelte-i18n';
 	import type * as Nostr from 'nostr-typedef';
 	import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
-	import { Login } from '$lib/Login';
+	import { Login, resetLoginState } from '$lib/Login';
 	import { loginType } from '$lib/stores/Author';
 	import { page } from '$app/state';
 	import { afterNavigate, goto } from '$app/navigation';
@@ -29,8 +29,7 @@
 
 	function resetLoginProgress() {
 		loggingInWith = undefined;
-		loginType.set(undefined);
-		auth.setAnonymous();
+		resetLoginState();
 	}
 
 	async function loginWithNip07() {
@@ -135,8 +134,7 @@
 			console.error('[register failed]', error);
 			setLoginStatus('failed', 'error');
 			registering = false;
-			loginType.set(undefined);
-			auth.setAnonymous();
+			resetLoginState();
 		}
 	}
 


### PR DESCRIPTION
## Summary

- add an explicit reset for authentication data
- clear login type and author whenever saved-login restoration does not authenticate
- catch restoration errors while preserving the saved credential for a future retry
- cover authentication reset behavior with a unit test

## Validation

- `npm test -- --run src/lib/auth.svelte.test.ts`
- `npm run check`
- `npm run lint`

Closes #1582