### PR TITLE
Harden standard bookmark writes

### DIFF
--- a/web/src/lib/author/Bookmark.test.ts
+++ b/web/src/lib/author/Bookmark.test.ts
@@ -1,37 +1,108 @@
-import { describe, expect, it, vi } from 'vitest';
-import { of } from 'rxjs';
+import { get } from 'svelte/store';
+import { of, Subject, throwError, type Observable } from 'rxjs';
 import { kinds as Kind } from 'nostr-tools';
+import type * as Nostr from 'nostr-typedef';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { signEvent } = vi.hoisted(() => ({
-	signEvent: vi.fn(async (event) => ({ ...event, id: 'signed', pubkey: 'pubkey', sig: 'sig' }))
+const mocks = vi.hoisted(() => ({
+	cached: undefined as Nostr.Event | undefined,
+	remote: undefined as Nostr.Event | undefined,
+	remoteEvents: [] as Array<Nostr.Event | undefined>,
+	mirrorCache: true,
+	pendingSend: undefined as Observable<{ ok: boolean }> | undefined,
+	sendFails: false,
+	sent: [] as Nostr.Event[],
+	setCalls: [] as Nostr.Event[],
+	signCount: 0
 }));
 
 vi.mock('$lib/timelines/MainTimeline', () => ({
-	rxNostr: { send: () => of({ ok: true }) }
+	rxNostr: {
+		send: (event: Nostr.Event) => {
+			mocks.sent.push(event);
+			if (mocks.pendingSend !== undefined) {
+				const pending = mocks.pendingSend;
+				mocks.pendingSend = undefined;
+				return pending;
+			}
+			return mocks.sendFails ? throwError(() => new Error('rejected')) : of({ ok: true });
+		}
+	}
 }));
-vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
-vi.mock('$lib/RxNostrHelper', () => ({ fetchLastEvent: vi.fn(async () => undefined) }));
+vi.mock('$lib/Signer', () => ({
+	Signer: {
+		signEvent: vi.fn(async (unsigned) => ({
+			...unsigned,
+			id: `signed-${++mocks.signCount}`,
+			pubkey: 'pubkey',
+			sig: 'sig'
+		}))
+	}
+}));
+vi.mock('$lib/RxNostrHelper', () => ({
+	fetchLastEvent: vi.fn(async () => {
+		if (mocks.remoteEvents.length > 0) return mocks.remoteEvents.shift();
+		return mocks.mirrorCache ? mocks.cached : mocks.remote;
+	})
+}));
+vi.mock('$lib/stores/Author', async () => {
+	const { writable } = await import('svelte/store');
+	return { pubkey: writable('pubkey') };
+});
 vi.mock('$lib/WebStorage', () => ({
 	WebStorage: class {
 		getReplaceableEvent() {
-			return undefined;
+			return mocks.cached;
 		}
 
-		setReplaceableEvent() {}
+		setReplaceableEvent(event: Nostr.Event) {
+			mocks.setCalls.push(event);
+			mocks.cached = event;
+		}
 	}
 }));
 vi.stubGlobal('localStorage', {});
 
-import { bookmark, bookmarkEvent, legacyBookmarkEvent, updateBookmarkTags } from './Bookmark';
-import { get } from 'svelte/store';
+import {
+	bookmark,
+	bookmarkEvent,
+	latestEvent,
+	legacyBookmarkEvent,
+	unbookmark,
+	updateBookmarkTags
+} from './Bookmark';
+
+const event = (values: Partial<Nostr.Event>): Nostr.Event =>
+	({
+		id: 'event',
+		pubkey: 'pubkey',
+		kind: Kind.BookmarkList,
+		created_at: 10,
+		content: '',
+		tags: [],
+		sig: 'sig',
+		...values
+	}) as Nostr.Event;
 
 describe('Bookmark', () => {
+	beforeEach(() => {
+		mocks.cached = undefined;
+		mocks.remote = undefined;
+		mocks.remoteEvents = [];
+		mocks.mirrorCache = true;
+		mocks.pendingSend = undefined;
+		mocks.sendFails = false;
+		mocks.sent = [];
+		mocks.setCalls = [];
+		mocks.signCount = 0;
+		bookmarkEvent.set(undefined);
+		legacyBookmarkEvent.set(undefined);
+	});
+
 	it('publishes updates as the standard NIP-51 bookmark kind', async () => {
 		await bookmark(['e', 'event-id']);
 
-		expect(signEvent).toHaveBeenCalledWith(
-			expect.objectContaining({ kind: Kind.BookmarkList })
-		);
+		expect(mocks.sent[0]).toEqual(expect.objectContaining({ kind: Kind.BookmarkList }));
 	});
 
 	it('adds and removes bookmark tags without an addressable-event identifier', () => {
@@ -43,13 +114,101 @@ describe('Bookmark', () => {
 	});
 
 	it('keeps standard and legacy bookmark events in separate state', () => {
-		const standard = { id: 'standard' } as never;
-		const legacy = { id: 'legacy' } as never;
+		const standard = event({ id: 'standard' });
+		const legacy = event({ id: 'legacy' });
 
 		bookmarkEvent.set(standard);
 		legacyBookmarkEvent.set(legacy);
 
 		expect(get(bookmarkEvent)).toBe(standard);
 		expect(get(legacyBookmarkEvent)).toBe(legacy);
+	});
+
+	it('preserves encrypted private content when adding a public bookmark', async () => {
+		mocks.cached = event({ content: 'opaque-encrypted-content' });
+
+		await bookmark(['e', 'new']);
+
+		expect(mocks.sent[0].content).toBe('opaque-encrypted-content');
+	});
+
+	it('preserves encrypted private content when removing a public bookmark', async () => {
+		mocks.cached = event({
+			content: 'opaque-encrypted-content',
+			tags: [['e', 'remove']]
+		});
+
+		await unbookmark(['e', 'remove']);
+
+		expect(mocks.sent[0].content).toBe('opaque-encrypted-content');
+	});
+
+	it('serializes concurrent writes without losing either change', async () => {
+		const firstPublish = new Subject<{ ok: boolean }>();
+		mocks.pendingSend = firstPublish;
+
+		const first = bookmark(['e', 'first']);
+		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
+		const second = bookmark(['e', 'second']);
+		await Promise.resolve();
+		expect(mocks.sent).toHaveLength(1);
+
+		firstPublish.next({ ok: true });
+		firstPublish.complete();
+		await Promise.all([first, second]);
+
+		expect(mocks.sent[1].tags).toEqual([
+			['e', 'first'],
+			['e', 'second']
+		]);
+	});
+
+	it('uses a newer relay event instead of a stale local snapshot', async () => {
+		mocks.cached = event({ id: 'local', created_at: 10, tags: [['e', 'local']] });
+		mocks.remote = event({ id: 'remote', created_at: 20, tags: [['e', 'remote']] });
+		mocks.mirrorCache = false;
+
+		await bookmark(['e', 'new']);
+
+		expect(mocks.sent[0].tags).toEqual([
+			['e', 'remote'],
+			['e', 'new']
+		]);
+	});
+
+	it('restarts a write when a newer relay event is observed before signing', async () => {
+		const original = event({ id: 'original', created_at: 10, tags: [['e', 'original']] });
+		const newer = event({ id: 'newer', created_at: 20, tags: [['e', 'newer']] });
+		mocks.cached = original;
+		mocks.remoteEvents = [original, newer, newer, newer];
+
+		await bookmark(['e', 'added']);
+
+		expect(mocks.sent).toHaveLength(1);
+		expect(mocks.sent[0].tags).toEqual([
+			['e', 'newer'],
+			['e', 'added']
+		]);
+	});
+
+	it('selects the lexicographically lower id when replaceable timestamps match', () => {
+		const higher = event({ id: 'bbbb', created_at: 20 });
+		const lower = event({ id: 'aaaa', created_at: 20 });
+
+		expect(latestEvent(higher, lower)).toBe(lower);
+		expect(latestEvent(lower, higher)).toBe(lower);
+	});
+
+	it('does not change local state or cache when relay publish fails', async () => {
+		const previous = event({ id: 'previous', tags: [['e', 'existing']] });
+		mocks.cached = previous;
+		bookmarkEvent.set(previous);
+		mocks.sendFails = true;
+
+		await expect(bookmark(['e', 'new'])).rejects.toThrow('rejected');
+
+		expect(get(bookmarkEvent)).toBe(previous);
+		expect(mocks.cached).toBe(previous);
+		expect(mocks.setCalls).toHaveLength(0);
 	});
 });

--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -4,7 +4,6 @@ import { filter, firstValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { kinds as Kind } from 'nostr-tools';
 import { rxNostr } from '$lib/timelines/MainTimeline';
-import { Queue } from '$lib/Queue';
 import { fetchLastEvent } from '$lib/RxNostrHelper';
 import { Signer } from '$lib/Signer';
 import { WebStorage } from '$lib/WebStorage';
@@ -16,9 +15,7 @@ type Data = {
 	tag: string[];
 };
 
-const queue = new Queue<Data>();
-
-let processing = false;
+let writeQueue = Promise.resolve();
 
 export const bookmarkEvent: Writable<Nostr.Event | undefined> = writable();
 export const legacyBookmarkEvent: Writable<Nostr.Event | undefined> = writable();
@@ -51,80 +48,65 @@ export const isBookmarked = (event: Nostr.Event): boolean => {
 };
 
 export async function bookmark(tag: string[]): Promise<void> {
-	console.log('[bookmark]', tag, queue.dump());
-	await save('bookmark', tag);
+	await serialize(() => publish({ type: 'bookmark', tag }));
 }
 
 export async function unbookmark(tag: string[]): Promise<void> {
-	console.log('[unbookmark]', tag, queue.dump());
-	await save('unbookmark', tag);
+	await serialize(() => publish({ type: 'unbookmark', tag }));
 }
 
-async function save(type: DataType, tag: string[]): Promise<void> {
-	queue.enqueue({
-		type,
-		tag
-	});
-
-	if (!processing) {
-		processing = true;
-		await publish();
-		processing = false;
-	}
+function serialize(operation: () => Promise<void>): Promise<void> {
+	const result = writeQueue.then(operation, operation);
+	writeQueue = result.catch(() => undefined);
+	return result;
 }
 
-async function publish(): Promise<void> {
+async function publish(data: Data): Promise<void> {
 	const storage = new WebStorage(localStorage);
-	const lastEvent = storage.getReplaceableEvent(Kind.BookmarkList);
-	let tags = lastEvent?.tags ?? [];
+	const $pubkey = get(pubkey);
 
-	while (queue.length > 0) {
-		const data = queue.dequeue();
-		if (data === undefined) {
-			break;
+	while (true) {
+		const cached = storage.getReplaceableEvent(Kind.BookmarkList);
+		const remote = await fetchBookmarkEvent($pubkey);
+		if (cached !== undefined && remote === undefined) {
+			throw new Error('Cache is outdated.');
 		}
 
-		tags = updateBookmarkTags(tags, data);
-	}
+		const base = latestEvent(cached, remote);
+		const tags = updateBookmarkTags(base?.tags ?? [], data);
 
-	const event = await Signer.signEvent({
-		kind: Kind.BookmarkList,
-		content: lastEvent?.content ?? '',
-		tags,
-		created_at: now()
-	});
+		// Recheck before signing so a newer event observed during this write is not lost.
+		const confirmedBase = latestEvent(base, await fetchBookmarkEvent($pubkey));
+		if (confirmedBase?.id !== base?.id) {
+			continue;
+		}
 
-	bookmarkEvent.set(event);
+		const event = await Signer.signEvent({
+			kind: Kind.BookmarkList,
+			content: base?.content ?? '',
+			tags,
+			created_at: Math.max(now(), (base?.created_at ?? 0) + 1)
+		});
 
-	// Lazy validation for UX
-	if (!(await validate(lastEvent))) {
-		bookmarkEvent.set(lastEvent);
-		throw new Error('Cache is outdated.');
-	}
-
-	storage.setReplaceableEvent(event);
-	await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
-
-	if (queue.length > 0) {
-		await publish();
+		await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
+		storage.setReplaceableEvent(event);
+		bookmarkEvent.set(event);
+		return;
 	}
 }
 
-async function validate(event: Nostr.Event | undefined): Promise<boolean> {
-	const $pubkey = get(pubkey);
-	const lastEvent = await fetchLastEvent({
-		kinds: [Kind.BookmarkList],
-		authors: [$pubkey],
-		limit: 1
-	});
+function fetchBookmarkEvent(author: string): Promise<Nostr.Event | undefined> {
+	return fetchLastEvent({ kinds: [Kind.BookmarkList], authors: [author], limit: 1 });
+}
 
-	if (event === undefined) {
-		if (lastEvent !== undefined) {
-			return false;
-		}
-	} else if (lastEvent === undefined || event.created_at < lastEvent.created_at) {
-		return false;
+export function latestEvent(
+	left: Nostr.Event | undefined,
+	right: Nostr.Event | undefined
+): Nostr.Event | undefined {
+	if (left === undefined) return right;
+	if (right === undefined) return left;
+	if (left.created_at !== right.created_at) {
+		return left.created_at > right.created_at ? left : right;
 	}
-
-	return true;
+	return left.id < right.id ? left : right;
 }


### PR DESCRIPTION
## Summary
- serialize standard Bookmark writes to prevent concurrent updates from being lost
- base writes on the latest cached/relay event, including the NIP-01 lower-ID tie-break for equal timestamps
- preserve encrypted private bookmark content as opaque data during public Bookmark changes
- update WebStorage and local Bookmark state only after relay publish succeeds

This is a prerequisite for the follow-up implementation of #2309.

## Validation
- npm test
- npm run check
- npm run lint
- npm run build