### PR TITLE
Replace text event composer class

### DIFF
--- a/web/src/lib/TextEventComposer.test.ts
+++ b/web/src/lib/TextEventComposer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { kinds as Kind, type Event } from 'nostr-tools';
-import { TextEventComposer } from './TextEventComposer';
+import { replyTags } from './TextEventComposer';
 
-describe('TextEventComposer.replyTags', () => {
+describe('replyTags', () => {
 	it('preserves NIP-28 root, reply, and pubkey tags when replying to a channel message', () => {
 		const replyTo: Event = {
 			kind: Kind.ChannelMessage,
@@ -18,7 +18,7 @@ describe('TextEventComposer.replyTags', () => {
 			sig: ''
 		};
 
-		const tags = new TextEventComposer().replyTags('', replyTo);
+		const tags = replyTags('', replyTo);
 
 		expect(tags).toContainEqual(['e', 'channel-id', '', 'root']);
 		expect(tags).toContainEqual(['e', 'reply-id', '', 'reply', 'reply-author']);

--- a/web/src/lib/TextEventComposer.ts
+++ b/web/src/lib/TextEventComposer.ts
@@ -8,169 +8,173 @@ import { referTags } from './EventHelper';
 import { getRelayHint } from './timelines/MainTimeline';
 import { unique } from './Array';
 
-export class TextEventComposer {
-	async compose(kind: number, content: string, tags: string[][]): Promise<Event | null> {
-		try {
-			return await Signer.signEvent({
-				kind,
-				content,
-				tags,
-				created_at: now()
-			});
-		} catch {
-			return null;
-		}
+export async function compose(
+	kind: number,
+	content: string,
+	tags: string[][]
+): Promise<Event | null> {
+	try {
+		return await Signer.signEvent({
+			kind,
+			content,
+			tags,
+			created_at: now()
+		});
+	} catch {
+		return null;
 	}
+}
 
-	replyTags(
-		content: string,
-		replyTo: Event | undefined = undefined,
-		channelId: string | undefined = undefined
-	): string[][] {
-		let pubkeys = new Set<string>();
-		const tags: string[][] = [];
+export function replyTags(
+	content: string,
+	replyTo: Event | undefined = undefined,
+	channelId: string | undefined = undefined
+): string[][] {
+	let pubkeys = new Set<string>();
+	const tags: string[][] = [];
 
-		if (channelId) {
-			tags.push(['e', channelId, '', 'root']);
-			if (replyTo !== undefined) {
-				tags.push(['e', replyTo.id, '', 'reply']);
-				if (
-					replyTo.tags.some(
-						([tagName, pubkey]) => tagName === 'p' && pubkey === replyTo.pubkey
-					)
-				) {
-					tags.push(...replyTo.tags.filter(([tagName]) => tagName === 'p'));
-				} else {
-					tags.push(...replyTo.tags.filter(([tagName]) => tagName === 'p'), [
-						'p',
-						replyTo.pubkey
-					]);
-				}
-			}
-		} else if (replyTo !== undefined) {
-			const { root } = referTags(replyTo);
-			const relay = getRelayHint(replyTo.id);
-			if (root === undefined) {
-				tags.push(['e', replyTo.id, relay ?? '', 'root', replyTo.pubkey]);
+	if (channelId) {
+		tags.push(['e', channelId, '', 'root']);
+		if (replyTo !== undefined) {
+			tags.push(['e', replyTo.id, '', 'reply']);
+			if (
+				replyTo.tags.some(
+					([tagName, pubkey]) => tagName === 'p' && pubkey === replyTo.pubkey
+				)
+			) {
+				tags.push(...replyTo.tags.filter(([tagName]) => tagName === 'p'));
 			} else {
-				tags.push(root);
-				tags.push(['e', replyTo.id, relay ?? '', 'reply', replyTo.pubkey]);
+				tags.push(...replyTo.tags.filter(([tagName]) => tagName === 'p'), [
+					'p',
+					replyTo.pubkey
+				]);
 			}
-			pubkeys = new Set([
-				replyTo.pubkey,
-				...replyTo.tags.filter((x) => x[0] === 'p').map((x) => x[1])
-			]);
 		}
+	} else if (replyTo !== undefined) {
+		const { root } = referTags(replyTo);
+		const relay = getRelayHint(replyTo.id);
+		if (root === undefined) {
+			tags.push(['e', replyTo.id, relay ?? '', 'root', replyTo.pubkey]);
+		} else {
+			tags.push(root);
+			tags.push(['e', replyTo.id, relay ?? '', 'reply', replyTo.pubkey]);
+		}
+		pubkeys = new Set([
+			replyTo.pubkey,
+			...replyTo.tags.filter((x) => x[0] === 'p').map((x) => x[1])
+		]);
+	}
 
-		const eventIds = Content.findNotesAndNeventsToIds(content);
-		tags.push(
-			...unique(eventIds).map((id) => {
-				const qTag = ['q', id];
-				const relay = getRelayHint(id);
-				if (relay) {
-					qTag.push(relay);
+	const eventIds = Content.findNotesAndNeventsToIds(content);
+	tags.push(
+		...unique(eventIds).map((id) => {
+			const qTag = ['q', id];
+			const relay = getRelayHint(id);
+			if (relay) {
+				qTag.push(relay);
+			}
+			return qTag;
+		})
+	);
+
+	for (const { type, data } of Content.findNpubsAndNprofiles(content).map((x) => {
+		try {
+			return nip19.decode(x);
+		} catch {
+			return { type: undefined, data: undefined };
+		}
+	})) {
+		switch (type) {
+			case 'npub': {
+				pubkeys.add(data as string);
+				break;
+			}
+			case 'nprofile': {
+				pubkeys.add((data as nip19.ProfilePointer).pubkey);
+			}
+		}
+	}
+	tags.push(...Array.from(pubkeys).map((pubkey) => ['p', pubkey]));
+
+	return tags;
+}
+
+export function hashtags(content: string): string[][] {
+	const hashtags = Content.findHashtags(content);
+	return hashtags.map((hashtag) => ['t', hashtag.toLowerCase()]);
+}
+
+export async function emojiTags(content: string, emojiTags: string[][] = []): Promise<string[][]> {
+	const tags: string[][] = [];
+
+	// Custom emojis
+	tags.push(...emojiTags.filter(([, shortcode]) => content.includes(`:${shortcode}:`)));
+	const readApi = new Api();
+	const shortcodes = Array.from(
+		new Set(
+			[...content.matchAll(/:(?<shortcode>\w+):/g)]
+				.map((match) => match.groups?.shortcode)
+				.filter((x): x is string => x !== undefined)
+		)
+	);
+	const customEmojiPubkeysMap = new Map(
+		shortcodes
+			.filter((shortcode) => shortcode.startsWith('npub1'))
+			.map((npub) => {
+				try {
+					const { data: pubkey } = nip19.decode(npub);
+					return [npub, pubkey as string];
+				} catch (error) {
+					console.warn('[invalid npub]', npub, error);
+					return [npub, undefined];
 				}
-				return qTag;
 			})
-		);
-
-		for (const { type, data } of Content.findNpubsAndNprofiles(content).map((x) => {
-			try {
-				return nip19.decode(x);
-			} catch {
-				return { type: undefined, data: undefined };
-			}
-		})) {
-			switch (type) {
-				case 'npub': {
-					pubkeys.add(data as string);
-					break;
+	);
+	const customEmojiMetadataEventsMap = await readApi.fetchMetadataEventsMap(
+		[...customEmojiPubkeysMap]
+			.map(([, pubkey]) => pubkey)
+			.filter((pubkey): pubkey is string => pubkey !== undefined)
+	);
+	tags.push(
+		...shortcodes
+			.filter(([, shortcode]) => !emojiTags.some(([, s]) => s === shortcode))
+			.map((shortcode) => {
+				const pubkey = customEmojiPubkeysMap.get(shortcode);
+				if (pubkey === undefined) {
+					return null;
 				}
-				case 'nprofile': {
-					pubkeys.add((data as nip19.ProfilePointer).pubkey);
+				const metadataEvent = customEmojiMetadataEventsMap.get(pubkey);
+				if (metadataEvent === undefined) {
+					return null;
 				}
-			}
-		}
-		tags.push(...Array.from(pubkeys).map((pubkey) => ['p', pubkey]));
+				try {
+					const metadata = JSON.parse(metadataEvent.content) as User;
+					const picture = new URL(metadata.picture);
+					return ['emoji', shortcode, picture.href];
+				} catch (error) {
+					console.warn('[invalid metadata]', metadataEvent, error);
+					return null;
+				}
+			})
+			.filter((x): x is string[] => x !== null)
+	);
 
-		return tags;
-	}
+	return tags;
+}
 
-	hashtags(content: string): string[][] {
-		const hashtags = Content.findHashtags(content);
-		return hashtags.map((hashtag) => ['t', hashtag.toLowerCase()]);
-	}
+export function contentWarningTags(
+	contentWarningReason: string | undefined = undefined
+): string[][] {
+	const tags: string[][] = [];
 
-	async emojiTags(content: string, emojiTags: string[][] = []): Promise<string[][]> {
-		const tags: string[][] = [];
-
-		// Custom emojis
-		tags.push(...emojiTags.filter(([, shortcode]) => content.includes(`:${shortcode}:`)));
-		const readApi = new Api();
-		const shortcodes = Array.from(
-			new Set(
-				[...content.matchAll(/:(?<shortcode>\w+):/g)]
-					.map((match) => match.groups?.shortcode)
-					.filter((x): x is string => x !== undefined)
-			)
-		);
-		const customEmojiPubkeysMap = new Map(
-			shortcodes
-				.filter((shortcode) => shortcode.startsWith('npub1'))
-				.map((npub) => {
-					try {
-						const { data: pubkey } = nip19.decode(npub);
-						return [npub, pubkey as string];
-					} catch (error) {
-						console.warn('[invalid npub]', npub, error);
-						return [npub, undefined];
-					}
-				})
-		);
-		const customEmojiMetadataEventsMap = await readApi.fetchMetadataEventsMap(
-			[...customEmojiPubkeysMap]
-				.map(([, pubkey]) => pubkey)
-				.filter((pubkey): pubkey is string => pubkey !== undefined)
-		);
+	// Content Warning
+	if (contentWarningReason !== undefined) {
 		tags.push(
-			...shortcodes
-				.filter(([, shortcode]) => !emojiTags.some(([, s]) => s === shortcode))
-				.map((shortcode) => {
-					const pubkey = customEmojiPubkeysMap.get(shortcode);
-					if (pubkey === undefined) {
-						return null;
-					}
-					const metadataEvent = customEmojiMetadataEventsMap.get(pubkey);
-					if (metadataEvent === undefined) {
-						return null;
-					}
-					try {
-						const metadata = JSON.parse(metadataEvent.content) as User;
-						const picture = new URL(metadata.picture);
-						return ['emoji', shortcode, picture.href];
-					} catch (error) {
-						console.warn('[invalid metadata]', metadataEvent, error);
-						return null;
-					}
-				})
-				.filter((x): x is string[] => x !== null)
+			contentWarningReason === ''
+				? ['content-warning']
+				: ['content-warning', contentWarningReason]
 		);
-
-		return tags;
 	}
 
-	contentWarningTags(contentWarningReason: string | undefined = undefined): string[][] {
-		const tags: string[][] = [];
-
-		// Content Warning
-		if (contentWarningReason !== undefined) {
-			tags.push(
-				contentWarningReason === ''
-					? ['content-warning']
-					: ['content-warning', contentWarningReason]
-			);
-		}
-
-		return tags;
-	}
+	return tags;
 }

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -6,7 +6,13 @@
 	import { complementPosition } from '$lib/styles/Complement';
 	import { adjustHeight } from '$lib/styles/Textarea';
 	import { rxNostr } from '$lib/timelines/MainTimeline';
-	import { TextEventComposer } from '$lib/TextEventComposer';
+	import {
+		compose,
+		contentWarningTags,
+		emojiTags as createEmojiTags,
+		hashtags,
+		replyTags
+	} from '$lib/TextEventComposer';
 	import { Content } from '$lib/Content';
 	import { filterTags } from '$lib/EventHelper';
 	import { metadataStore } from '$lib/cache/Events';
@@ -277,13 +283,12 @@
 	let containsNsec = $derived(/nsec1\w{6,}/.test(content));
 
 	$effect(() => {
-		const textEventComposer = new TextEventComposer();
-		textEventComposer.emojiTags(content, emojiTags).then((emojiTags) => {
+		createEmojiTags(content, emojiTags).then((emojiTags) => {
 			tags = [
-				...textEventComposer.replyTags(content, $state.snapshot(replyTo?.event)),
-				...textEventComposer.hashtags(content),
+				...replyTags(content, $state.snapshot(replyTo?.event)),
+				...hashtags(content),
 				...emojiTags,
-				...textEventComposer.contentWarningTags(contentWarningReason)
+				...contentWarningTags(contentWarningReason)
 			];
 		});
 	});
@@ -479,15 +484,14 @@
 		}
 		const finalContent = appendUrls(contentTarget, uploadedUrls);
 
-		const textEventComposer = new TextEventComposer();
-		const event = await textEventComposer.compose(
+		const event = await compose(
 			replyEvent?.kind === Kind.ChannelMessage ? Kind.ChannelMessage : Kind.ShortTextNote,
 			Content.replaceNip19(finalContent),
 			[
-				...textEventComposer.replyTags(finalContent, replyEvent),
-				...textEventComposer.hashtags(finalContent),
-				...(await textEventComposer.emojiTags(finalContent, $state.snapshot(emojiTags))),
-				...textEventComposer.contentWarningTags(contentWarningReason),
+				...replyTags(finalContent, replyEvent),
+				...hashtags(finalContent),
+				...(await createEmojiTags(finalContent, $state.snapshot(emojiTags))),
+				...contentWarningTags(contentWarningReason),
 				...(enableVia ? [createViaTag()] : [])
 			]
 		);

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -5,7 +5,12 @@
 	import { ChannelMessage } from 'nostr-tools/kinds';
 	import { _ } from 'svelte-i18n';
 	import { IconSend, IconX } from '@tabler/icons-svelte-runes';
-	import { TextEventComposer } from '$lib/TextEventComposer';
+	import {
+		compose,
+		emojiTags as createEmojiTags,
+		hashtags,
+		replyTags
+	} from '$lib/TextEventComposer';
 	import { Content } from '$lib/Content';
 	import { rxNostr } from '$lib/timelines/MainTimeline';
 	import { findCustomEmojiSetAddress } from '$lib/author/CustomEmojis';
@@ -67,11 +72,10 @@
 		}
 		const finalContent = appendUrls(contentTarget, uploadedUrls);
 
-		const composer = new TextEventComposer();
-		const event = await composer.compose(ChannelMessage, Content.replaceNip19(finalContent), [
-			...composer.replyTags(finalContent, replyTarget, channelId),
-			...composer.hashtags(finalContent),
-			...(await composer.emojiTags(finalContent, emojiTagsTarget))
+		const event = await compose(ChannelMessage, Content.replaceNip19(finalContent), [
+			...replyTags(finalContent, replyTarget, channelId),
+			...hashtags(finalContent),
+			...(await createEmojiTags(finalContent, emojiTagsTarget))
 		]);
 
 		if (event === null) {


### PR DESCRIPTION
## Summary

- replace the stateless `TextEventComposer` class with named module functions
- remove unnecessary instance creation from NoteComposer, ChannelComposer, and tests
- preserve the existing function implementations and posting/tag behavior

## Validation

- `npm run check`
- `npm test -- --run` (37 files, 330 tests passed)
- `npm run lint`
- `npm run build`
- `git diff --check`