### PR TITLE
Share CI working directory default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,14 @@ name: Test
 on:
   pull_request:
 
+defaults:
+  run:
+    working-directory: web
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -22,9 +23,6 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -36,9 +34,6 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
### Motivation
- Centralize the duplicated `defaults.run.working-directory: web` settings used by the `lint`, `unit-test`, and `e2e-test` jobs to simplify the workflow while keeping behavior unchanged.

### Description
- Added a workflow-level `defaults.run.working-directory: web` entry to `.github/workflows/test.yml` and removed the duplicated job-level `defaults.run.working-directory: web` blocks from the `lint`, `unit-test`, and `e2e-test` jobs.
- Preserved all job configurations including `runs-on`, `timeout-minutes`, `uses:` steps (`actions/checkout` and `actions/setup-node`), npm commands, and the `npx playwright install chromium --only-shell` step.
- Changes were committed on the branch `share-ci-working-directory` with commit message `Share CI working directory default`.

### Testing
- Verified YAML syntax with Ruby YAML parser (`YAML.parse_file`) and the file parsed successfully (`YAML syntax OK`).
- Confirmed that all `run:` steps remain present and will inherit the workflow-level `working-directory: web` by inspecting the modified `.github/workflows/test.yml` and running text searches.
- Performed a `git diff` to ensure only the intended changes are present and no other refactors were introduced.
- Attempted to push the branch and create a PR but GitHub authentication was not available in the environment, so remote push/PR creation was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f95501ab4832eba6835a4d85c7e78)