### PR TITLE
Reduce Playwright browser install in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,5 @@ jobs:
         with:
           node-version: "24.x"
       - run: npm ci
-      - run: npx playwright install
+      - run: npx playwright install chromium --only-shell
       - run: npm run test:e2e


### PR DESCRIPTION
### Motivation
- Reduce CI download size and time by installing only the Chromium headless shell because the E2E tests run headless on Chromium (no `channel` specified and Firefox/WebKit are not used). 

### Description
- Replace `npx playwright install` with `npx playwright install chromium --only-shell` in the `e2e-test` job of `.github/workflows/test.yml` and make no other changes to Playwright config, tests, or dependencies. 

### Testing
- Verified with `npx playwright install chromium --only-shell --dry-run` that only the Chromium Headless Shell and related FFmpeg are targeted, attempted `npx playwright install chromium --only-shell` which failed to download from the Playwright CDN due to a `403` in this environment, and ran `npm run test:e2e` (which failed because the headless shell binary was not present due to the download error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f8e8163f0832e91b2d19d57e07a61)