### PR TITLE
Harden bookmark write failure handling

### DIFF
--- a/web/src/lib/author/Bookmark.test.ts
+++ b/web/src/lib/author/Bookmark.test.ts
@@ -121,6 +121,7 @@ describe('Bookmark', () => {
 
 	it('batches operations queued during publish and updates the UI optimistically', async () => {
 		const firstPublish = new Subject<{ ok: boolean }>();
+		const secondPublish = new Subject<{ ok: boolean }>();
 		mocks.pendingSend = firstPublish;
 
 		const first = bookmark(['e', 'first']);
@@ -129,19 +130,30 @@ describe('Bookmark', () => {
 		expect(get(bookmarkEvent)).toBe(mocks.sent[0]);
 		expect(mocks.setCalls).toHaveLength(0);
 
-		await bookmark(['e', 'second']);
-		await unbookmark(['e', 'first']);
+		const second = bookmark(['e', 'second']);
+		const third = unbookmark(['e', 'first']);
+		const queuedSettled = vi.fn();
+		void second.then(queuedSettled, queuedSettled);
+		void third.then(queuedSettled, queuedSettled);
+		await Promise.resolve();
+		expect(queuedSettled).not.toHaveBeenCalled();
 		expect(mocks.sent).toHaveLength(1);
 
+		mocks.pendingSend = secondPublish;
 		firstPublish.next({ ok: true });
 		firstPublish.complete();
 		await first;
+		await vi.waitFor(() => expect(mocks.sent).toHaveLength(2));
+		expect(queuedSettled).not.toHaveBeenCalled();
 
-		expect(mocks.sent).toHaveLength(2);
+		secondPublish.next({ ok: true });
+		secondPublish.complete();
+		await Promise.all([second, third]);
 		expect(mocks.sent[1].tags).toEqual([['e', 'second']]);
+		expect(queuedSettled).toHaveBeenCalledTimes(2);
 	});
 
-	it('automatically batches queued operations after the active publish fails', async () => {
+	it('aborts queued operations when the active publish fails and recovers for a new write', async () => {
 		const previous = event({ id: 'previous', tags: [['e', 'existing']] });
 		const firstPublish = new Subject<{ ok: boolean }>();
 		mocks.stored = previous;
@@ -150,48 +162,39 @@ describe('Bookmark', () => {
 
 		const first = bookmark(['e', 'failed']);
 		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
-		await bookmark(['e', 'second']);
-		await bookmark(['e', 'third']);
+		const second = bookmark(['e', 'second']);
+		const third = bookmark(['e', 'third']);
+		const queuedSettled = vi.fn();
+		void second.then(queuedSettled, queuedSettled);
+		void third.then(queuedSettled, queuedSettled);
+		const secondRejected = expect(second).rejects.toThrow('first rejected');
+		const thirdRejected = expect(third).rejects.toThrow('first rejected');
+		await Promise.resolve();
+		expect(queuedSettled).not.toHaveBeenCalled();
 		expect(mocks.sent).toHaveLength(1);
 
 		firstPublish.error(new Error('first rejected'));
 		await expect(first).rejects.toThrow('first rejected');
-		await vi.waitFor(() => expect(mocks.setCalls).toHaveLength(1));
+		await Promise.all([secondRejected, thirdRejected]);
+
+		expect(queuedSettled).toHaveBeenCalledTimes(2);
+		expect(mocks.sent).toHaveLength(1);
+		expect(mocks.setCalls).toHaveLength(0);
+		expect(mocks.stored).toBe(previous);
+		expect(get(bookmarkEvent)).toBe(previous);
+
+		await bookmark(['e', 'after-abort']);
 
 		expect(mocks.sent).toHaveLength(2);
 		expect(mocks.sent[1].tags).toEqual([
 			['e', 'existing'],
-			['e', 'second'],
-			['e', 'third']
+			['e', 'after-abort']
 		]);
 		expect(mocks.sent[1].tags).not.toContainEqual(['e', 'failed']);
+		expect(mocks.sent[1].tags).not.toContainEqual(['e', 'second']);
+		expect(mocks.sent[1].tags).not.toContainEqual(['e', 'third']);
 		expect(mocks.stored).toBe(mocks.sent[1]);
 		expect(get(bookmarkEvent)).toBe(mocks.sent[1]);
-	});
-
-	it('does not leave processing stuck when an automatic recovery also fails', async () => {
-		const previous = event({ id: 'previous' });
-		const firstPublish = new Subject<{ ok: boolean }>();
-		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-		mocks.stored = previous;
-		mocks.pendingSend = firstPublish;
-		bookmarkEvent.set(previous);
-
-		const first = bookmark(['e', 'first-failed']);
-		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
-		await bookmark(['e', 'recovery-failed']);
-		mocks.sendFails = true;
-
-		firstPublish.error(new Error('first rejected'));
-		await expect(first).rejects.toThrow('first rejected');
-		await vi.waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
-
-		mocks.sendFails = false;
-		await bookmark(['e', 'after-failures']);
-
-		expect(mocks.sent).toHaveLength(3);
-		expect(mocks.sent[2].tags).toEqual([['e', 'after-failures']]);
-		consoleError.mockRestore();
 	});
 
 	it('preserves encrypted private content while updating public bookmarks', async () => {

--- a/web/src/lib/author/Bookmark.test.ts
+++ b/web/src/lib/author/Bookmark.test.ts
@@ -1,37 +1,103 @@
-import { describe, expect, it, vi } from 'vitest';
-import { of } from 'rxjs';
+import { get } from 'svelte/store';
+import { of, Subject, throwError, type Observable } from 'rxjs';
 import { kinds as Kind } from 'nostr-tools';
+import type * as Nostr from 'nostr-typedef';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { signEvent } = vi.hoisted(() => ({
-	signEvent: vi.fn(async (event) => ({ ...event, id: 'signed', pubkey: 'pubkey', sig: 'sig' }))
+const mocks = vi.hoisted(() => ({
+	stored: undefined as Nostr.Event | undefined,
+	remote: undefined as Nostr.Event | undefined,
+	mirrorStored: true,
+	pendingSend: undefined as Observable<{ ok: boolean }> | undefined,
+	sendFails: false,
+	sent: [] as Nostr.Event[],
+	setCalls: [] as Nostr.Event[],
+	signCount: 0
 }));
 
 vi.mock('$lib/timelines/MainTimeline', () => ({
-	rxNostr: { send: () => of({ ok: true }) }
+	rxNostr: {
+		send: (event: Nostr.Event) => {
+			mocks.sent.push(event);
+			if (mocks.pendingSend !== undefined) {
+				const pending = mocks.pendingSend;
+				mocks.pendingSend = undefined;
+				return pending;
+			}
+			return mocks.sendFails ? throwError(() => new Error('rejected')) : of({ ok: true });
+		}
+	}
 }));
-vi.mock('$lib/Signer', () => ({ Signer: { signEvent } }));
-vi.mock('$lib/RxNostrHelper', () => ({ fetchLastEvent: vi.fn(async () => undefined) }));
+vi.mock('$lib/Signer', () => ({
+	Signer: {
+		signEvent: vi.fn(async (unsigned) => ({
+			...unsigned,
+			id: `signed-${++mocks.signCount}`,
+			pubkey: 'pubkey',
+			sig: 'sig'
+		}))
+	}
+}));
+vi.mock('$lib/RxNostrHelper', () => ({
+	fetchLastEvent: vi.fn(async () => (mocks.mirrorStored ? mocks.stored : mocks.remote))
+}));
+vi.mock('$lib/stores/Author', async () => {
+	const { writable } = await import('svelte/store');
+	return { pubkey: writable('pubkey') };
+});
 vi.mock('$lib/WebStorage', () => ({
 	WebStorage: class {
 		getReplaceableEvent() {
-			return undefined;
+			return mocks.stored;
 		}
 
-		setReplaceableEvent() {}
+		setReplaceableEvent(event: Nostr.Event) {
+			mocks.setCalls.push(event);
+			mocks.stored = event;
+		}
 	}
 }));
 vi.stubGlobal('localStorage', {});
 
-import { bookmark, bookmarkEvent, legacyBookmarkEvent, updateBookmarkTags } from './Bookmark';
-import { get } from 'svelte/store';
+import {
+	bookmark,
+	bookmarkEvent,
+	isLatestReplaceableEvent,
+	legacyBookmarkEvent,
+	unbookmark,
+	updateBookmarkTags
+} from './Bookmark';
+
+const event = (values: Partial<Nostr.Event>): Nostr.Event =>
+	({
+		id: 'event',
+		pubkey: 'pubkey',
+		kind: Kind.BookmarkList,
+		created_at: 10,
+		content: '',
+		tags: [],
+		sig: 'sig',
+		...values
+	}) as Nostr.Event;
 
 describe('Bookmark', () => {
+	beforeEach(() => {
+		mocks.stored = undefined;
+		mocks.remote = undefined;
+		mocks.mirrorStored = true;
+		mocks.pendingSend = undefined;
+		mocks.sendFails = false;
+		mocks.sent = [];
+		mocks.setCalls = [];
+		mocks.signCount = 0;
+		bookmarkEvent.set(undefined);
+		legacyBookmarkEvent.set(undefined);
+	});
+
 	it('publishes updates as the standard NIP-51 bookmark kind', async () => {
 		await bookmark(['e', 'event-id']);
 
-		expect(signEvent).toHaveBeenCalledWith(
-			expect.objectContaining({ kind: Kind.BookmarkList })
-		);
+		expect(mocks.sent[0]).toEqual(expect.objectContaining({ kind: Kind.BookmarkList }));
 	});
 
 	it('adds and removes bookmark tags without an addressable-event identifier', () => {
@@ -43,13 +109,109 @@ describe('Bookmark', () => {
 	});
 
 	it('keeps standard and legacy bookmark events in separate state', () => {
-		const standard = { id: 'standard' } as never;
-		const legacy = { id: 'legacy' } as never;
+		const standard = event({ id: 'standard' });
+		const legacy = event({ id: 'legacy' });
 
 		bookmarkEvent.set(standard);
 		legacyBookmarkEvent.set(legacy);
 
 		expect(get(bookmarkEvent)).toBe(standard);
 		expect(get(legacyBookmarkEvent)).toBe(legacy);
+	});
+
+	it('batches operations queued during publish and updates the UI optimistically', async () => {
+		const firstPublish = new Subject<{ ok: boolean }>();
+		mocks.pendingSend = firstPublish;
+
+		const first = bookmark(['e', 'first']);
+		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
+
+		expect(get(bookmarkEvent)).toBe(mocks.sent[0]);
+		expect(mocks.setCalls).toHaveLength(0);
+
+		await bookmark(['e', 'second']);
+		await unbookmark(['e', 'first']);
+		expect(mocks.sent).toHaveLength(1);
+
+		firstPublish.next({ ok: true });
+		firstPublish.complete();
+		await first;
+
+		expect(mocks.sent).toHaveLength(2);
+		expect(mocks.sent[1].tags).toEqual([['e', 'second']]);
+	});
+
+	it('preserves encrypted private content while updating public bookmarks', async () => {
+		mocks.stored = event({ content: 'opaque-encrypted-content' });
+
+		await bookmark(['e', 'public']);
+
+		expect(mocks.sent[0].content).toBe('opaque-encrypted-content');
+	});
+
+	it('recovers processing and does not save or retain a failed optimistic event', async () => {
+		const previous = event({ id: 'previous', tags: [['e', 'existing']] });
+		mocks.stored = previous;
+		bookmarkEvent.set(previous);
+		mocks.sendFails = true;
+
+		await expect(bookmark(['e', 'failed'])).rejects.toThrow('rejected');
+
+		expect(mocks.setCalls).toHaveLength(0);
+		expect(mocks.stored).toBe(previous);
+		expect(get(bookmarkEvent)).toBe(previous);
+
+		mocks.sendFails = false;
+		await bookmark(['e', 'recovered']);
+
+		expect(mocks.sent).toHaveLength(2);
+		expect(mocks.sent[1].tags).toEqual([
+			['e', 'existing'],
+			['e', 'recovered']
+		]);
+	});
+
+	it('does not overwrite newer local state when a failed publish rolls back', async () => {
+		const previous = event({ id: 'previous' });
+		const newer = event({ id: 'newer', created_at: 20 });
+		const pendingPublish = new Subject<{ ok: boolean }>();
+		mocks.stored = previous;
+		mocks.pendingSend = pendingPublish;
+		bookmarkEvent.set(previous);
+
+		const publishing = bookmark(['e', 'new']);
+		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
+		bookmarkEvent.set(newer);
+		pendingPublish.error(new Error('rejected'));
+
+		await expect(publishing).rejects.toThrow('rejected');
+		expect(get(bookmarkEvent)).toBe(newer);
+		expect(mocks.setCalls).toHaveLength(0);
+	});
+
+	it('compares replaceable events by timestamp and then lowest id', () => {
+		const older = event({ id: 'aaaa', created_at: 10 });
+		const newer = event({ id: 'bbbb', created_at: 20 });
+		const lower = event({ id: 'aaaa', created_at: 20 });
+		const higher = event({ id: 'bbbb', created_at: 20 });
+
+		expect(isLatestReplaceableEvent(newer, older)).toBe(true);
+		expect(isLatestReplaceableEvent(older, newer)).toBe(false);
+		expect(isLatestReplaceableEvent(lower, higher)).toBe(true);
+		expect(isLatestReplaceableEvent(higher, lower)).toBe(false);
+	});
+
+	it('rejects a cached event when the relay has a lower id at the same timestamp', async () => {
+		const cached = event({ id: 'bbbb', created_at: 20 });
+		mocks.stored = cached;
+		mocks.remote = event({ id: 'aaaa', created_at: 20 });
+		mocks.mirrorStored = false;
+		bookmarkEvent.set(cached);
+
+		await expect(bookmark(['e', 'new'])).rejects.toThrow('Cache is outdated.');
+
+		expect(mocks.sent).toHaveLength(0);
+		expect(mocks.setCalls).toHaveLength(0);
+		expect(get(bookmarkEvent)).toBe(cached);
 	});
 });

--- a/web/src/lib/author/Bookmark.test.ts
+++ b/web/src/lib/author/Bookmark.test.ts
@@ -141,6 +141,59 @@ describe('Bookmark', () => {
 		expect(mocks.sent[1].tags).toEqual([['e', 'second']]);
 	});
 
+	it('automatically batches queued operations after the active publish fails', async () => {
+		const previous = event({ id: 'previous', tags: [['e', 'existing']] });
+		const firstPublish = new Subject<{ ok: boolean }>();
+		mocks.stored = previous;
+		mocks.pendingSend = firstPublish;
+		bookmarkEvent.set(previous);
+
+		const first = bookmark(['e', 'failed']);
+		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
+		await bookmark(['e', 'second']);
+		await bookmark(['e', 'third']);
+		expect(mocks.sent).toHaveLength(1);
+
+		firstPublish.error(new Error('first rejected'));
+		await expect(first).rejects.toThrow('first rejected');
+		await vi.waitFor(() => expect(mocks.setCalls).toHaveLength(1));
+
+		expect(mocks.sent).toHaveLength(2);
+		expect(mocks.sent[1].tags).toEqual([
+			['e', 'existing'],
+			['e', 'second'],
+			['e', 'third']
+		]);
+		expect(mocks.sent[1].tags).not.toContainEqual(['e', 'failed']);
+		expect(mocks.stored).toBe(mocks.sent[1]);
+		expect(get(bookmarkEvent)).toBe(mocks.sent[1]);
+	});
+
+	it('does not leave processing stuck when an automatic recovery also fails', async () => {
+		const previous = event({ id: 'previous' });
+		const firstPublish = new Subject<{ ok: boolean }>();
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		mocks.stored = previous;
+		mocks.pendingSend = firstPublish;
+		bookmarkEvent.set(previous);
+
+		const first = bookmark(['e', 'first-failed']);
+		await vi.waitFor(() => expect(mocks.sent).toHaveLength(1));
+		await bookmark(['e', 'recovery-failed']);
+		mocks.sendFails = true;
+
+		firstPublish.error(new Error('first rejected'));
+		await expect(first).rejects.toThrow('first rejected');
+		await vi.waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
+
+		mocks.sendFails = false;
+		await bookmark(['e', 'after-failures']);
+
+		expect(mocks.sent).toHaveLength(3);
+		expect(mocks.sent[2].tags).toEqual([['e', 'after-failures']]);
+		consoleError.mockRestore();
+	});
+
 	it('preserves encrypted private content while updating public bookmarks', async () => {
 		mocks.stored = event({ content: 'opaque-encrypted-content' });
 

--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -68,8 +68,11 @@ async function save(type: DataType, tag: string[]): Promise<void> {
 
 	if (!processing) {
 		processing = true;
-		await publish();
-		processing = false;
+		try {
+			await publish();
+		} finally {
+			processing = false;
+		}
 	}
 }
 
@@ -94,16 +97,24 @@ async function publish(): Promise<void> {
 		created_at: now()
 	});
 
+	const previousEvent = get(bookmarkEvent);
 	bookmarkEvent.set(event);
 
-	// Lazy validation for UX
-	if (!(await validate(lastEvent))) {
-		bookmarkEvent.set(lastEvent);
-		throw new Error('Cache is outdated.');
+	try {
+		// Lazy validation for UX
+		if (!(await validate(lastEvent))) {
+			throw new Error('Cache is outdated.');
+		}
+
+		await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
+	} catch (error) {
+		if (get(bookmarkEvent)?.id === event.id) {
+			bookmarkEvent.set(previousEvent);
+		}
+		throw error;
 	}
 
 	storage.setReplaceableEvent(event);
-	await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
 
 	if (queue.length > 0) {
 		await publish();
@@ -122,9 +133,16 @@ async function validate(event: Nostr.Event | undefined): Promise<boolean> {
 		if (lastEvent !== undefined) {
 			return false;
 		}
-	} else if (lastEvent === undefined || event.created_at < lastEvent.created_at) {
+	} else if (lastEvent === undefined || !isLatestReplaceableEvent(event, lastEvent)) {
 		return false;
 	}
 
 	return true;
+}
+
+export function isLatestReplaceableEvent(event: Nostr.Event, other: Nostr.Event): boolean {
+	if (event.created_at !== other.created_at) {
+		return event.created_at > other.created_at;
+	}
+	return event.id <= other.id;
 }

--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -15,8 +15,16 @@ type Data = {
 	type: DataType;
 	tag: string[];
 };
+type QueuedData = Data & {
+	resolve: () => void;
+	reject: (reason?: unknown) => void;
+};
+type QueueFailure = {
+	error: unknown;
+	data: QueuedData[];
+};
 
-const queue = new Queue<Data>();
+const queue = new Queue<QueuedData>();
 
 let processing = false;
 
@@ -61,70 +69,96 @@ export async function unbookmark(tag: string[]): Promise<void> {
 }
 
 async function save(type: DataType, tag: string[]): Promise<void> {
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
 	queue.enqueue({
 		type,
-		tag
+		tag,
+		resolve,
+		reject
 	});
 
 	if (!processing) {
-		await processQueue();
+		void processQueue();
 	}
+
+	await promise;
 }
 
 async function processQueue(): Promise<void> {
 	processing = true;
+	let failure: QueueFailure | undefined;
 	try {
-		await publish();
+		failure = await publish();
 	} finally {
 		processing = false;
-		if (queue.length > 0) {
-			void processQueue().catch((error) => console.error('[bookmark queue]', error));
+	}
+	if (failure !== undefined) {
+		for (const data of failure.data) {
+			data.reject(failure.error);
 		}
 	}
 }
 
-async function publish(): Promise<void> {
-	const storage = new WebStorage(localStorage);
-	const lastEvent = storage.getReplaceableEvent(Kind.BookmarkList);
-	let tags = lastEvent?.tags ?? [];
-
+async function publish(): Promise<QueueFailure | undefined> {
+	const batch: QueuedData[] = [];
 	while (queue.length > 0) {
 		const data = queue.dequeue();
 		if (data === undefined) {
 			break;
 		}
-
-		tags = updateBookmarkTags(tags, data);
+		batch.push(data);
 	}
 
-	const event = await Signer.signEvent({
-		kind: Kind.BookmarkList,
-		content: lastEvent?.content ?? '',
-		tags,
-		created_at: now()
-	});
-
-	const previousEvent = get(bookmarkEvent);
-	bookmarkEvent.set(event);
+	let event: Nostr.Event | undefined;
+	let previousEvent: Nostr.Event | undefined;
+	let published = false;
 
 	try {
+		const storage = new WebStorage(localStorage);
+		const lastEvent = storage.getReplaceableEvent(Kind.BookmarkList);
+		let tags = lastEvent?.tags ?? [];
+		for (const data of batch) {
+			tags = updateBookmarkTags(tags, data);
+		}
+
+		event = await Signer.signEvent({
+			kind: Kind.BookmarkList,
+			content: lastEvent?.content ?? '',
+			tags,
+			created_at: now()
+		});
+
+		previousEvent = get(bookmarkEvent);
+		bookmarkEvent.set(event);
+
 		// Lazy validation for UX
 		if (!(await validate(lastEvent))) {
 			throw new Error('Cache is outdated.');
 		}
 
 		await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
+		published = true;
+		storage.setReplaceableEvent(event);
 	} catch (error) {
-		if (get(bookmarkEvent)?.id === event.id) {
+		if (!published && event !== undefined && get(bookmarkEvent)?.id === event.id) {
 			bookmarkEvent.set(previousEvent);
 		}
-		throw error;
+		const failed = [...batch];
+		while (queue.length > 0) {
+			const data = queue.dequeue();
+			if (data !== undefined) {
+				failed.push(data);
+			}
+		}
+		return { error, data: failed };
 	}
 
-	storage.setReplaceableEvent(event);
+	for (const data of batch) {
+		data.resolve();
+	}
 
 	if (queue.length > 0) {
-		await publish();
+		return await publish();
 	}
 }
 

--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -67,11 +67,18 @@ async function save(type: DataType, tag: string[]): Promise<void> {
 	});
 
 	if (!processing) {
-		processing = true;
-		try {
-			await publish();
-		} finally {
-			processing = false;
+		await processQueue();
+	}
+}
+
+async function processQueue(): Promise<void> {
+	processing = true;
+	try {
+		await publish();
+	} finally {
+		processing = false;
+		if (queue.length > 0) {
+			void processQueue().catch((error) => console.error('[bookmark queue]', error));
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- preserve the existing Queue, batching behavior, and optimistic Bookmark UI
- resolve queued operations only after their published batch succeeds
- abort and reject the active batch and all remaining queued operations when a batch fails
- persist only successfully published events to WebStorage and allow later writes to restart from confirmed state
- protect newer local state during optimistic rollback
- apply the NIP-01 lowest-ID rule when validating equal-timestamp replaceable events

## Validation
- npm test (37 files, 337 tests)
- npm run check
- npm run lint
- npm run build