### PR TITLE
Clarify NoteDialog content state

### DIFF
--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -15,7 +15,7 @@
 	import { metadataStore } from '$lib/cache/Events';
 	import { EventItem, Metadata } from '$lib/Items';
 	import { RelayList } from '$lib/RelayList';
-	import { openNoteDialog, replyTo, quotes, intentContent } from '$lib/stores/NoteDialog';
+	import { openNoteDialog, replyTo, quotes } from '$lib/stores/NoteDialog';
 	import { author, pubkey, rom } from '$lib/stores/Author';
 	import { customEmojiTags, findCustomEmojiSetAddress } from '$lib/author/CustomEmojis';
 	import { fetchFolloweesMetadata } from '$lib/author/Follow';
@@ -52,7 +52,6 @@
 
 	function clearComposer(closed = false): void {
 		clearAttachments();
-		$intentContent = '';
 		$replyTo = undefined;
 		$quotes = [];
 		mention = undefined;
@@ -308,11 +307,6 @@
 			textarea.setSelectionRange(0, 0);
 			textarea.focus();
 		}
-	});
-
-	intentContent.subscribe((value) => {
-		content = value;
-		value = '';
 	});
 
 	async function onKeydown(e: KeyboardEvent) {

--- a/web/src/lib/components/content/LongFormContent.svelte
+++ b/web/src/lib/components/content/LongFormContent.svelte
@@ -2,7 +2,7 @@
 	import { stopPropagation } from 'svelte/legacy';
 
 	import { nip19, type Event } from 'nostr-tools';
-	import { intentContent, openNoteDialog } from '$lib/stores/NoteDialog';
+	import { noteDialogContent, openNoteDialog } from '$lib/stores/NoteDialog';
 	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
 	import IconQuote from '@tabler/icons-svelte-runes/icons/quote';
 	import SeenOnRelays from '../SeenOnRelays.svelte';
@@ -31,7 +31,7 @@
 	let jsonDisplay = $state(false);
 
 	function quote() {
-		$intentContent = `\nnostr:${naddr}`;
+		$noteDialogContent = `\nnostr:${naddr}`;
 		$openNoteDialog = true;
 	}
 

--- a/web/src/lib/components/items/Channel.svelte
+++ b/web/src/lib/components/items/Channel.svelte
@@ -7,7 +7,7 @@
 	import type { Item } from '$lib/Items';
 	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
 	import IconQuote from '@tabler/icons-svelte-runes/icons/quote';
-	import { intentContent, openNoteDialog } from '$lib/stores/NoteDialog';
+	import { noteDialogContent, openNoteDialog } from '$lib/stores/NoteDialog';
 	import { Channel } from '$lib/Channel';
 	import { findChannelId } from '$lib/EventHelper';
 	import OnelineProfile from '../profile/OnelineProfile.svelte';
@@ -56,7 +56,7 @@
 	let jsonDisplay = $state(false);
 
 	function quote(): void {
-		$intentContent = '\n' + nevent;
+		$noteDialogContent = '\n' + nevent;
 		$openNoteDialog = true;
 	}
 

--- a/web/src/lib/stores/NoteDialog.ts
+++ b/web/src/lib/stores/NoteDialog.ts
@@ -5,4 +5,4 @@ import type { EventItem } from '$lib/Items';
 export const openNoteDialog = writable(false);
 export const replyTo: Writable<EventItem | undefined> = writable(undefined);
 export const quotes: Writable<Nostr.Event[]> = writable([]);
-export const intentContent = writable('');
+export const noteDialogContent = writable('');

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
-	import { openNoteDialog } from '$lib/stores/NoteDialog';
+	import { noteDialogContent, openNoteDialog } from '$lib/stores/NoteDialog';
 	import { emojiPickerOpen } from '$lib/components/EmojiPicker.svelte';
 	import NoteComposer from '$lib/components/composer/NoteComposer.svelte';
 	import IconX from '@tabler/icons-svelte-runes/icons/x';
 
-	let content = $state('');
 	let hasAttachments = $state(false);
 	let composerBusy = $state(false);
 
@@ -32,12 +31,13 @@
 
 	function closed(): void {
 		composer?.clear(true);
+		$noteDialogContent = '';
 	}
 
 	function closeIfNotEmpty(e?: Event): void {
 		e?.preventDefault();
 		if (composerBusy) return;
-		if ((content === '' && !hasAttachments) || confirm($_('editor.close.confirm'))) {
+		if (($noteDialogContent === '' && !hasAttachments) || confirm($_('editor.close.confirm'))) {
 			dialog?.close();
 		}
 	}
@@ -59,7 +59,7 @@
 		</button>
 		<NoteComposer
 			bind:this={composer}
-			bind:content
+			bind:content={$noteDialogContent}
 			bind:hasAttachments
 			bind:busy={composerBusy}
 			on:sent={sent}

--- a/web/src/routes/(app)/post/+page.svelte
+++ b/web/src/routes/(app)/post/+page.svelte
@@ -3,10 +3,9 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { appName } from '$lib/Constants';
-	import { intentContent } from '$lib/stores/NoteDialog';
 	import NoteComposer from '$lib/components/composer/NoteComposer.svelte';
 
-	const content = page.url.searchParams.get('content');
+	const contentParameter = page.url.searchParams.get('content');
 
 	// Web Share Target API
 	// Android has no dedicated url field, so the shared URL arrives in text (or title).
@@ -24,11 +23,7 @@
 		.filter((param) => !params.some((other) => other !== param && other.includes(param)))
 		.join('\n');
 
-	if (content !== null) {
-		$intentContent = content;
-	} else {
-		$intentContent = sharedContent;
-	}
+	let content = $state(contentParameter ?? sharedContent);
 
 	let composer: NoteComposer | undefined = $state();
 
@@ -44,5 +39,5 @@
 </svelte:head>
 
 <article class="card">
-	<NoteComposer bind:this={composer} {afterPost} />
+	<NoteComposer bind:this={composer} bind:content {afterPost} />
 </article>


### PR DESCRIPTION
## Summary

- Keep `/post` query and Web Share Target content in route-local state and bind it directly to `NoteComposer`
- Remove NoteDialog content state access and subscription from `NoteComposer`
- Rename `intentContent` to the dialog-specific `noteDialogContent` and bind it in `NoteDialog`
- Preserve Channel and LongForm quote content, post navigation, and dialog clearing behavior

## Validation

- `npm run check`
- `npm test -- --run` (36 files, 322 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`