### PR TITLE
Share data transfer file extraction

### DIFF
--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -34,7 +34,11 @@
 	import ContinuePosting from './ContinuePosting.svelte';
 	import ExternalLink from '../ExternalLink.svelte';
 	import { emojiEditorUrl } from '$lib/Constants';
-	import { appendUrls, type LocalAttachment } from '$lib/media/LocalAttachment';
+	import {
+		appendUrls,
+		filesFromDataTransferItems,
+		type LocalAttachment
+	} from '$lib/media/LocalAttachment';
 	import { LocalAttachments } from '$lib/media/LocalAttachments.svelte';
 	import MediaAttachments from '../MediaAttachments.svelte';
 
@@ -559,10 +563,7 @@
 			return;
 		}
 
-		const files = [...event.clipboardData.items]
-			.filter((item) => item.kind === 'file')
-			.map((item) => item.getAsFile())
-			.filter((file): file is File => file !== null);
+		const files = filesFromDataTransferItems(event.clipboardData.items);
 		addAttachments(files);
 	}
 
@@ -580,10 +581,7 @@
 			return;
 		}
 
-		const files = [...event.dataTransfer.items]
-			.filter((item) => item.kind === 'file')
-			.map((item) => item.getAsFile())
-			.filter((file): file is File => file !== null);
+		const files = filesFromDataTransferItems(event.dataTransfer.items);
 		addAttachments(files);
 	}
 

--- a/web/src/lib/media/LocalAttachment.test.ts
+++ b/web/src/lib/media/LocalAttachment.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	appendUrls,
 	createLocalAttachments,
+	filesFromDataTransferItems,
 	revokeAttachments,
 	uploadLocalAttachments,
 	type LocalAttachment
@@ -16,6 +17,21 @@ afterEach(() => {
 });
 
 describe('local attachments', () => {
+	it('extracts file items in order and ignores strings and unavailable files', () => {
+		const first = new File([], 'first.png');
+		const second = new File([], 'second.png');
+		const stringGetAsFile = vi.fn(() => null);
+		const items = [
+			{ kind: 'file', getAsFile: () => first },
+			{ kind: 'string', getAsFile: stringGetAsFile },
+			{ kind: 'file', getAsFile: () => null },
+			{ kind: 'file', getAsFile: () => second }
+		] as unknown as DataTransferItemList;
+
+		expect(filesFromDataTransferItems(items)).toEqual([first, second]);
+		expect(stringGetAsFile).not.toHaveBeenCalled();
+	});
+
 	it('creates image, video, and audio previews without uploading', () => {
 		createObjectURL.mockImplementation((file) => `blob:${(file as File).name}`);
 		const files = [

--- a/web/src/lib/media/LocalAttachment.ts
+++ b/web/src/lib/media/LocalAttachment.ts
@@ -16,6 +16,13 @@ export interface LocalMediaPreview {
 	kind: MediaKind;
 }
 
+export function filesFromDataTransferItems(items: DataTransferItemList): File[] {
+	return [...items]
+		.filter((item) => item.kind === 'file')
+		.map((item) => item.getAsFile())
+		.filter((file): file is File => file !== null);
+}
+
 export function createLocalAttachments(files: FileList | File[]): LocalAttachment[] {
 	return [...files].flatMap((file) => {
 		const kind = mediaKindFromContentType(file.type) ?? mediaKindFromPathname(file.name);

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -15,7 +15,11 @@
 	import type { PickerEmoji } from '$lib/Emoji';
 	import MediaPicker from '$lib/components/MediaPicker.svelte';
 	import MediaAttachments from '$lib/components/MediaAttachments.svelte';
-	import { appendUrls, type LocalAttachment } from '$lib/media/LocalAttachment';
+	import {
+		appendUrls,
+		filesFromDataTransferItems,
+		type LocalAttachment
+	} from '$lib/media/LocalAttachment';
 	import { LocalAttachments } from '$lib/media/LocalAttachments.svelte';
 	import { composerFocus } from './ComposerFocus.svelte';
 
@@ -131,10 +135,7 @@
 		if (composerLocked || event.clipboardData === null) {
 			return;
 		}
-		const files = [...event.clipboardData.items]
-			.filter((item) => item.kind === 'file')
-			.map((item) => item.getAsFile())
-			.filter((file): file is File => file !== null);
+		const files = filesFromDataTransferItems(event.clipboardData.items);
 		addAttachments(files);
 	}
 
@@ -143,10 +144,7 @@
 		if (composerLocked || event.dataTransfer === null) {
 			return;
 		}
-		const files = [...event.dataTransfer.items]
-			.filter((item) => item.kind === 'file')
-			.map((item) => item.getAsFile())
-			.filter((file): file is File => file !== null);
+		const files = filesFromDataTransferItems(event.dataTransfer.items);
 		addAttachments(files);
 	}
 


### PR DESCRIPTION
## Summary

- add `filesFromDataTransferItems` to convert `DataTransferItemList` into ordered `File[]` values
- share the helper across NoteComposer and ChannelComposer paste/drop handlers
- keep DOM event handling in each Composer and attachment state ownership in LocalAttachments
- preserve existing paste/drop behavior

## Validation

- `npm run check`
- `npm test -- --run` (37 files, 330 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`