### PR TITLE
Add bookmark copy core

### DIFF
--- a/web/src/lib/author/Bookmark.ts
+++ b/web/src/lib/author/Bookmark.ts
@@ -19,6 +19,7 @@ type Data = {
 const queue = new Queue<Data>();
 
 let processing = false;
+let copying = false;
 
 export const bookmarkEvent: Writable<Nostr.Event | undefined> = writable();
 export const legacyBookmarkEvent: Writable<Nostr.Event | undefined> = writable();
@@ -61,6 +62,10 @@ export async function unbookmark(tag: string[]): Promise<void> {
 }
 
 async function save(type: DataType, tag: string[]): Promise<void> {
+	if (copying) {
+		throw new Error('Bookmark copy is in progress.');
+	}
+
 	queue.enqueue({
 		type,
 		tag
@@ -70,6 +75,19 @@ async function save(type: DataType, tag: string[]): Promise<void> {
 		processing = true;
 		await publish();
 		processing = false;
+	}
+}
+
+export async function runBookmarkCopyExclusively<T>(copy: () => Promise<T>): Promise<T> {
+	if (processing || queue.length > 0 || copying) {
+		throw new Error('Bookmark operation is busy.');
+	}
+
+	copying = true;
+	try {
+		return await copy();
+	} finally {
+		copying = false;
 	}
 }
 

--- a/web/src/lib/author/BookmarkCopy.test.ts
+++ b/web/src/lib/author/BookmarkCopy.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { EMPTY, of, Subject } from 'rxjs';
+import { EMPTY, from, of, Subject } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { kinds as Kind } from 'nostr-tools';
 import { get } from 'svelte/store';
@@ -8,6 +8,7 @@ import { legacyBookmarkIdentifier } from '$lib/Constants';
 const mocks = vi.hoisted(() => ({
 	userPubkey: 'f'.repeat(64),
 	fetchLastEvent: vi.fn(),
+	use: vi.fn(),
 	signEvent: vi.fn(),
 	decrypt: vi.fn(),
 	decryptNip44: vi.fn(),
@@ -31,7 +32,10 @@ vi.mock('$lib/Signer', () => ({
 		encryptNip44: mocks.encryptNip44
 	}
 }));
-vi.mock('$lib/timelines/MainTimeline', () => ({ rxNostr: { send: mocks.send } }));
+vi.mock('$lib/timelines/MainTimeline', () => ({
+	rxNostr: { send: mocks.send, use: mocks.use },
+	tie: <T>(source: T): T => source
+}));
 vi.mock('$lib/WebStorage', () => ({
 	WebStorage: class {
 		getReplaceableEvent() {
@@ -46,7 +50,7 @@ vi.mock('$lib/WebStorage', () => ({
 vi.stubGlobal('localStorage', {});
 
 import { bookmark, bookmarkEvent, legacyBookmarkEvent } from './Bookmark';
-import { copyLegacyBookmarks, decryptBookmarkContentStrict } from './BookmarkCopy';
+import { copyLegacyBookmarks } from './BookmarkCopy';
 
 const eventId = 'a'.repeat(64);
 const otherEventId = 'b'.repeat(64);
@@ -87,13 +91,16 @@ beforeEach(() => {
 	standardRelayEvent = undefined;
 	mocks.storage.cachedEvent = undefined;
 	mocks.fetchLastEvent.mockImplementation(async (filter: { kinds?: number[] }) => {
-		if (filter.kinds?.[0] === Kind.Genericlists) {
-			return legacyRelayEvent;
-		}
 		if (filter.kinds?.[0] === Kind.BookmarkList) {
 			return standardRelayEvent;
 		}
 		return undefined;
+	});
+	mocks.use.mockImplementation(() => {
+		const events = [legacyRelayEvent, standardRelayEvent].filter(
+			(sourceEvent): sourceEvent is Nostr.Event => sourceEvent !== undefined
+		);
+		return from(events.map((sourceEvent) => ({ event: sourceEvent, from: 'relay.example' })));
 	});
 	mocks.signEvent.mockImplementation(async (unsigned: Nostr.UnsignedEvent) =>
 		signedEvent(unsigned)
@@ -126,41 +133,23 @@ describe('copy exclusivity', () => {
 		await vi.waitFor(() => expect(mocks.signEvent).toHaveBeenCalledOnce());
 
 		await expect(copyLegacyBookmarks()).rejects.toThrow('busy');
-		expect(mocks.fetchLastEvent).not.toHaveBeenCalled();
+		expect(mocks.use).not.toHaveBeenCalled();
 
 		pendingSign.resolve(signedEvent(unsignedEvent!, 'normal-write'));
 		await normalWrite;
 	});
 
-	it('rejects copy while a normal operation is pending in the queue', async () => {
-		const pendingSign = Promise.withResolvers<Nostr.Event>();
-		let unsignedEvent: Nostr.UnsignedEvent | undefined;
-		mocks.signEvent.mockImplementationOnce((unsigned: Nostr.UnsignedEvent) => {
-			unsignedEvent = unsigned;
-			return pendingSign.promise;
-		});
-
-		const firstWrite = bookmark(['e', eventId]);
-		await vi.waitFor(() => expect(mocks.signEvent).toHaveBeenCalledOnce());
-		await bookmark(['e', otherEventId]);
-
-		await expect(copyLegacyBookmarks()).rejects.toThrow('busy');
-		pendingSign.resolve(signedEvent(unsignedEvent!, 'first-normal-write'));
-		await firstWrite;
-		expect(mocks.signEvent).toHaveBeenCalledTimes(2);
-	});
-
 	it('does not enqueue bookmarks during copy and releases the lock after failure', async () => {
-		const pendingFetch = Promise.withResolvers<Nostr.Event | undefined>();
-		mocks.fetchLastEvent.mockImplementationOnce(() => pendingFetch.promise);
+		const pendingSources = new Subject<{ event: Nostr.Event; from: string }>();
+		mocks.use.mockReturnValueOnce(pendingSources);
 
 		const copy = copyLegacyBookmarks();
-		await vi.waitFor(() => expect(mocks.fetchLastEvent).toHaveBeenCalledOnce());
+		await vi.waitFor(() => expect(mocks.use).toHaveBeenCalledOnce());
 		await expect(bookmark(['e', eventId])).rejects.toThrow('copy is in progress');
 		expect(mocks.signEvent).not.toHaveBeenCalled();
 
-		pendingFetch.reject(new Error('relay failure'));
-		await expect(copy).rejects.toThrow('relay failure');
+		pendingSources.error(new Error('relay failure'));
+		await expect(copy).rejects.toThrow('not found');
 		await bookmark(['e', otherEventId]);
 
 		expect(mocks.signEvent).toHaveBeenCalledOnce();
@@ -170,15 +159,15 @@ describe('copy exclusivity', () => {
 	});
 
 	it('rejects a second copy while copy is running', async () => {
-		const pendingFetch = Promise.withResolvers<Nostr.Event | undefined>();
-		mocks.fetchLastEvent.mockImplementationOnce(() => pendingFetch.promise);
+		const pendingSources = new Subject<{ event: Nostr.Event; from: string }>();
+		mocks.use.mockReturnValueOnce(pendingSources);
 
 		const firstCopy = copyLegacyBookmarks();
-		await vi.waitFor(() => expect(mocks.fetchLastEvent).toHaveBeenCalledOnce());
+		await vi.waitFor(() => expect(mocks.use).toHaveBeenCalledOnce());
 		await expect(copyLegacyBookmarks()).rejects.toThrow('busy');
 
-		pendingFetch.reject(new Error('stop copy'));
-		await expect(firstCopy).rejects.toThrow('stop copy');
+		pendingSources.error(new Error('stop copy'));
+		await expect(firstCopy).rejects.toThrow('not found');
 	});
 
 	it('releases the lock after success so a normal bookmark write can start', async () => {
@@ -193,21 +182,39 @@ describe('copy exclusivity', () => {
 
 describe('copy sources and public references', () => {
 	it('fetches and uses the latest legacy bookmark event from relays', async () => {
-		legacyBookmarkEvent.set(
-			event(Kind.Genericlists, [
+		const staleEvent = event(
+			Kind.Genericlists,
+			[
 				['d', legacyBookmarkIdentifier],
 				['e', otherEventId]
-			])
+			],
+			'',
+			'stale',
+			1
+		);
+		legacyBookmarkEvent.set(staleEvent);
+		legacyRelayEvent = event(
+			Kind.Genericlists,
+			[
+				['d', legacyBookmarkIdentifier],
+				['e', eventId]
+			],
+			'',
+			'fresh',
+			2
+		);
+		mocks.use.mockReturnValueOnce(
+			from(
+				[staleEvent, legacyRelayEvent].map((sourceEvent) => ({
+					event: sourceEvent,
+					from: 'relay.example'
+				}))
+			)
 		);
 
 		await copyLegacyBookmarks();
 
-		expect(mocks.fetchLastEvent).toHaveBeenNthCalledWith(1, {
-			kinds: [Kind.Genericlists],
-			authors: [mocks.userPubkey],
-			'#d': [legacyBookmarkIdentifier],
-			limit: 1
-		});
+		expect(mocks.use).toHaveBeenCalledOnce();
 		expect(mocks.signEvent).toHaveBeenCalledWith(
 			expect.objectContaining({ tags: [['e', eventId]] })
 		);
@@ -241,11 +248,21 @@ describe('copy sources and public references', () => {
 	});
 
 	it('uses the relay standard event as the base instead of the cache', async () => {
+		const staleStandardEvent = event(Kind.BookmarkList, [['e', 'stale']], '', 'stale', 1);
 		mocks.storage.cachedEvent = event(Kind.BookmarkList, [['e', 'cached']]);
-		standardRelayEvent = event(Kind.BookmarkList, [['e', otherEventId]]);
+		standardRelayEvent = event(Kind.BookmarkList, [['e', otherEventId]], '', 'fresh', 2);
+		mocks.use.mockReturnValueOnce(
+			from(
+				[legacyRelayEvent!, staleStandardEvent, standardRelayEvent].map((sourceEvent) => ({
+					event: sourceEvent,
+					from: 'relay.example'
+				}))
+			)
+		);
 
 		await copyLegacyBookmarks();
 
+		expect(mocks.use).toHaveBeenCalledOnce();
 		expect(mocks.signEvent).toHaveBeenCalledWith(
 			expect.objectContaining({
 				tags: [
@@ -354,12 +371,6 @@ describe('private bookmark copy', () => {
 		expect(mocks.decryptNip44).toHaveBeenCalledWith(mocks.userPubkey, 'legacy-nip44');
 		expect(mocks.decrypt).not.toHaveBeenCalled();
 		expect(mocks.encryptNip44).toHaveBeenCalledOnce();
-	});
-
-	it('returns an empty collection without decrypting empty content', async () => {
-		await expect(decryptBookmarkContentStrict(mocks.userPubkey, '')).resolves.toEqual([]);
-		expect(mocks.decrypt).not.toHaveBeenCalled();
-		expect(mocks.decryptNip44).not.toHaveBeenCalled();
 	});
 
 	it('rejects a legacy private decrypt failure before signing or publishing', async () => {

--- a/web/src/lib/author/BookmarkCopy.test.ts
+++ b/web/src/lib/author/BookmarkCopy.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY, of, Subject } from 'rxjs';
+import type * as Nostr from 'nostr-typedef';
+import { kinds as Kind } from 'nostr-tools';
+import { get } from 'svelte/store';
+import { legacyBookmarkIdentifier } from '$lib/Constants';
+
+const mocks = vi.hoisted(() => ({
+	userPubkey: 'f'.repeat(64),
+	fetchLastEvent: vi.fn(),
+	signEvent: vi.fn(),
+	decrypt: vi.fn(),
+	decryptNip44: vi.fn(),
+	encryptNip44: vi.fn(),
+	send: vi.fn(),
+	getReplaceableEvent: vi.fn(),
+	setReplaceableEvent: vi.fn(),
+	storage: { cachedEvent: undefined as unknown }
+}));
+
+vi.mock('$lib/stores/Author', async () => {
+	const { writable } = await import('svelte/store');
+	return { pubkey: writable(mocks.userPubkey) };
+});
+vi.mock('$lib/RxNostrHelper', () => ({ fetchLastEvent: mocks.fetchLastEvent }));
+vi.mock('$lib/Signer', () => ({
+	Signer: {
+		signEvent: mocks.signEvent,
+		decrypt: mocks.decrypt,
+		decryptNip44: mocks.decryptNip44,
+		encryptNip44: mocks.encryptNip44
+	}
+}));
+vi.mock('$lib/timelines/MainTimeline', () => ({ rxNostr: { send: mocks.send } }));
+vi.mock('$lib/WebStorage', () => ({
+	WebStorage: class {
+		getReplaceableEvent() {
+			return mocks.getReplaceableEvent();
+		}
+
+		setReplaceableEvent(event: Nostr.Event) {
+			mocks.setReplaceableEvent(event);
+		}
+	}
+}));
+vi.stubGlobal('localStorage', {});
+
+import { bookmark, bookmarkEvent, legacyBookmarkEvent } from './Bookmark';
+import { copyLegacyBookmarks, decryptBookmarkContentStrict } from './BookmarkCopy';
+
+const eventId = 'a'.repeat(64);
+const otherEventId = 'b'.repeat(64);
+const address = `30023:${'c'.repeat(64)}:article`;
+const otherAddress = `30023:${'d'.repeat(64)}:other-article`;
+
+function event(
+	kind: number,
+	tags: string[][] = [],
+	content = '',
+	id = `${kind}-event`,
+	created_at = 1
+): Nostr.Event {
+	return {
+		kind,
+		tags,
+		content,
+		id,
+		created_at,
+		pubkey: mocks.userPubkey,
+		sig: 'sig'
+	};
+}
+
+function signedEvent(unsigned: Nostr.UnsignedEvent, id = 'signed'): Nostr.Event {
+	return { ...unsigned, id, pubkey: mocks.userPubkey, sig: 'sig' };
+}
+
+let legacyRelayEvent: Nostr.Event | undefined;
+let standardRelayEvent: Nostr.Event | undefined;
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	legacyRelayEvent = event(Kind.Genericlists, [
+		['d', legacyBookmarkIdentifier],
+		['e', eventId]
+	]);
+	standardRelayEvent = undefined;
+	mocks.storage.cachedEvent = undefined;
+	mocks.fetchLastEvent.mockImplementation(async (filter: { kinds?: number[] }) => {
+		if (filter.kinds?.[0] === Kind.Genericlists) {
+			return legacyRelayEvent;
+		}
+		if (filter.kinds?.[0] === Kind.BookmarkList) {
+			return standardRelayEvent;
+		}
+		return undefined;
+	});
+	mocks.signEvent.mockImplementation(async (unsigned: Nostr.UnsignedEvent) =>
+		signedEvent(unsigned)
+	);
+	mocks.encryptNip44.mockImplementation(
+		async (_pubkey: string, plaintext: string) => `nip44:${plaintext}`
+	);
+	mocks.send.mockImplementation((sentEvent: Nostr.Event) => {
+		standardRelayEvent = sentEvent;
+		return of({ ok: true });
+	});
+	mocks.getReplaceableEvent.mockImplementation(() => mocks.storage.cachedEvent);
+	mocks.setReplaceableEvent.mockImplementation((storedEvent: Nostr.Event) => {
+		mocks.storage.cachedEvent = storedEvent;
+	});
+	bookmarkEvent.set(undefined);
+	legacyBookmarkEvent.set(undefined);
+});
+
+describe('copy exclusivity', () => {
+	it('rejects copy while a normal bookmark write is processing', async () => {
+		const pendingSign = Promise.withResolvers<Nostr.Event>();
+		let unsignedEvent: Nostr.UnsignedEvent | undefined;
+		mocks.signEvent.mockImplementationOnce((unsigned: Nostr.UnsignedEvent) => {
+			unsignedEvent = unsigned;
+			return pendingSign.promise;
+		});
+
+		const normalWrite = bookmark(['e', eventId]);
+		await vi.waitFor(() => expect(mocks.signEvent).toHaveBeenCalledOnce());
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('busy');
+		expect(mocks.fetchLastEvent).not.toHaveBeenCalled();
+
+		pendingSign.resolve(signedEvent(unsignedEvent!, 'normal-write'));
+		await normalWrite;
+	});
+
+	it('rejects copy while a normal operation is pending in the queue', async () => {
+		const pendingSign = Promise.withResolvers<Nostr.Event>();
+		let unsignedEvent: Nostr.UnsignedEvent | undefined;
+		mocks.signEvent.mockImplementationOnce((unsigned: Nostr.UnsignedEvent) => {
+			unsignedEvent = unsigned;
+			return pendingSign.promise;
+		});
+
+		const firstWrite = bookmark(['e', eventId]);
+		await vi.waitFor(() => expect(mocks.signEvent).toHaveBeenCalledOnce());
+		await bookmark(['e', otherEventId]);
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('busy');
+		pendingSign.resolve(signedEvent(unsignedEvent!, 'first-normal-write'));
+		await firstWrite;
+		expect(mocks.signEvent).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not enqueue bookmarks during copy and releases the lock after failure', async () => {
+		const pendingFetch = Promise.withResolvers<Nostr.Event | undefined>();
+		mocks.fetchLastEvent.mockImplementationOnce(() => pendingFetch.promise);
+
+		const copy = copyLegacyBookmarks();
+		await vi.waitFor(() => expect(mocks.fetchLastEvent).toHaveBeenCalledOnce());
+		await expect(bookmark(['e', eventId])).rejects.toThrow('copy is in progress');
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+
+		pendingFetch.reject(new Error('relay failure'));
+		await expect(copy).rejects.toThrow('relay failure');
+		await bookmark(['e', otherEventId]);
+
+		expect(mocks.signEvent).toHaveBeenCalledOnce();
+		expect(mocks.signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ tags: [['e', otherEventId]] })
+		);
+	});
+
+	it('rejects a second copy while copy is running', async () => {
+		const pendingFetch = Promise.withResolvers<Nostr.Event | undefined>();
+		mocks.fetchLastEvent.mockImplementationOnce(() => pendingFetch.promise);
+
+		const firstCopy = copyLegacyBookmarks();
+		await vi.waitFor(() => expect(mocks.fetchLastEvent).toHaveBeenCalledOnce());
+		await expect(copyLegacyBookmarks()).rejects.toThrow('busy');
+
+		pendingFetch.reject(new Error('stop copy'));
+		await expect(firstCopy).rejects.toThrow('stop copy');
+	});
+
+	it('releases the lock after success so a normal bookmark write can start', async () => {
+		const copiedEvent = await copyLegacyBookmarks();
+
+		await bookmark(['e', otherEventId]);
+
+		expect(copiedEvent?.kind).toBe(Kind.BookmarkList);
+		expect(mocks.signEvent).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('copy sources and public references', () => {
+	it('fetches and uses the latest legacy bookmark event from relays', async () => {
+		legacyBookmarkEvent.set(
+			event(Kind.Genericlists, [
+				['d', legacyBookmarkIdentifier],
+				['e', otherEventId]
+			])
+		);
+
+		await copyLegacyBookmarks();
+
+		expect(mocks.fetchLastEvent).toHaveBeenNthCalledWith(1, {
+			kinds: [Kind.Genericlists],
+			authors: [mocks.userPubkey],
+			'#d': [legacyBookmarkIdentifier],
+			limit: 1
+		});
+		expect(mocks.signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ tags: [['e', eventId]] })
+		);
+	});
+
+	it('does not publish when no legacy bookmark event is found', async () => {
+		legacyRelayEvent = undefined;
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('not found');
+
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+		expect(mocks.send).not.toHaveBeenCalled();
+	});
+
+	it('does not publish an invalid legacy bookmark event', async () => {
+		legacyRelayEvent = event(Kind.Genericlists, [['d', 'other']]);
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('Invalid legacy');
+
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+		expect(mocks.send).not.toHaveBeenCalled();
+	});
+
+	it('rejects an unverifiable cached standard bookmark event', async () => {
+		mocks.storage.cachedEvent = event(Kind.BookmarkList, [['e', otherEventId]]);
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('freshness');
+
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+		expect(mocks.send).not.toHaveBeenCalled();
+	});
+
+	it('uses the relay standard event as the base instead of the cache', async () => {
+		mocks.storage.cachedEvent = event(Kind.BookmarkList, [['e', 'cached']]);
+		standardRelayEvent = event(Kind.BookmarkList, [['e', otherEventId]]);
+
+		await copyLegacyBookmarks();
+
+		expect(mocks.signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tags: [
+					['e', otherEventId],
+					['e', eventId]
+				]
+			})
+		);
+	});
+
+	it('preserves standard public references and adds only new valid legacy references', async () => {
+		standardRelayEvent = event(Kind.BookmarkList, [
+			['e', eventId, 'wss://relay.example'],
+			['a', address, 'wss://articles.example']
+		]);
+		legacyRelayEvent = event(Kind.Genericlists, [
+			['d', legacyBookmarkIdentifier],
+			['title', 'Bookmarks'],
+			['p', mocks.userPubkey],
+			['e', eventId],
+			['a', address],
+			['e', otherEventId],
+			['a', otherAddress]
+		]);
+
+		await copyLegacyBookmarks();
+
+		expect(mocks.signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tags: [
+					['e', eventId, 'wss://relay.example'],
+					['a', address, 'wss://articles.example'],
+					['e', otherEventId],
+					['a', otherAddress]
+				]
+			})
+		);
+	});
+
+	it('does not publish a replacement event when copy adds nothing', async () => {
+		standardRelayEvent = event(Kind.BookmarkList, [['e', eventId]]);
+
+		await expect(copyLegacyBookmarks()).resolves.toBeUndefined();
+
+		expect(mocks.encryptNip44).not.toHaveBeenCalled();
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+		expect(mocks.send).not.toHaveBeenCalled();
+	});
+});
+
+describe('private bookmark copy', () => {
+	it('strictly decrypts, merges, and re-encrypts private references with NIP-44', async () => {
+		standardRelayEvent = event(Kind.BookmarkList, [['e', eventId]], 'standard-nip44');
+		legacyRelayEvent = event(
+			Kind.Genericlists,
+			[
+				['d', legacyBookmarkIdentifier],
+				['e', otherEventId]
+			],
+			'legacy?iv=nip04'
+		);
+		mocks.decryptNip44.mockResolvedValue(
+			JSON.stringify([['a', address, 'wss://articles.example']])
+		);
+		mocks.decrypt.mockResolvedValue(
+			JSON.stringify([
+				['a', address],
+				['e', otherEventId],
+				['a', otherAddress]
+			])
+		);
+
+		await copyLegacyBookmarks();
+
+		expect(mocks.decryptNip44).toHaveBeenCalledWith(mocks.userPubkey, 'standard-nip44');
+		expect(mocks.decrypt).toHaveBeenCalledWith(mocks.userPubkey, 'legacy?iv=nip04');
+		expect(mocks.encryptNip44).toHaveBeenCalledWith(
+			mocks.userPubkey,
+			JSON.stringify([
+				['a', address, 'wss://articles.example'],
+				['e', otherEventId],
+				['a', otherAddress]
+			])
+		);
+		expect(mocks.signEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tags: [
+					['e', eventId],
+					['e', otherEventId]
+				],
+				content: expect.stringContaining('nip44:')
+			})
+		);
+	});
+
+	it('decrypts a NIP-44 legacy source', async () => {
+		legacyRelayEvent = event(
+			Kind.Genericlists,
+			[['d', legacyBookmarkIdentifier]],
+			'legacy-nip44'
+		);
+		mocks.decryptNip44.mockResolvedValue(JSON.stringify([['a', address]]));
+
+		await copyLegacyBookmarks();
+
+		expect(mocks.decryptNip44).toHaveBeenCalledWith(mocks.userPubkey, 'legacy-nip44');
+		expect(mocks.decrypt).not.toHaveBeenCalled();
+		expect(mocks.encryptNip44).toHaveBeenCalledOnce();
+	});
+
+	it('returns an empty collection without decrypting empty content', async () => {
+		await expect(decryptBookmarkContentStrict(mocks.userPubkey, '')).resolves.toEqual([]);
+		expect(mocks.decrypt).not.toHaveBeenCalled();
+		expect(mocks.decryptNip44).not.toHaveBeenCalled();
+	});
+
+	it('rejects a legacy private decrypt failure before signing or publishing', async () => {
+		legacyRelayEvent = event(
+			Kind.Genericlists,
+			[['d', legacyBookmarkIdentifier]],
+			'legacy-nip44'
+		);
+		mocks.decryptNip44.mockRejectedValue(new Error('decrypt failed'));
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('decrypt failed');
+
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+		expect(mocks.send).not.toHaveBeenCalled();
+	});
+
+	it('rejects a standard private decrypt failure before signing or publishing', async () => {
+		standardRelayEvent = event(Kind.BookmarkList, [], 'standard-nip44');
+		mocks.decryptNip44.mockRejectedValue(new Error('decrypt failed'));
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow('decrypt failed');
+
+		expect(mocks.signEvent).not.toHaveBeenCalled();
+		expect(mocks.send).not.toHaveBeenCalled();
+	});
+
+	it.each(['not JSON', JSON.stringify({ tags: [['e', eventId]] })])(
+		'rejects invalid private JSON before signing or publishing',
+		async (plaintext) => {
+			legacyRelayEvent = event(
+				Kind.Genericlists,
+				[['d', legacyBookmarkIdentifier]],
+				'legacy-nip44'
+			);
+			mocks.decryptNip44.mockResolvedValue(plaintext);
+
+			await expect(copyLegacyBookmarks()).rejects.toThrow();
+
+			expect(mocks.signEvent).not.toHaveBeenCalled();
+			expect(mocks.send).not.toHaveBeenCalled();
+		}
+	);
+});
+
+describe('copy publishing', () => {
+	it('does not update cache or bookmark state when no relay accepts the event', async () => {
+		const previousEvent = event(Kind.BookmarkList, [], '', 'previous');
+		bookmarkEvent.set(previousEvent);
+		mocks.send.mockReturnValue(EMPTY);
+
+		await expect(copyLegacyBookmarks()).rejects.toThrow();
+
+		expect(mocks.setReplaceableEvent).not.toHaveBeenCalled();
+		expect(get(bookmarkEvent)).toBe(previousEvent);
+	});
+
+	it('publishes one standard event and updates local state only after relay success', async () => {
+		const previousEvent = event(Kind.BookmarkList, [], '', 'previous');
+		const relayResults = new Subject<{ ok: boolean }>();
+		const updateOrder: string[] = [];
+		bookmarkEvent.set(previousEvent);
+		mocks.send.mockReturnValue(relayResults);
+		mocks.setReplaceableEvent.mockImplementation((storedEvent: Nostr.Event) => {
+			updateOrder.push('cache');
+			mocks.storage.cachedEvent = storedEvent;
+		});
+		const unsubscribe = bookmarkEvent.subscribe((storedEvent) => {
+			if (storedEvent?.id === 'signed') {
+				updateOrder.push('store');
+			}
+		});
+
+		const copy = copyLegacyBookmarks();
+		await vi.waitFor(() => expect(mocks.send).toHaveBeenCalledOnce());
+		expect(mocks.setReplaceableEvent).not.toHaveBeenCalled();
+		expect(get(bookmarkEvent)).toBe(previousEvent);
+
+		relayResults.next({ ok: true });
+		const copiedEvent = await copy;
+		unsubscribe();
+
+		expect(mocks.send).toHaveBeenCalledOnce();
+		expect(mocks.send).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: Kind.BookmarkList })
+		);
+		expect(mocks.setReplaceableEvent).toHaveBeenCalledWith(copiedEvent);
+		expect(get(bookmarkEvent)).toBe(copiedEvent);
+		expect(updateOrder).toEqual(['cache', 'store']);
+	});
+});

--- a/web/src/lib/author/BookmarkCopy.ts
+++ b/web/src/lib/author/BookmarkCopy.ts
@@ -1,0 +1,101 @@
+import { get } from 'svelte/store';
+import { now } from 'rx-nostr';
+import { filter, firstValueFrom } from 'rxjs';
+import type * as Nostr from 'nostr-typedef';
+import { kinds as Kind } from 'nostr-tools';
+import { legacyBookmarkIdentifier } from '$lib/Constants';
+import { isLegacyEncryption } from '$lib/EventHelper';
+import { fetchLastEvent } from '$lib/RxNostrHelper';
+import { Signer } from '$lib/Signer';
+import { pubkey } from '$lib/stores/Author';
+import { rxNostr } from '$lib/timelines/MainTimeline';
+import { WebStorage } from '$lib/WebStorage';
+import { bookmarkEvent, runBookmarkCopyExclusively } from './Bookmark';
+import { isLegacyBookmarkEvent, mergeBookmarkReferences } from './BookmarkMigration';
+
+function isTagCollection(value: unknown): value is string[][] {
+	return (
+		Array.isArray(value) &&
+		value.every((tag) => Array.isArray(tag) && tag.every((item) => typeof item === 'string'))
+	);
+}
+
+export async function decryptBookmarkContentStrict(
+	pubkey: string,
+	content: string
+): Promise<string[][]> {
+	if (content === '') {
+		return [];
+	}
+
+	const plaintext = await (isLegacyEncryption(content)
+		? Signer.decrypt(pubkey, content)
+		: Signer.decryptNip44(pubkey, content));
+	const tags: unknown = JSON.parse(plaintext);
+	if (!isTagCollection(tags)) {
+		throw new Error('Invalid bookmark content.');
+	}
+	return tags;
+}
+
+function tagsEqual(left: string[][], right: string[][]): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export async function copyLegacyBookmarks(): Promise<Nostr.Event | undefined> {
+	return runBookmarkCopyExclusively(async () => {
+		const $pubkey = get(pubkey);
+		const legacyEvent = await fetchLastEvent({
+			kinds: [Kind.Genericlists],
+			authors: [$pubkey],
+			'#d': [legacyBookmarkIdentifier],
+			limit: 1
+		});
+		if (legacyEvent === undefined) {
+			throw new Error('Legacy bookmark event not found.');
+		}
+		if (!isLegacyBookmarkEvent(legacyEvent)) {
+			throw new Error('Invalid legacy bookmark event.');
+		}
+
+		const storage = new WebStorage(localStorage);
+		const cachedEvent = storage.getReplaceableEvent(Kind.BookmarkList);
+		const standardEvent = await fetchLastEvent({
+			kinds: [Kind.BookmarkList],
+			authors: [$pubkey],
+			limit: 1
+		});
+		if (standardEvent === undefined && cachedEvent !== undefined) {
+			throw new Error('Standard bookmark cache freshness could not be verified.');
+		}
+
+		const existingPublic = standardEvent?.tags ?? [];
+		const mergedPublic = mergeBookmarkReferences(existingPublic, legacyEvent.tags);
+		const existingPrivate = await decryptBookmarkContentStrict(
+			$pubkey,
+			standardEvent?.content ?? ''
+		);
+		const legacyPrivate = await decryptBookmarkContentStrict($pubkey, legacyEvent.content);
+		const mergedPrivate = mergeBookmarkReferences(existingPrivate, legacyPrivate);
+
+		if (tagsEqual(existingPublic, mergedPublic) && tagsEqual(existingPrivate, mergedPrivate)) {
+			return undefined;
+		}
+
+		const content =
+			mergedPrivate.length === 0
+				? ''
+				: await Signer.encryptNip44($pubkey, JSON.stringify(mergedPrivate));
+		const event = await Signer.signEvent({
+			kind: Kind.BookmarkList,
+			content,
+			tags: mergedPublic,
+			created_at: now()
+		});
+
+		await firstValueFrom(rxNostr.send(event).pipe(filter(({ ok }) => ok)));
+		storage.setReplaceableEvent(event);
+		bookmarkEvent.set(event);
+		return event;
+	});
+}

--- a/web/src/lib/author/BookmarkCopy.ts
+++ b/web/src/lib/author/BookmarkCopy.ts
@@ -1,14 +1,13 @@
 import { get } from 'svelte/store';
-import { now } from 'rx-nostr';
+import { createRxBackwardReq, latestEach, now } from 'rx-nostr';
 import { filter, firstValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { kinds as Kind } from 'nostr-tools';
 import { legacyBookmarkIdentifier } from '$lib/Constants';
 import { isLegacyEncryption } from '$lib/EventHelper';
-import { fetchLastEvent } from '$lib/RxNostrHelper';
 import { Signer } from '$lib/Signer';
 import { pubkey } from '$lib/stores/Author';
-import { rxNostr } from '$lib/timelines/MainTimeline';
+import { rxNostr, tie } from '$lib/timelines/MainTimeline';
 import { WebStorage } from '$lib/WebStorage';
 import { bookmarkEvent, runBookmarkCopyExclusively } from './Bookmark';
 import { isLegacyBookmarkEvent, mergeBookmarkReferences } from './BookmarkMigration';
@@ -42,15 +41,57 @@ function tagsEqual(left: string[][], right: string[][]): boolean {
 	return JSON.stringify(left) === JSON.stringify(right);
 }
 
+async function fetchBookmarkSources(pubkey: string): Promise<{
+	legacyEvent: Nostr.Event | undefined;
+	standardEvent: Nostr.Event | undefined;
+}> {
+	return new Promise((resolve) => {
+		let legacyEvent: Nostr.Event | undefined;
+		let standardEvent: Nostr.Event | undefined;
+		const req = createRxBackwardReq();
+		const done = () => resolve({ legacyEvent, standardEvent });
+
+		rxNostr
+			.use(req)
+			.pipe(
+				tie,
+				latestEach(({ event }) => event.kind)
+			)
+			.subscribe({
+				next: ({ event }) => {
+					if (event.kind === Kind.Genericlists) {
+						legacyEvent = event;
+					} else if (event.kind === Kind.BookmarkList) {
+						standardEvent = event;
+					}
+				},
+				complete: done,
+				error: (error) => {
+					console.warn('[bookmark sources error]', error);
+					done();
+				}
+			});
+		req.emit([
+			{
+				kinds: [Kind.Genericlists],
+				authors: [pubkey],
+				'#d': [legacyBookmarkIdentifier],
+				limit: 1
+			},
+			{
+				kinds: [Kind.BookmarkList],
+				authors: [pubkey],
+				limit: 1
+			}
+		]);
+		req.over();
+	});
+}
+
 export async function copyLegacyBookmarks(): Promise<Nostr.Event | undefined> {
 	return runBookmarkCopyExclusively(async () => {
 		const $pubkey = get(pubkey);
-		const legacyEvent = await fetchLastEvent({
-			kinds: [Kind.Genericlists],
-			authors: [$pubkey],
-			'#d': [legacyBookmarkIdentifier],
-			limit: 1
-		});
+		const { legacyEvent, standardEvent } = await fetchBookmarkSources($pubkey);
 		if (legacyEvent === undefined) {
 			throw new Error('Legacy bookmark event not found.');
 		}
@@ -60,11 +101,6 @@ export async function copyLegacyBookmarks(): Promise<Nostr.Event | undefined> {
 
 		const storage = new WebStorage(localStorage);
 		const cachedEvent = storage.getReplaceableEvent(Kind.BookmarkList);
-		const standardEvent = await fetchLastEvent({
-			kinds: [Kind.BookmarkList],
-			authors: [$pubkey],
-			limit: 1
-		});
 		if (standardEvent === undefined && cachedEvent !== undefined) {
 			throw new Error('Standard bookmark cache freshness could not be verified.');
 		}


### PR DESCRIPTION
## Summary

- old-format Public / Private Bookmark を standard Bookmark へコピーする core を追加
- Copy は normal Bookmark Queue に入れず、Copy と normal writes を排他化
- private content を strict decrypt し、merge 後は NIP-44 で再暗号化
- relay publish success 後にのみ WebStorage と bookmark state を更新
- UI / i18n / deletion は未実装

Refs #2309