### PR TITLE
Add bookmark migration helpers

### DIFF
--- a/web/src/lib/author/BookmarkMigration.test.ts
+++ b/web/src/lib/author/BookmarkMigration.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { kinds as Kind } from 'nostr-tools';
+import { legacyBookmarkIdentifier } from '$lib/Constants';
+import {
+	filterBookmarkReferences,
+	isLegacyBookmarkEvent,
+	mergeBookmarkReferences
+} from './BookmarkMigration';
+
+const eventId = 'a'.repeat(64);
+const otherEventId = 'b'.repeat(64);
+const address = `30023:${'c'.repeat(64)}:article`;
+const otherAddress = `30023:${'d'.repeat(64)}:other-article`;
+
+describe('isLegacyBookmarkEvent', () => {
+	it('accepts kind 30001 with the legacy bookmark identifier', () => {
+		expect(
+			isLegacyBookmarkEvent({
+				kind: Kind.Genericlists,
+				tags: [['d', legacyBookmarkIdentifier]]
+			})
+		).toBe(true);
+	});
+
+	it('rejects a different kind', () => {
+		expect(
+			isLegacyBookmarkEvent({
+				kind: Kind.BookmarkList,
+				tags: [['d', legacyBookmarkIdentifier]]
+			})
+		).toBe(false);
+	});
+
+	it('rejects a different identifier', () => {
+		expect(isLegacyBookmarkEvent({ kind: Kind.Genericlists, tags: [['d', 'other']] })).toBe(
+			false
+		);
+	});
+});
+
+describe('filterBookmarkReferences', () => {
+	it('keeps valid e and a references and removes list metadata and unrelated tags', () => {
+		const eventReference = ['e', eventId, 'wss://relay.example'];
+		const addressReference = ['a', address];
+
+		const result = filterBookmarkReferences([
+			['d', legacyBookmarkIdentifier],
+			['title', 'Bookmarks'],
+			['image', 'https://example.com/image.png'],
+			['description', 'Saved items'],
+			['p', 'e'.repeat(64)],
+			eventReference,
+			addressReference,
+			['r', 'https://example.com']
+		]);
+
+		expect(result).toEqual([eventReference, addressReference]);
+		expect(result[0]).not.toBe(eventReference);
+		expect(result[1]).not.toBe(addressReference);
+	});
+
+	it('removes malformed e and a references using the existing validation rules', () => {
+		expect(
+			filterBookmarkReferences([
+				['e', 'not-an-event-id'],
+				['e'],
+				['a', '30023:not-a-pubkey:article'],
+				['a'],
+				['e', eventId],
+				['a', address]
+			])
+		).toEqual([
+			['e', eventId],
+			['a', address]
+		]);
+	});
+});
+
+describe('mergeBookmarkReferences', () => {
+	it('preserves existing references and appends only new legacy references', () => {
+		const existing = [
+			['e', eventId, 'wss://relay.example'],
+			['a', address, 'wss://articles.example']
+		];
+		const legacy = [
+			['d', legacyBookmarkIdentifier],
+			['e', eventId],
+			['a', address],
+			['e', otherEventId],
+			['a', otherAddress],
+			['e', otherEventId]
+		];
+
+		expect(mergeBookmarkReferences(existing, legacy)).toEqual([
+			['e', eventId, 'wss://relay.example'],
+			['a', address, 'wss://articles.example'],
+			['e', otherEventId],
+			['a', otherAddress]
+		]);
+	});
+
+	it('does not mutate or reuse the input arrays', () => {
+		const existing = [['e', eventId, 'wss://relay.example']];
+		const legacy = [['a', address]];
+		const originalExisting = structuredClone(existing);
+		const originalLegacy = structuredClone(legacy);
+
+		const result = mergeBookmarkReferences(existing, legacy);
+		result[0].push('changed');
+		result[1].push('changed');
+
+		expect(existing).toEqual(originalExisting);
+		expect(legacy).toEqual(originalLegacy);
+	});
+
+	it('handles public and decrypted private reference arrays identically', () => {
+		const publicReferences = [
+			['e', eventId],
+			['a', address]
+		];
+		const decryptedPrivateReferences = structuredClone(publicReferences);
+
+		expect(mergeBookmarkReferences([], publicReferences)).toEqual(
+			mergeBookmarkReferences([], decryptedPrivateReferences)
+		);
+	});
+});

--- a/web/src/lib/author/BookmarkMigration.test.ts
+++ b/web/src/lib/author/BookmarkMigration.test.ts
@@ -36,6 +36,10 @@ describe('isLegacyBookmarkEvent', () => {
 			false
 		);
 	});
+
+	it('rejects an event without an identifier', () => {
+		expect(isLegacyBookmarkEvent({ kind: Kind.Genericlists, tags: [] })).toBe(false);
+	});
 });
 
 describe('filterBookmarkReferences', () => {
@@ -111,17 +115,5 @@ describe('mergeBookmarkReferences', () => {
 
 		expect(existing).toEqual(originalExisting);
 		expect(legacy).toEqual(originalLegacy);
-	});
-
-	it('handles public and decrypted private reference arrays identically', () => {
-		const publicReferences = [
-			['e', eventId],
-			['a', address]
-		];
-		const decryptedPrivateReferences = structuredClone(publicReferences);
-
-		expect(mergeBookmarkReferences([], publicReferences)).toEqual(
-			mergeBookmarkReferences([], decryptedPrivateReferences)
-		);
 	});
 });

--- a/web/src/lib/author/BookmarkMigration.ts
+++ b/web/src/lib/author/BookmarkMigration.ts
@@ -1,0 +1,41 @@
+import { addressRegexp, hexRegexp, legacyBookmarkIdentifier } from '$lib/Constants';
+import { findIdentifier } from '$lib/EventHelper';
+import { kinds as Kind, type Event } from 'nostr-tools';
+
+type BookmarkEvent = Pick<Event, 'kind' | 'tags'>;
+
+export function isLegacyBookmarkEvent(event: BookmarkEvent): boolean {
+	return (
+		event.kind === Kind.Genericlists && findIdentifier(event.tags) === legacyBookmarkIdentifier
+	);
+}
+
+export function filterBookmarkReferences(tags: string[][]): string[][] {
+	return tags
+		.filter(
+			([tagName, reference]) =>
+				(tagName === 'e' && hexRegexp.test(reference)) ||
+				(tagName === 'a' && addressRegexp.test(reference))
+		)
+		.map((tag) => [...tag]);
+}
+
+export function mergeBookmarkReferences(
+	existingReferences: string[][],
+	legacyTags: string[][]
+): string[][] {
+	const merged = existingReferences.map((tag) => [...tag]);
+	const references = new Set(
+		existingReferences.map(([tagName, reference]) => JSON.stringify([tagName, reference]))
+	);
+
+	for (const tag of filterBookmarkReferences(legacyTags)) {
+		const reference = JSON.stringify([tag[0], tag[1]]);
+		if (!references.has(reference)) {
+			merged.push(tag);
+			references.add(reference);
+		}
+	}
+
+	return merged;
+}


### PR DESCRIPTION
## Summary

- NIP-51 old-format（kind 30001 / d bookmark）→ standard Bookmark migration 用の pure helper を追加
- Bookmark reference の filtering / deduplication / merge を実装
- Bookmark writer / Queue / crypto / UI は変更なし

Refs #2309

## Validation

- npm test — 38 files / 338 tests passed
- npm run check — 0 errors / 0 warnings
- npm run lint — passed
- npm run build — passed