### PR TITLE
Log request context for 404 responses

### DIFF
--- a/web/src/hooks.server.test.ts
+++ b/web/src/hooks.server.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RequestEvent } from '@sveltejs/kit';
+import { notFound } from './hooks.server';
+
+type Resolve = Parameters<typeof notFound>[0]['resolve'];
+
+const createEvent = ({
+	path = '/',
+	method = 'GET',
+	headers = {},
+	routeId = null
+}: {
+	path?: string;
+	method?: string;
+	headers?: Record<string, string>;
+	routeId?: string | null;
+} = {}): RequestEvent => {
+	const url = new URL(`https://nostter.app${path}`);
+	return {
+		request: new Request(url, { method, headers }),
+		url,
+		route: { id: routeId }
+	} as unknown as RequestEvent;
+};
+
+const createResolve = (response: Response): Resolve => vi.fn(async () => response);
+
+const spyOnInfo = () => vi.spyOn(console, 'info').mockImplementation(() => {});
+
+let info: ReturnType<typeof spyOnInfo>;
+
+beforeEach(() => {
+	info = spyOnInfo();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('404 request logging', () => {
+	it('logs a single structured entry for 404 responses', async () => {
+		const event = createEvent({
+			path: '/.env',
+			headers: {
+				'cf-connecting-ip': '203.0.113.10',
+				'cf-ray': '8f0a1b2c3d4e5f60-NRT',
+				'user-agent': 'curl/8.5.0'
+			}
+		});
+
+		await notFound({ event, resolve: createResolve(new Response(null, { status: 404 })) });
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info).toHaveBeenCalledWith({
+			event: 'http_not_found',
+			clientIp: '203.0.113.10',
+			method: 'GET',
+			path: '/.env',
+			routeId: null,
+			rayId: '8f0a1b2c3d4e5f60-NRT',
+			userAgent: 'curl/8.5.0'
+		});
+	});
+
+	it('logs the matched route id when a route produced the 404', async () => {
+		const event = createEvent({ path: '/npub1nonexistent', routeId: '/(app)/[slug=npub]' });
+
+		await notFound({ event, resolve: createResolve(new Response(null, { status: 404 })) });
+
+		expect(info.mock.calls[0][0]).toMatchObject({ routeId: '/(app)/[slug=npub]' });
+	});
+
+	it('logs the request method', async () => {
+		const event = createEvent({ path: '/wp-login.php', method: 'POST' });
+
+		await notFound({ event, resolve: createResolve(new Response(null, { status: 404 })) });
+
+		expect(info.mock.calls[0][0]).toMatchObject({ method: 'POST' });
+	});
+
+	it.each([200, 204, 301, 403, 500])('does not log for %i responses', async (status) => {
+		const event = createEvent({ path: '/.env' });
+
+		await notFound({ event, resolve: createResolve(new Response(null, { status })) });
+
+		expect(info).not.toHaveBeenCalled();
+	});
+
+	it('logs null instead of throwing when Cloudflare headers are absent', async () => {
+		const event = createEvent({ path: '/graphql' });
+
+		await expect(
+			notFound({ event, resolve: createResolve(new Response(null, { status: 404 })) })
+		).resolves.toBeInstanceOf(Response);
+
+		expect(info).toHaveBeenCalledWith({
+			event: 'http_not_found',
+			clientIp: null,
+			method: 'GET',
+			path: '/graphql',
+			routeId: null,
+			rayId: null,
+			userAgent: null
+		});
+	});
+
+	it('logs only the pathname and omits sensitive request data', async () => {
+		const event = createEvent({
+			path: '/admin/login?redirect=%2Fsecret&token=s3cret',
+			headers: {
+				cookie: 'session=cookie-value',
+				authorization: 'Bearer token-value',
+				referer: 'https://evil.example.com/referer-value',
+				'cf-connecting-ip': '203.0.113.10'
+			}
+		});
+
+		await notFound({ event, resolve: createResolve(new Response(null, { status: 404 })) });
+
+		const logged = info.mock.calls[0][0] as Record<string, unknown>;
+		expect(Object.keys(logged).sort()).toStrictEqual([
+			'clientIp',
+			'event',
+			'method',
+			'path',
+			'rayId',
+			'routeId',
+			'userAgent'
+		]);
+		expect(logged.path).toBe('/admin/login');
+		expect(JSON.stringify(logged)).not.toMatch(
+			/cookie-value|token-value|referer-value|redirect|s3cret|nostter\.app/
+		);
+	});
+
+	it.each([200, 404])('returns the %i response of the inner hooks untouched', async (status) => {
+		const resolved = new Response('<html lang="ja"></html>', {
+			status,
+			headers: { 'Content-Security-Policy': "default-src 'self'" }
+		});
+		const event = createEvent({ path: '/' });
+
+		const response = await notFound({ event, resolve: createResolve(resolved) });
+
+		expect(response).toBe(resolved);
+		expect(response.status).toBe(status);
+		expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'self'");
+		expect(await response.text()).toBe('<html lang="ja"></html>');
+	});
+});

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -61,4 +61,20 @@ const csp: Handle = async ({ event, resolve }) => {
 	return response;
 };
 
-export const handle: Handle = sequence(i18n, lang, csp);
+export const notFound: Handle = async ({ event, resolve }) => {
+	const response = await resolve(event);
+	if (response.status === 404) {
+		console.info({
+			event: 'http_not_found',
+			clientIp: event.request.headers.get('cf-connecting-ip'),
+			method: event.request.method,
+			path: event.url.pathname,
+			routeId: event.route.id,
+			rayId: event.request.headers.get('cf-ray'),
+			userAgent: event.request.headers.get('user-agent')
+		});
+	}
+	return response;
+};
+
+export const handle: Handle = sequence(notFound, i18n, lang, csp);


### PR DESCRIPTION
Cloudflare Bot Fight Mode を通過して Worker まで到達する `/.env`、WordPress 関連パス、GraphQL エンドポイント、管理画面などの探索アクセスについて、後から送信元 IP を追跡できるようにするための structured log を追加します。

Cloudflare Security Analytics / Security Events だけでは過去リクエストの送信元 IP を確実に追跡できないため、404 レスポンスに限り必要最小限のリクエスト情報を Workers Logs に残します。これにより「不審な path から IP を特定 → その IP で再検索 → 複数の探索パスを叩いていることを確認 → 必要なら Cloudflare 側で手動 BAN」という調査が可能になります。

## 変更内容

`src/hooks.server.ts` に `notFound` hook を追加し、`sequence` の先頭に配置しました。先頭に置くことで内側の hook をすべて通過した最終的な `Response` を受け取れるため、`response.status === 404` のときだけログを1件出力します。

ログは文字列に埋め込まず JSON object のまま `console.info(...)` に渡しています。Workers Logs は JSON を deserialize して各フィールドを index するため、`clientIp` や `path` 単位で直接検索・フィルターできます。404 自体が必ずしも不正アクセスではないため、log level は `warn` / `error` ではなく `info` です。

## 保存する情報

| field | 内容 |
| --- | --- |
| `event` | 固定値 `http_not_found` |
| `clientIp` | `CF-Connecting-IP` |
| `method` | HTTP method |
| `path` | `event.url.pathname` |
| `routeId` | `event.route.id` |
| `rayId` | `CF-Ray` |
| `userAgent` | `User-Agent` |

`routeId` を残すことで、SvelteKit の正規ルートにマッチした上で発生した 404 と、ルートにマッチしなかった 404（`null`）を調査時に区別できます。

`clientIp` は Cloudflare の仕様どおり `CF-Connecting-IP` header から取得しています。header 取得のみで完結するため Cloudflare 固有の Platform 型は追加していません。ローカル開発や prerender のように header が存在しない場合は `null` になるだけで例外は発生しません。

## 保存しない情報

目的に不要・機密性の高いデータは意図的に除外しています。header 全体をログ出力せず、必要な3つだけを個別に取得しています。

- query string、完全な URL（`event.url.pathname` のみ保存）
- Cookie、Authorization、Referer、request body、request headers 全体
- timestamp（Workers Logs 自体が保持）、response status（`http_not_found` と重複）
- host、ASN、その他の Cloudflare request metadata

## スコープ外

今回はログ追加のみです。自動 BAN、WAF ルール、Bot Fight Mode、Rate Limiting、IP block list、KV による IP 管理、`RESTRICTION` の仕組み、404 ページの UI はいずれも変更していません。`wrangler.jsonc` は Workers Observability がすでに有効なため未変更です（`invocation_logs: false` もそのままです）。

## 検証

`web` ディレクトリで順番に実行し、いずれも成功しています。

- `npm run check` — 7618 files, 0 errors, 0 warnings
- `npm run lint` — prettier / eslint ともに指摘なし
- `npm test` — 40 files, 369 tests passed（新規 12 件を含む）
- `npm run build` — 成功。生成された `hooks.server.js` に7項目のログと `sequence(notFound, i18n, lang, csp)` の順序を確認

既存の server hook 用テストが無かったため、既存の vitest 構成に沿って `src/hooks.server.test.ts` を追加しました（新しいテスト基盤は追加していません）。カバーしている内容:

- 404 の場合だけログが1件出ること
- 200 / 204 / 301 / 403 / 500 ではログが出ないこと
- `routeId` が matched / unmatched の両方で正しく記録されること
- `CF-Connecting-IP` / `CF-Ray` / `User-Agent` が無い環境でも例外にならず `null` になること
- ログの key が上記7項目ちょうどであり、query string・Cookie・Authorization・Referer の値が含まれないこと
- 内側の hook が返した `Response`（`Content-Security-Policy` header や `lang` 置換後の body）をそのまま返すこと

なお `sequence()` は SvelteKit 内部の request store を必要とし、公開 API だけでは `handle` 全体を直接呼び出せないため、テストは `notFound` hook を対象にしています。`i18n` / `lang` / `csp` の挙動が変わっていないことは、上記の pass-through テストと `npm run build` および既存テストで確認しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCcqCseAzj3qwcaFXMwHmL)_