### PR TITLE
Localize NoteDialog state

### DIFF
--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -14,8 +14,8 @@
 	import { filterTags } from '$lib/EventHelper';
 	import { metadataStore } from '$lib/cache/Events';
 	import { EventItem, Metadata } from '$lib/Items';
+	import type * as Nostr from 'nostr-typedef';
 	import { RelayList } from '$lib/RelayList';
-	import { replyTo, quotes } from '$lib/stores/NoteDialog';
 	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import { author, pubkey, rom } from '$lib/stores/Author';
 	import { customEmojiTags, findCustomEmojiSetAddress } from '$lib/author/CustomEmojis';
@@ -59,8 +59,8 @@
 
 	function clearComposer(closed = false): void {
 		clearAttachments();
-		$replyTo = undefined;
-		$quotes = [];
+		replyTo = undefined;
+		quotes = [];
 		mention = undefined;
 		emojiTags = [];
 		contentWarningReason = undefined;
@@ -83,6 +83,8 @@
 	interface Props {
 		afterPost?: () => Promise<void>;
 		content?: string;
+		replyTo?: EventItem;
+		quotes?: Nostr.Event[];
 		hasAttachments?: boolean;
 		busy?: boolean;
 	}
@@ -90,6 +92,8 @@
 	let {
 		afterPost = async () => {},
 		content = $bindable(''),
+		replyTo = $bindable(),
+		quotes = $bindable([]),
 		hasAttachments = $bindable(false),
 		busy = $bindable(false)
 	}: Props = $props();
@@ -277,7 +281,7 @@
 		const textEventComposer = new TextEventComposer();
 		textEventComposer.emojiTags(content, emojiTags).then((emojiTags) => {
 			tags = [
-				...textEventComposer.replyTags(content, $state.snapshot($replyTo?.event)),
+				...textEventComposer.replyTags(content, $state.snapshot(replyTo?.event)),
 				...textEventComposer.hashtags(content),
 				...emojiTags,
 				...textEventComposer.contentWarningTags(contentWarningReason)
@@ -450,12 +454,10 @@
 
 		const textEventComposer = new TextEventComposer();
 		const event = await textEventComposer.compose(
-			$replyTo?.event?.kind === Kind.ChannelMessage
-				? Kind.ChannelMessage
-				: Kind.ShortTextNote,
+			replyTo?.event?.kind === Kind.ChannelMessage ? Kind.ChannelMessage : Kind.ShortTextNote,
 			Content.replaceNip19(finalContent),
 			[
-				...textEventComposer.replyTags(finalContent, $state.snapshot($replyTo?.event)),
+				...textEventComposer.replyTags(finalContent, $state.snapshot(replyTo?.event)),
 				...textEventComposer.hashtags(finalContent),
 				...(await textEventComposer.emojiTags(finalContent, $state.snapshot(emojiTags))),
 				...textEventComposer.contentWarningTags(contentWarningReason),
@@ -498,12 +500,12 @@
 			}
 		});
 
-		if ($replyTo === undefined) {
+		if (replyTo === undefined) {
 			return;
 		}
 
 		RelayList.fetchEvents(
-			filterTags('p', $replyTo.event.tags).filter((p) => p !== $pubkey)
+			filterTags('p', replyTo.event.tags).filter((p) => p !== $pubkey)
 		).then((relayListEventsMap) => {
 			if (relayListEventsMap.size === 0) {
 				return;
@@ -617,9 +619,9 @@
 />
 
 <article class="note-composer" inert={composerLocked} aria-busy={composerLocked}>
-	{#if $replyTo}
+	{#if replyTo}
 		<article class="reply-to">
-			<Note item={$replyTo} readonly={true} full={true} />
+			<Note item={replyTo} readonly={true} full={true} />
 		</article>
 	{/if}
 	<div class="content">
@@ -740,8 +742,8 @@
 			<EnableVia bind:enable={enableVia} />
 		</div>
 	{/if}
-	{#if $quotes.length > 0}
-		{#each $quotes as quote}
+	{#if quotes.length > 0}
+		{#each quotes as quote}
 			<Note item={new EventItem(quote)} readonly={true} />
 		{/each}
 	{/if}

--- a/web/src/lib/stores/NoteDialog.ts
+++ b/web/src/lib/stores/NoteDialog.ts
@@ -1,7 +1,0 @@
-import { writable, type Writable } from 'svelte/store';
-import type * as Nostr from 'nostr-typedef';
-import type { EventItem } from '$lib/Items';
-
-export const replyTo: Writable<EventItem | undefined> = writable(undefined);
-export const quotes: Writable<Nostr.Event[]> = writable([]);
-export const noteDialogContent = writable('');

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
 	import { nip19 } from 'nostr-tools';
-	import { noteDialogContent, quotes, replyTo } from '$lib/stores/NoteDialog';
+	import type * as Nostr from 'nostr-typedef';
+	import type { EventItem } from '$lib/Items';
 	import type { NoteDialogOpenRequest } from '$lib/NoteDialogContext';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import { emojiPickerOpen } from '$lib/components/EmojiPicker.svelte';
@@ -10,17 +11,20 @@
 
 	let hasAttachments = $state(false);
 	let composerBusy = $state(false);
+	let content = $state('');
+	let replyTo = $state<EventItem>();
+	let quotes = $state<Nostr.Event[]>([]);
 
 	let dialog = $state<HTMLDialogElement>();
 	let composer = $state<NoteComposer>();
 
 	export async function open(request: NoteDialogOpenRequest = {}): Promise<void> {
 		if (request.replyTo !== undefined) {
-			$replyTo = request.replyTo;
+			replyTo = request.replyTo;
 		}
 		if (request.quotes !== undefined) {
-			$quotes = request.quotes;
-			$noteDialogContent =
+			quotes = request.quotes;
+			content =
 				'\n' +
 				request.quotes
 					.map(
@@ -35,7 +39,7 @@
 					.join('\n');
 		}
 		if (request.content !== undefined) {
-			$noteDialogContent = request.content;
+			content = request.content;
 		}
 
 		if (dialog === undefined || dialog.open) {
@@ -59,13 +63,12 @@
 
 	function closed(): void {
 		composer?.clear(true);
-		$noteDialogContent = '';
 	}
 
 	function closeIfNotEmpty(e?: Event): void {
 		e?.preventDefault();
 		if (composerBusy) return;
-		if (($noteDialogContent === '' && !hasAttachments) || confirm($_('editor.close.confirm'))) {
+		if ((content === '' && !hasAttachments) || confirm($_('editor.close.confirm'))) {
 			dialog?.close();
 		}
 	}
@@ -87,7 +90,9 @@
 		</button>
 		<NoteComposer
 			bind:this={composer}
-			bind:content={$noteDialogContent}
+			bind:content
+			bind:replyTo
+			bind:quotes
 			bind:hasAttachments
 			bind:busy={composerBusy}
 			on:sent={sent}

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -63,6 +63,7 @@
 
 	function closed(): void {
 		composer?.clear(true);
+		content = '';
 	}
 
 	function closeIfNotEmpty(e?: Event): void {


### PR DESCRIPTION
## Summary

- Move NoteDialog content, reply target, and quote events to instance-local state
- Remove NoteComposer dependency on the NoteDialog global store and bind the owned state through minimal bindable props
- Delete `web/src/lib/stores/NoteDialog.ts`
- Preserve the Context-based open API and existing quote encoding/preview behavior
- Preserve existing clear, continue-posting, duplicate-open, and sent behavior

## Validation

- `npm run check`
- `npm test -- --run` (36 files, 322 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`
- Confirmed zero `$lib/stores/NoteDialog` references