### PR TITLE
Share local attachment lifecycle

### DIFF
--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -49,6 +49,10 @@
 		textarea?.focus();
 	}
 
+	export function hasAttachments(): boolean {
+		return localAttachments.attachments.length > 0;
+	}
+
 	function clearComposer(closed = false): void {
 		clearAttachments();
 		mention = undefined;
@@ -76,7 +80,6 @@
 		content?: string;
 		replyTo?: EventItem;
 		quotes?: Nostr.Event[];
-		hasAttachments?: boolean;
 		busy?: boolean;
 	}
 
@@ -86,7 +89,6 @@
 		content = $bindable(''),
 		replyTo,
 		quotes = [],
-		hasAttachments = $bindable(false),
 		busy = $bindable(false)
 	}: Props = $props();
 
@@ -593,18 +595,15 @@
 	function addAttachments(files: FileList | File[]): void {
 		if (composerLocked) return;
 		localAttachments.add(files);
-		hasAttachments = localAttachments.attachments.length > 0;
 	}
 
 	function removeAttachment(attachment: LocalAttachment): void {
 		if (composerLocked) return;
 		localAttachments.remove(attachment);
-		hasAttachments = localAttachments.attachments.length > 0;
 	}
 
 	function clearAttachments(): void {
 		localAttachments.clear();
-		hasAttachments = false;
 	}
 
 	async function retryAttachment(attachment: LocalAttachment): Promise<void> {

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -50,7 +50,7 @@
 	}
 
 	export function hasAttachments(): boolean {
-		return localAttachments.attachments.length > 0;
+		return localAttachments.hasAttachments;
 	}
 
 	function clearComposer(closed = false): void {
@@ -456,7 +456,7 @@
 		}
 		if (
 			content === '' &&
-			localAttachments.attachments.length === 0 &&
+			!localAttachments.hasAttachments &&
 			!confirm($_('editor.post.empty'))
 		) {
 			return;
@@ -733,7 +733,7 @@
 				class="active"
 				onclick={postNote}
 				disabled={$author === undefined ||
-					(content === '' && localAttachments.attachments.length === 0) ||
+					(content === '' && !localAttachments.hasAttachments) ||
 					$rom ||
 					posting ||
 					localAttachments.uploading}
@@ -759,7 +759,7 @@
 			<Loading />
 		</div>
 	{/if}
-	{#if content !== '' || localAttachments.attachments.length > 0}
+	{#if content !== '' || localAttachments.hasAttachments}
 		<section class="preview card">
 			<ContentComponent content={Content.replaceNip19(content)} {tags} {localMedia} />
 			{#if enableVia}

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -34,13 +34,8 @@
 	import ContinuePosting from './ContinuePosting.svelte';
 	import ExternalLink from '../ExternalLink.svelte';
 	import { emojiEditorUrl } from '$lib/Constants';
-	import {
-		appendUrls,
-		createLocalAttachments,
-		revokeAttachments,
-		uploadLocalAttachments,
-		type LocalAttachment
-	} from '$lib/media/LocalAttachment';
+	import { appendUrls, type LocalAttachment } from '$lib/media/LocalAttachment';
+	import { LocalAttachments } from '$lib/media/LocalAttachments.svelte';
 	import MediaAttachments from '../MediaAttachments.svelte';
 
 	export function clear(closed = false): void {
@@ -258,17 +253,18 @@
 	//#region Media
 
 	let onDrag = $state(false);
-	let attachments: LocalAttachment[] = $state([]);
+	const localAttachments = new LocalAttachments();
 
-	let uploading = $derived(attachments.some(({ state }) => state === 'uploading'));
-	let composerLocked = $derived(posting || uploading);
-	let localMedia = $derived(attachments.map(({ previewUrl: url, kind }) => ({ url, kind })));
+	let composerLocked = $derived(posting || localAttachments.uploading);
+	let localMedia = $derived(
+		localAttachments.attachments.map(({ previewUrl: url, kind }) => ({ url, kind }))
+	);
 
 	$effect(() => {
 		busy = composerLocked;
 	});
 
-	onDestroy(() => revokeAttachments(attachments));
+	onDestroy(() => localAttachments.dispose());
 
 	//#endregion
 
@@ -456,7 +452,11 @@
 		if (posting) {
 			return;
 		}
-		if (content === '' && attachments.length === 0 && !confirm($_('editor.post.empty'))) {
+		if (
+			content === '' &&
+			localAttachments.attachments.length === 0 &&
+			!confirm($_('editor.post.empty'))
+		) {
 			return;
 		}
 		if (containsNsec && !confirm($_('editor.post.nsec'))) {
@@ -466,8 +466,7 @@
 		const replyEvent = $state.snapshot(replyTarget?.event);
 		posting = true;
 		const contentTarget = content;
-		const uploadTarget = [...attachments];
-		const uploadedUrls = await uploadLocalAttachments(uploadTarget);
+		const uploadedUrls = await localAttachments.upload();
 		if (uploadedUrls === undefined) {
 			posting = false;
 			return;
@@ -593,32 +592,29 @@
 
 	function addAttachments(files: FileList | File[]): void {
 		if (composerLocked) return;
-		attachments = [...attachments, ...createLocalAttachments(files)];
-		hasAttachments = attachments.length > 0;
+		localAttachments.add(files);
+		hasAttachments = localAttachments.attachments.length > 0;
 	}
 
 	function removeAttachment(attachment: LocalAttachment): void {
 		if (composerLocked) return;
-		URL.revokeObjectURL(attachment.previewUrl);
-		attachments = attachments.filter((candidate) => candidate !== attachment);
-		hasAttachments = attachments.length > 0;
+		localAttachments.remove(attachment);
+		hasAttachments = localAttachments.attachments.length > 0;
 	}
 
 	function clearAttachments(): void {
-		revokeAttachments(attachments);
-		attachments = [];
+		localAttachments.clear();
 		hasAttachments = false;
 	}
 
 	async function retryAttachment(attachment: LocalAttachment): Promise<void> {
-		if (composerLocked || attachment.state !== 'failed') return;
-		await uploadLocalAttachments([attachment]);
+		if (composerLocked) return;
+		await localAttachments.retry(attachment);
 	}
 
 	async function addAttachmentUrls(): Promise<void> {
 		if (composerLocked) return;
-		const uploadTarget = [...attachments];
-		const uploadedUrls = await uploadLocalAttachments(uploadTarget);
+		const uploadedUrls = await localAttachments.upload();
 		if (uploadedUrls === undefined) return;
 		content = appendUrls(content, uploadedUrls);
 		clearAttachments();
@@ -712,7 +708,7 @@
 	</div>
 
 	<MediaAttachments
-		{attachments}
+		attachments={localAttachments.attachments}
 		disabled={composerLocked}
 		onRetry={retryAttachment}
 		onRemove={removeAttachment}
@@ -738,10 +734,10 @@
 				class="active"
 				onclick={postNote}
 				disabled={$author === undefined ||
-					(content === '' && attachments.length === 0) ||
+					(content === '' && localAttachments.attachments.length === 0) ||
 					$rom ||
 					posting ||
-					uploading}
+					localAttachments.uploading}
 			>
 				{$_('editor.post.button')}
 			</button>
@@ -759,12 +755,12 @@
 			<Note item={new EventItem(quote)} readonly={true} />
 		{/each}
 	{/if}
-	{#if uploading}
+	{#if localAttachments.uploading}
 		<div class="uploading">
 			<Loading />
 		</div>
 	{/if}
-	{#if content !== '' || attachments.length > 0}
+	{#if content !== '' || localAttachments.attachments.length > 0}
 		<section class="preview card">
 			<ContentComponent content={Content.replaceNip19(content)} {tags} {localMedia} />
 			{#if enableVia}

--- a/web/src/lib/media/LocalAttachments.svelte.ts
+++ b/web/src/lib/media/LocalAttachments.svelte.ts
@@ -1,0 +1,39 @@
+import {
+	createLocalAttachments,
+	revokeAttachments,
+	uploadLocalAttachments,
+	type LocalAttachment
+} from './LocalAttachment';
+
+export class LocalAttachments {
+	attachments = $state<LocalAttachment[]>([]);
+
+	uploading = $derived(this.attachments.some(({ state }) => state === 'uploading'));
+
+	add(files: FileList | File[]): void {
+		this.attachments = [...this.attachments, ...createLocalAttachments(files)];
+	}
+
+	remove(attachment: LocalAttachment): void {
+		URL.revokeObjectURL(attachment.previewUrl);
+		this.attachments = this.attachments.filter((candidate) => candidate !== attachment);
+	}
+
+	clear(): void {
+		revokeAttachments(this.attachments);
+		this.attachments = [];
+	}
+
+	async retry(attachment: LocalAttachment): Promise<void> {
+		if (attachment.state !== 'failed') return;
+		await uploadLocalAttachments([attachment]);
+	}
+
+	async upload(): Promise<string[] | undefined> {
+		return await uploadLocalAttachments([...this.attachments]);
+	}
+
+	dispose(): void {
+		this.clear();
+	}
+}

--- a/web/src/lib/media/LocalAttachments.svelte.ts
+++ b/web/src/lib/media/LocalAttachments.svelte.ts
@@ -8,6 +8,10 @@ import {
 export class LocalAttachments {
 	attachments = $state<LocalAttachment[]>([]);
 
+	get hasAttachments(): boolean {
+		return this.attachments.length > 0;
+	}
+
 	uploading = $derived(this.attachments.some(({ state }) => state === 'uploading'));
 
 	add(files: FileList | File[]): void {

--- a/web/src/lib/media/LocalAttachments.test.ts
+++ b/web/src/lib/media/LocalAttachments.test.ts
@@ -20,6 +20,21 @@ afterEach(() => {
 });
 
 describe('LocalAttachments', () => {
+	it('reports whether attachments exist', () => {
+		const localAttachments = new LocalAttachments();
+		expect(localAttachments.hasAttachments).toBe(false);
+
+		localAttachments.add([new File([], 'first.png', { type: 'image/png' })]);
+		expect(localAttachments.hasAttachments).toBe(true);
+
+		localAttachments.remove(localAttachments.attachments[0]);
+		expect(localAttachments.hasAttachments).toBe(false);
+
+		localAttachments.add([new File([], 'second.png', { type: 'image/png' })]);
+		localAttachments.clear();
+		expect(localAttachments.hasAttachments).toBe(false);
+	});
+
 	it('adds supported media without uploading', () => {
 		const localAttachments = new LocalAttachments();
 		localAttachments.add([

--- a/web/src/lib/media/LocalAttachments.test.ts
+++ b/web/src/lib/media/LocalAttachments.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { uploadFiles } = vi.hoisted(() => ({ uploadFiles: vi.fn() }));
+
+vi.mock('./Uploader', () => ({ uploadFiles }));
+
+import { LocalAttachments } from './LocalAttachments.svelte';
+
+const createObjectURL = vi.spyOn(URL, 'createObjectURL');
+const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL');
+
+beforeEach(() => {
+	createObjectURL.mockImplementation((file) => `blob:${(file as File).name}`);
+});
+
+afterEach(() => {
+	uploadFiles.mockReset();
+	createObjectURL.mockReset();
+	revokeObjectURL.mockReset();
+});
+
+describe('LocalAttachments', () => {
+	it('adds supported media without uploading', () => {
+		const localAttachments = new LocalAttachments();
+		localAttachments.add([
+			new File([], 'image.png', { type: 'image/png' }),
+			new File([], 'video.mp4', { type: 'video/mp4' }),
+			new File([], 'unknown.txt', { type: 'text/plain' })
+		]);
+
+		expect(
+			localAttachments.attachments.map(({ file, kind, state, previewUrl }) => ({
+				name: file.name,
+				kind,
+				state,
+				previewUrl
+			}))
+		).toEqual([
+			{ name: 'image.png', kind: 'image', state: 'pending', previewUrl: 'blob:image.png' },
+			{ name: 'video.mp4', kind: 'video', state: 'pending', previewUrl: 'blob:video.mp4' }
+		]);
+		expect(uploadFiles).not.toHaveBeenCalled();
+	});
+
+	it('revokes the preview URL before removing an attachment', () => {
+		const localAttachments = new LocalAttachments();
+		localAttachments.add([
+			new File([], 'first.png', { type: 'image/png' }),
+			new File([], 'second.png', { type: 'image/png' })
+		]);
+
+		localAttachments.remove(localAttachments.attachments[0]);
+
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:first.png');
+		expect(localAttachments.attachments.map(({ file }) => file.name)).toEqual(['second.png']);
+	});
+
+	it('revokes all preview URLs and empties the collection when cleared', () => {
+		const localAttachments = new LocalAttachments();
+		localAttachments.add([
+			new File([], 'first.png', { type: 'image/png' }),
+			new File([], 'second.png', { type: 'image/png' })
+		]);
+
+		localAttachments.clear();
+
+		expect(revokeObjectURL.mock.calls).toEqual([['blob:first.png'], ['blob:second.png']]);
+		expect(localAttachments.attachments).toEqual([]);
+	});
+
+	it('uploads a collection snapshot and reacts to in-place upload state changes', async () => {
+		const localAttachments = new LocalAttachments();
+		const first = new File([], 'first.png', { type: 'image/png' });
+		localAttachments.add([first]);
+		let finishUpload: (results: { file: File; url: string | undefined }[]) => void = () => {};
+		uploadFiles.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					finishUpload = resolve;
+				})
+		);
+
+		const uploading = localAttachments.upload();
+		expect(localAttachments.uploading).toBe(true);
+		localAttachments.add([new File([], 'second.png', { type: 'image/png' })]);
+		finishUpload([{ file: first, url: 'https://media/first.png' }]);
+
+		expect(await uploading).toEqual(['https://media/first.png']);
+		expect(localAttachments.uploading).toBe(false);
+		expect(uploadFiles).toHaveBeenCalledWith([first]);
+		expect(localAttachments.attachments.map(({ state }) => state)).toEqual([
+			'uploaded',
+			'pending'
+		]);
+	});
+
+	it('keeps failed uploads retryable', async () => {
+		const localAttachments = new LocalAttachments();
+		const file = new File([], 'image.png', { type: 'image/png' });
+		localAttachments.add([file]);
+		uploadFiles
+			.mockResolvedValueOnce([{ file, url: undefined }])
+			.mockResolvedValueOnce([{ file, url: 'https://media/image.png' }]);
+
+		expect(await localAttachments.upload()).toBeUndefined();
+		expect(localAttachments.attachments[0].state).toBe('failed');
+		await localAttachments.retry(localAttachments.attachments[0]);
+
+		expect(localAttachments.attachments[0]).toMatchObject({
+			state: 'uploaded',
+			url: 'https://media/image.png'
+		});
+		expect(uploadFiles).toHaveBeenCalledTimes(2);
+	});
+
+	it('revokes remaining preview URLs on dispose without double-revoking cleared entries', () => {
+		const localAttachments = new LocalAttachments();
+		localAttachments.add([new File([], 'image.png', { type: 'image/png' })]);
+
+		localAttachments.dispose();
+		localAttachments.dispose();
+
+		expect(revokeObjectURL).toHaveBeenCalledOnce();
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:image.png');
+		expect(localAttachments.attachments).toEqual([]);
+	});
+});

--- a/web/src/routes/(app)/NoteDialog.svelte
+++ b/web/src/routes/(app)/NoteDialog.svelte
@@ -9,7 +9,6 @@
 	import NoteComposer from '$lib/components/composer/NoteComposer.svelte';
 	import IconX from '@tabler/icons-svelte-runes/icons/x';
 
-	let hasAttachments = $state(false);
 	let composerBusy = $state(false);
 	let content = $state('');
 	let replyTo = $state<EventItem>();
@@ -71,7 +70,8 @@
 	function closeIfNotEmpty(e?: Event): void {
 		e?.preventDefault();
 		if (composerBusy) return;
-		if ((content === '' && !hasAttachments) || confirm($_('editor.close.confirm'))) {
+		const composerHasAttachments = composer?.hasAttachments() ?? false;
+		if ((content === '' && !composerHasAttachments) || confirm($_('editor.close.confirm'))) {
 			dialog?.close();
 		}
 	}
@@ -101,7 +101,6 @@
 			bind:content
 			{replyTo}
 			{quotes}
-			bind:hasAttachments
 			bind:busy={composerBusy}
 			onSent={handleSent}
 			afterPost={closeDialog}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -15,13 +15,8 @@
 	import type { PickerEmoji } from '$lib/Emoji';
 	import MediaPicker from '$lib/components/MediaPicker.svelte';
 	import MediaAttachments from '$lib/components/MediaAttachments.svelte';
-	import {
-		appendUrls,
-		createLocalAttachments,
-		revokeAttachments,
-		uploadLocalAttachments,
-		type LocalAttachment
-	} from '$lib/media/LocalAttachment';
+	import { appendUrls, type LocalAttachment } from '$lib/media/LocalAttachment';
+	import { LocalAttachments } from '$lib/media/LocalAttachments.svelte';
 	import { composerFocus } from './ComposerFocus.svelte';
 
 	interface Props {
@@ -35,10 +30,9 @@
 	let content = $state('');
 	let posting = $state(false);
 	let emojiTags = $state<string[][]>([]);
-	let attachments: LocalAttachment[] = $state([]);
+	const localAttachments = new LocalAttachments();
 
-	let uploading = $derived(attachments.some(({ state }) => state === 'uploading'));
-	let composerLocked = $derived(posting || uploading);
+	let composerLocked = $derived(posting || localAttachments.uploading);
 	let replyName = $derived(
 		replyTo !== undefined
 			? ($metadataStore.get(replyTo.pubkey)?.displayName ?? alternativeName(replyTo.pubkey))
@@ -51,19 +45,21 @@
 
 	onDestroy(() => {
 		composerFocus.current = undefined;
-		revokeAttachments(attachments);
+		localAttachments.dispose();
 	});
 
 	async function send(): Promise<void> {
-		if (composerLocked || (content.trim() === '' && attachments.length === 0)) {
+		if (
+			composerLocked ||
+			(content.trim() === '' && localAttachments.attachments.length === 0)
+		) {
 			return;
 		}
 		posting = true;
 		const contentTarget = content;
 		const replyTarget = $state.snapshot(replyTo);
 		const emojiTagsTarget = $state.snapshot(emojiTags);
-		const attachmentTarget = [...attachments];
-		const uploadedUrls = await uploadLocalAttachments(attachmentTarget);
+		const uploadedUrls = await localAttachments.upload();
 		if (uploadedUrls === undefined) {
 			posting = false;
 			return;
@@ -163,18 +159,12 @@
 
 	function addAttachments(files: FileList | File[]): void {
 		if (composerLocked) return;
-		attachments = [...attachments, ...createLocalAttachments(files)];
+		localAttachments.add(files);
 	}
 
 	function removeAttachment(attachment: LocalAttachment): void {
 		if (composerLocked) return;
-		URL.revokeObjectURL(attachment.previewUrl);
-		attachments = attachments.filter((candidate) => candidate !== attachment);
-	}
-
-	function clearAttachments(): void {
-		revokeAttachments(attachments);
-		attachments = [];
+		localAttachments.remove(attachment);
 	}
 
 	function clearReply(): void {
@@ -186,21 +176,20 @@
 		content = '';
 		emojiTags = [];
 		replyTo = undefined;
-		clearAttachments();
+		localAttachments.clear();
 	}
 
 	async function retryAttachment(attachment: LocalAttachment): Promise<void> {
-		if (composerLocked || attachment.state !== 'failed') return;
-		await uploadLocalAttachments([attachment]);
+		if (composerLocked) return;
+		await localAttachments.retry(attachment);
 	}
 
 	async function addAttachmentUrls(): Promise<void> {
 		if (composerLocked) return;
-		const attachmentTarget = [...attachments];
-		const uploadedUrls = await uploadLocalAttachments(attachmentTarget);
+		const uploadedUrls = await localAttachments.upload();
 		if (uploadedUrls === undefined) return;
 		content = appendUrls(content, uploadedUrls);
-		clearAttachments();
+		localAttachments.clear();
 	}
 </script>
 
@@ -222,7 +211,7 @@
 		</div>
 	{/if}
 	<MediaAttachments
-		{attachments}
+		attachments={localAttachments.attachments}
 		disabled={composerLocked}
 		onRetry={retryAttachment}
 		onRemove={removeAttachment}
@@ -244,7 +233,8 @@
 		<button
 			class="send"
 			title="{$_('channel.send')} (Ctrl + Enter)"
-			disabled={composerLocked || (content.trim() === '' && attachments.length === 0)}
+			disabled={composerLocked ||
+				(content.trim() === '' && localAttachments.attachments.length === 0)}
 			onclick={send}
 		>
 			<IconSend size={20} />

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -49,10 +49,7 @@
 	});
 
 	async function send(): Promise<void> {
-		if (
-			composerLocked ||
-			(content.trim() === '' && localAttachments.attachments.length === 0)
-		) {
+		if (composerLocked || (content.trim() === '' && !localAttachments.hasAttachments)) {
 			return;
 		}
 		posting = true;
@@ -233,8 +230,7 @@
 		<button
 			class="send"
 			title="{$_('channel.send')} (Ctrl + Enter)"
-			disabled={composerLocked ||
-				(content.trim() === '' && localAttachments.attachments.length === 0)}
+			disabled={composerLocked || (content.trim() === '' && !localAttachments.hasAttachments)}
 			onclick={send}
 		>
 			<IconSend size={20} />


### PR DESCRIPTION
## Summary

- Add a reusable Svelte reactive `LocalAttachments` controller for attachment collection state, upload state, and lifecycle operations.
- Use the controller from both NoteComposer and ChannelComposer to share add/remove/clear/retry/upload/dispose orchestration.
- Reuse the existing `LocalAttachment.ts` create, upload, and revoke primitives without changing their upload behavior.
- Keep content updates, posting/lock decisions, paste/drop extraction, lifecycle hook registration, and UI ownership in each Composer. `MediaAttachments.svelte` remains presentation-only.
- Preserve individual removal, collection clear, and component destruction object URL cleanup. Uploads continue to use a collection snapshot.

## Tests and validation

- Added 6 controller unit tests covering add without upload, remove/clear/dispose cleanup, upload snapshot and reactive uploading state, failure, and retry.
- `npm run check`
- `npm test -- --run` (37 files, 328 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`