### PR TITLE
Replace NoteDialog open store with context command

### DIFF
--- a/web/src/lib/NoteDialogContext.ts
+++ b/web/src/lib/NoteDialogContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'svelte';
+import type * as Nostr from 'nostr-typedef';
+import type { EventItem } from '$lib/Items';
+
+export interface NoteDialogOpenRequest {
+	content?: string;
+	replyTo?: EventItem;
+	quotes?: Nostr.Event[];
+}
+
+export type OpenNoteDialog = (request?: NoteDialogOpenRequest) => Promise<void>;
+
+export const [getOpenNoteDialog, setOpenNoteDialog] = createContext<OpenNoteDialog>();

--- a/web/src/lib/components/RepostButton.svelte
+++ b/web/src/lib/components/RepostButton.svelte
@@ -5,7 +5,7 @@
 	import { repostedEvents, updateRepostedEvents } from '$lib/author/Action';
 	import { Signer } from '$lib/Signer';
 	import { rom } from '$lib/stores/Author';
-	import { openNoteDialog, quotes } from '$lib/stores/NoteDialog';
+	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import { getRelayHint, rxNostr, seenOn } from '$lib/timelines/MainTimeline';
 	import { createDropdownMenu, melt } from '@melt-ui/svelte';
 	import { IconQuote, IconRepeat, IconTrash } from '@tabler/icons-svelte-runes';
@@ -17,6 +17,7 @@
 	}
 
 	let { event, iconSize }: Props = $props();
+	const openNoteDialog = getOpenNoteDialog();
 
 	const {
 		elements: { menu, item, trigger, overlay, separator }
@@ -64,8 +65,7 @@
 	}
 
 	function onQuote(): void {
-		$quotes.push(event);
-		$openNoteDialog = true;
+		void openNoteDialog({ quotes: [event] });
 	}
 </script>
 

--- a/web/src/lib/components/actions/ActionMenu.svelte
+++ b/web/src/lib/components/actions/ActionMenu.svelte
@@ -12,7 +12,7 @@
 	import { sendReaction } from '$lib/author/Reaction';
 	import type * as Nostr from 'nostr-typedef';
 	import { notesKinds } from '$lib/Constants';
-	import { openNoteDialog, replyTo } from '$lib/stores/NoteDialog';
+	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import { rom } from '$lib/stores/Author';
 	import SeenOnRelays from '../SeenOnRelays.svelte';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
@@ -30,6 +30,7 @@
 	let zapDialogComponent = $state<ZapDialog>();
 
 	const iconSize = 20;
+	const openNoteDialog = getOpenNoteDialog();
 
 	let metadata = $derived($metadataStore.get(item.event.pubkey));
 	let nevent = $derived(
@@ -42,8 +43,7 @@
 	);
 
 	function reply() {
-		$replyTo = item;
-		$openNoteDialog = true;
+		void openNoteDialog({ replyTo: item });
 	}
 
 	async function emojiReaction(note: Nostr.Event, emoji: PickerEmoji) {

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -8,14 +8,15 @@
 	import { kinds as Kind, nip19 } from 'nostr-tools';
 	import { complementPosition } from '$lib/styles/Complement';
 	import { adjustHeight } from '$lib/styles/Textarea';
-	import { getSeenOnRelays, rxNostr } from '$lib/timelines/MainTimeline';
+	import { rxNostr } from '$lib/timelines/MainTimeline';
 	import { TextEventComposer } from '$lib/TextEventComposer';
 	import { Content } from '$lib/Content';
 	import { filterTags } from '$lib/EventHelper';
 	import { metadataStore } from '$lib/cache/Events';
 	import { EventItem, Metadata } from '$lib/Items';
 	import { RelayList } from '$lib/RelayList';
-	import { openNoteDialog, replyTo, quotes } from '$lib/stores/NoteDialog';
+	import { replyTo, quotes } from '$lib/stores/NoteDialog';
+	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import { author, pubkey, rom } from '$lib/stores/Author';
 	import { customEmojiTags, findCustomEmojiSetAddress } from '$lib/author/CustomEmojis';
 	import { fetchFolloweesMetadata } from '$lib/author/Follow';
@@ -50,6 +51,12 @@
 		clearComposer(closed);
 	}
 
+	export async function focus(): Promise<void> {
+		await tick();
+		textarea?.setSelectionRange(0, 0);
+		textarea?.focus();
+	}
+
 	function clearComposer(closed = false): void {
 		clearAttachments();
 		$replyTo = undefined;
@@ -60,7 +67,6 @@
 
 		if (!continuePosting) {
 			content = '';
-			$openNoteDialog = false;
 			collapsible.open = false;
 		} else {
 			const hashtags = Content.findHashtags(content);
@@ -280,34 +286,7 @@
 	});
 
 	const dispatch = createEventDispatcher();
-
-	// FIXME: Change trigger
-	openNoteDialog.subscribe(async (open) => {
-		if (open) {
-			if ($quotes.length > 0) {
-				content =
-					'\n' +
-					$quotes
-						.map(
-							(event) =>
-								`nostr:${nip19.neventEncode({
-									id: event.id,
-									relays: getSeenOnRelays(event.id),
-									author: event.pubkey,
-									kind: event.kind
-								})}`
-						)
-						.join('\n');
-			}
-
-			await tick();
-			if (textarea === undefined) {
-				return;
-			}
-			textarea.setSelectionRange(0, 0);
-			textarea.focus();
-		}
-	});
+	const openNoteDialog = getOpenNoteDialog();
 
 	async function onKeydown(e: KeyboardEvent) {
 		if (composerLocked) return;
@@ -627,9 +606,7 @@
 		onDrag = false;
 	})}
 	ondragover={preventDefault(() => {
-		if (!$openNoteDialog) {
-			$openNoteDialog = true;
-		}
+		void openNoteDialog();
 	})}
 	ondrop={preventDefault(() => {
 		onDrag = false;

--- a/web/src/lib/components/content/LongFormContent.svelte
+++ b/web/src/lib/components/content/LongFormContent.svelte
@@ -2,7 +2,7 @@
 	import { stopPropagation } from 'svelte/legacy';
 
 	import { nip19, type Event } from 'nostr-tools';
-	import { noteDialogContent, openNoteDialog } from '$lib/stores/NoteDialog';
+	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
 	import IconQuote from '@tabler/icons-svelte-runes/icons/quote';
 	import SeenOnRelays from '../SeenOnRelays.svelte';
@@ -28,11 +28,11 @@
 	);
 
 	const iconSize = 20;
+	const openNoteDialog = getOpenNoteDialog();
 	let jsonDisplay = $state(false);
 
 	function quote() {
-		$noteDialogContent = `\nnostr:${naddr}`;
-		$openNoteDialog = true;
+		void openNoteDialog({ content: `\nnostr:${naddr}` });
 	}
 
 	const toggleJsonDisplay = () => {

--- a/web/src/lib/components/items/Channel.svelte
+++ b/web/src/lib/components/items/Channel.svelte
@@ -7,7 +7,7 @@
 	import type { Item } from '$lib/Items';
 	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
 	import IconQuote from '@tabler/icons-svelte-runes/icons/quote';
-	import { noteDialogContent, openNoteDialog } from '$lib/stores/NoteDialog';
+	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import { Channel } from '$lib/Channel';
 	import { findChannelId } from '$lib/EventHelper';
 	import OnelineProfile from '../profile/OnelineProfile.svelte';
@@ -53,11 +53,11 @@
 	});
 
 	const iconSize = 20;
+	const openNoteDialog = getOpenNoteDialog();
 	let jsonDisplay = $state(false);
 
 	function quote(): void {
-		$noteDialogContent = '\n' + nevent;
-		$openNoteDialog = true;
+		void openNoteDialog({ content: '\n' + nevent });
 	}
 
 	const toggleJsonDisplay = () => {

--- a/web/src/lib/stores/NoteDialog.ts
+++ b/web/src/lib/stores/NoteDialog.ts
@@ -2,7 +2,6 @@ import { writable, type Writable } from 'svelte/store';
 import type * as Nostr from 'nostr-typedef';
 import type { EventItem } from '$lib/Items';
 
-export const openNoteDialog = writable(false);
 export const replyTo: Writable<EventItem | undefined> = writable(undefined);
 export const quotes: Writable<Nostr.Event[]> = writable([]);
 export const noteDialogContent = writable('');

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -5,7 +5,7 @@
 	import Notice from '$lib/components/Notice.svelte';
 	import Header from './Header.svelte';
 	import NoteDialog from './NoteDialog.svelte';
-	import { openNoteDialog } from '$lib/stores/NoteDialog';
+	import { setOpenNoteDialog, type OpenNoteDialog } from '$lib/NoteDialogContext';
 	import { fetchLastNotification } from '$lib/author/Notifications';
 	import { onMount } from 'svelte';
 	import Gdpr from '$lib/components/Gdpr.svelte';
@@ -19,6 +19,10 @@
 	}
 
 	let { children }: Props = $props();
+	let noteDialog = $state<NoteDialog>();
+
+	const openNoteDialog: OpenNoteDialog = async (request) => noteDialog?.open(request);
+	setOpenNoteDialog(openNoteDialog);
 
 	const konamiCode = [
 		'ArrowUp',
@@ -57,7 +61,7 @@
 			if (composerFocus.current !== undefined) {
 				composerFocus.current();
 			} else {
-				$openNoteDialog = true;
+				void openNoteDialog();
 			}
 			event.preventDefault();
 		}
@@ -152,7 +156,7 @@
 <Notice />
 
 <div class="app">
-	<NoteDialog />
+	<NoteDialog bind:this={noteDialog} />
 
 	<header>
 		<div>

--- a/web/src/routes/(app)/Header.svelte
+++ b/web/src/routes/(app)/Header.svelte
@@ -30,7 +30,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { followees, pubkey, rom } from '$lib/stores/Author';
-	import { openNoteDialog } from '$lib/stores/NoteDialog';
+	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import { lastReadAt, notifiedEventItems } from '$lib/author/Notifications';
 	import NostterLogo from '$lib/components/logo/NostterLogo.svelte';
 	import NostterLogoIcon from '$lib/components/logo/NostterLogoIcon.svelte';
@@ -44,9 +44,10 @@
 	const {
 		elements: { menu, item, trigger, overlay }
 	} = createDropdownMenu({ preventScroll: false });
+	const openNoteDialog = getOpenNoteDialog();
 
-	async function onClickPostButton(): Promise<void> {
-		$openNoteDialog = !$openNoteDialog;
+	function onClickPostButton(): void {
+		void openNoteDialog();
 	}
 
 	function requestTimelineScrollToTopForCurrentLink(event: MouseEvent, link: string): boolean {

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -38,9 +38,10 @@
 			$noteDialogContent = request.content;
 		}
 
-		if (dialog !== undefined && !dialog.open) {
-			dialog.showModal();
+		if (dialog === undefined || dialog.open) {
+			return;
 		}
+		dialog.showModal();
 		await composer?.focus();
 	}
 

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
-	import { noteDialogContent, openNoteDialog } from '$lib/stores/NoteDialog';
+	import { nip19 } from 'nostr-tools';
+	import { noteDialogContent, quotes, replyTo } from '$lib/stores/NoteDialog';
+	import type { NoteDialogOpenRequest } from '$lib/NoteDialogContext';
+	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import { emojiPickerOpen } from '$lib/components/EmojiPicker.svelte';
 	import NoteComposer from '$lib/components/composer/NoteComposer.svelte';
 	import IconX from '@tabler/icons-svelte-runes/icons/x';
@@ -11,11 +14,35 @@
 	let dialog = $state<HTMLDialogElement>();
 	let composer = $state<NoteComposer>();
 
-	openNoteDialog.subscribe(async (open) => {
-		if (open) {
-			dialog?.showModal();
+	export async function open(request: NoteDialogOpenRequest = {}): Promise<void> {
+		if (request.replyTo !== undefined) {
+			$replyTo = request.replyTo;
 		}
-	});
+		if (request.quotes !== undefined) {
+			$quotes = request.quotes;
+			$noteDialogContent =
+				'\n' +
+				request.quotes
+					.map(
+						(event) =>
+							`nostr:${nip19.neventEncode({
+								id: event.id,
+								relays: getSeenOnRelays(event.id),
+								author: event.pubkey,
+								kind: event.kind
+							})}`
+					)
+					.join('\n');
+		}
+		if (request.content !== undefined) {
+			$noteDialogContent = request.content;
+		}
+
+		if (dialog !== undefined && !dialog.open) {
+			dialog.showModal();
+		}
+		await composer?.focus();
+	}
 
 	function tryClose(e: MouseEvent): void {
 		if (emojiPickerOpen || !dialog?.open) {


### PR DESCRIPTION
## Summary

- Remove the boolean `openNoteDialog` writable store
- Provide a typed, layout-scoped open command through Svelte Context
- Apply reply, quote, and content payloads as part of the same open operation
- Move dialog opening, duplicate-open protection, quote content generation, and composer focus into `NoteDialog`
- Remove the direct open subscription and dialog state mutation from `NoteComposer` while preserving post, continue-posting, close, and dragover behavior

## Validation

- `npm run check`
- `npm test -- --run` (36 files, 322 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`