### PR TITLE
Remove obsolete channelIdStore

### DIFF
--- a/web/src/lib/Channel.ts
+++ b/web/src/lib/Channel.ts
@@ -1,8 +1,5 @@
 import type { Event } from 'nostr-tools';
 import type { ChannelMetadata } from './Types';
-import { writable, type Writable } from 'svelte/store';
-
-export const channelIdStore: Writable<string | undefined> = writable();
 
 export class Channel {
 	static parseMetadata(event: Event): ChannelMetadata | undefined {

--- a/web/src/lib/EventNavigation.ts
+++ b/web/src/lib/EventNavigation.ts
@@ -2,7 +2,6 @@ import type * as Nostr from 'nostr-typedef';
 import { goto } from '$app/navigation';
 import { nip19 } from 'nostr-tools';
 import { get } from 'svelte/store';
-import { channelIdStore } from '$lib/Channel';
 import { findChannelId, filterTags } from '$lib/EventHelper';
 import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 import { emojiPickerOpen } from '$lib/components/EmojiPicker.svelte';
@@ -37,9 +36,6 @@ const shouldSkipNavigation = (e: MouseEvent | KeyboardEvent): boolean => {
 };
 
 const resolveChannelDestination = (nostrEvent: Nostr.Event): string | undefined => {
-	if (get(channelIdStore) !== undefined) {
-		return undefined;
-	}
 	if (nostrEvent.kind === 40) {
 		return `/channels/${nip19.neventEncode({
 			id: nostrEvent.id,

--- a/web/src/lib/TextEventComposer.test.ts
+++ b/web/src/lib/TextEventComposer.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { kinds as Kind, type Event } from 'nostr-tools';
+import { TextEventComposer } from './TextEventComposer';
+
+describe('TextEventComposer.replyTags', () => {
+	it('preserves NIP-28 root, reply, and pubkey tags when replying to a channel message', () => {
+		const replyTo: Event = {
+			kind: Kind.ChannelMessage,
+			pubkey: 'reply-author',
+			content: 'channel message',
+			tags: [
+				['e', 'channel-id', '', 'root'],
+				['p', 'channel-creator'],
+				['p', 'mentioned-pubkey']
+			],
+			created_at: 0,
+			id: 'reply-id',
+			sig: ''
+		};
+
+		const tags = new TextEventComposer().replyTags('', replyTo);
+
+		expect(tags).toContainEqual(['e', 'channel-id', '', 'root']);
+		expect(tags).toContainEqual(['e', 'reply-id', '', 'reply', 'reply-author']);
+		expect(tags).toContainEqual(['p', 'reply-author']);
+		expect(tags).toContainEqual(['p', 'channel-creator']);
+		expect(tags).toContainEqual(['p', 'mentioned-pubkey']);
+	});
+});

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -5,15 +5,14 @@
 	import data from '@emoji-mart/data';
 	import { createEventDispatcher, onDestroy, tick, untrack } from 'svelte';
 	import { _ } from 'svelte-i18n';
-	import { kinds as Kind, nip19, type Event as NostrEvent } from 'nostr-tools';
+	import { kinds as Kind, nip19 } from 'nostr-tools';
 	import { complementPosition } from '$lib/styles/Complement';
 	import { adjustHeight } from '$lib/styles/Textarea';
 	import { getSeenOnRelays, rxNostr } from '$lib/timelines/MainTimeline';
 	import { TextEventComposer } from '$lib/TextEventComposer';
-	import { channelIdStore, Channel } from '$lib/Channel';
 	import { Content } from '$lib/Content';
 	import { filterTags } from '$lib/EventHelper';
-	import { cachedEvents, channelMetadataEventsStore, metadataStore } from '$lib/cache/Events';
+	import { metadataStore } from '$lib/cache/Events';
 	import { EventItem, Metadata } from '$lib/Items';
 	import { RelayList } from '$lib/RelayList';
 	import { openNoteDialog, replyTo, quotes, intentContent } from '$lib/stores/NoteDialog';
@@ -22,7 +21,6 @@
 	import { fetchFolloweesMetadata } from '$lib/author/Follow';
 	import Note from '../items/Note.svelte';
 	import OnelineProfile from '../profile/OnelineProfile.svelte';
-	import ChannelTitle from '../ChannelTitle.svelte';
 	import MediaPicker from '../MediaPicker.svelte';
 	import ContentComponent from '../Content.svelte';
 	import CustomEmoji from '../content/CustomEmoji.svelte';
@@ -93,7 +91,6 @@
 
 	let tags: string[][] = $state([]);
 	let posting = $state(false);
-	let channelEvent: NostrEvent | undefined = $state();
 	let emojiTags: string[][] = $state([]);
 	let continuePosting = $state(false);
 	let contentWarningReason: string | undefined = $state();
@@ -275,11 +272,7 @@
 		const textEventComposer = new TextEventComposer();
 		textEventComposer.emojiTags(content, emojiTags).then((emojiTags) => {
 			tags = [
-				...textEventComposer.replyTags(
-					content,
-					$state.snapshot($replyTo?.event),
-					$channelIdStore
-				),
+				...textEventComposer.replyTags(content, $state.snapshot($replyTo?.event)),
 				...textEventComposer.hashtags(content),
 				...emojiTags,
 				...textEventComposer.contentWarningTags(contentWarningReason)
@@ -288,15 +281,6 @@
 	});
 
 	const dispatch = createEventDispatcher();
-
-	channelIdStore.subscribe((channelId) => {
-		if (channelId !== undefined) {
-			channelEvent =
-				$channelMetadataEventsStore.get(channelId) ?? cachedEvents.get(channelId);
-		} else {
-			channelEvent = undefined;
-		}
-	});
 
 	// FIXME: Change trigger
 	openNoteDialog.subscribe(async (open) => {
@@ -493,16 +477,12 @@
 
 		const textEventComposer = new TextEventComposer();
 		const event = await textEventComposer.compose(
-			$channelIdStore !== undefined || $replyTo?.event?.kind === Kind.ChannelMessage
+			$replyTo?.event?.kind === Kind.ChannelMessage
 				? Kind.ChannelMessage
 				: Kind.ShortTextNote,
 			Content.replaceNip19(finalContent),
 			[
-				...textEventComposer.replyTags(
-					finalContent,
-					$state.snapshot($replyTo?.event),
-					$channelIdStore
-				),
+				...textEventComposer.replyTags(finalContent, $state.snapshot($replyTo?.event)),
 				...textEventComposer.hashtags(finalContent),
 				...(await textEventComposer.emojiTags(finalContent, $state.snapshot(emojiTags))),
 				...textEventComposer.contentWarningTags(contentWarningReason),
@@ -666,9 +646,6 @@
 />
 
 <article class="note-composer" inert={composerLocked} aria-busy={composerLocked}>
-	{#if channelEvent !== undefined}
-		<ChannelTitle channelMetadata={Channel.parseMetadata(channelEvent)} />
-	{/if}
 	{#if $replyTo}
 		<article class="reply-to">
 			<Note item={$replyTo} readonly={true} full={true} />

--- a/web/src/lib/components/items/Note.svelte
+++ b/web/src/lib/components/items/Note.svelte
@@ -8,7 +8,7 @@
 	import { onMount } from 'svelte';
 	import Content from '$lib/components/Content.svelte';
 	import { isReply } from '$lib/EventHelper';
-	import { Channel, channelIdStore } from '$lib/Channel';
+	import { Channel } from '$lib/Channel';
 	import EventMetadata from '$lib/components/EventMetadata.svelte';
 	import ProxyLink from '../ProxyLink.svelte';
 	import Nip94 from '$lib/components/Nip94.svelte';
@@ -127,7 +127,7 @@
 					</div>
 				</Foldable>
 			{/if}
-			{#if item.event.kind === Kind.ChannelMessage && channelId !== undefined && $channelIdStore === undefined}
+			{#if item.event.kind === Kind.ChannelMessage && channelId !== undefined}
 				<div class="channel">
 					<IconMessages size={16} color="gray" />
 					<span>


### PR DESCRIPTION
## Summary

- Remove `channelIdStore`, which no longer had a writer after the channel page moved to the dedicated `ChannelComposer`
- Remove dead branches that depended on the store always being `undefined`
- Preserve kind 42 reply behavior and add coverage for NIP-28 root, reply, and p tags

## Validation

- `npm run check`
- `npm test -- --run` (36 files, 322 tests)
- ESLint on changed files
- `npm run lint`
- `npm run build`
- `git diff --check`