### PR TITLE
Apply Prettier 3.9.6 formatting to /web files

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -56,7 +56,7 @@
 				"globals": "^17.11.0",
 				"html5-qrcode": "^2.3.8",
 				"nostr-typedef": "^0.13.0",
-				"prettier": "^3.7.4",
+				"prettier": "^3.9.6",
 				"prettier-plugin-svelte": "^3.2.6",
 				"rollup-plugin-visualizer": "^7.1.1",
 				"svelte": "^5.56.9",
@@ -6757,9 +6757,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-			"integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+			"integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,7 @@
 		"globals": "^17.11.0",
 		"html5-qrcode": "^2.3.8",
 		"nostr-typedef": "^0.13.0",
-		"prettier": "^3.7.4",
+		"prettier": "^3.9.6",
 		"prettier-plugin-svelte": "^3.2.6",
 		"rollup-plugin-visualizer": "^7.1.1",
 		"svelte": "^5.56.9",

--- a/web/src/lib/Content.ts
+++ b/web/src/lib/Content.ts
@@ -50,13 +50,7 @@ type NipToken = {
 };
 
 export type Token =
-	| TextToken
-	| ReferenceToken
-	| HashtagToken
-	| EmojiToken
-	| UrlToken
-	| RelayToken
-	| NipToken;
+	TextToken | ReferenceToken | HashtagToken | EmojiToken | UrlToken | RelayToken | NipToken;
 
 export class Content {
 	static parse(content: string, tags: string[][] = []): Token[] {
@@ -78,9 +72,11 @@ export class Content {
 		const foundTokens: Token[] = [];
 		foundTokens.push(
 			...urls
-				.map(
-					({ url, indices }): UrlToken => ({ type: 'url', text: url, start: indices[0] })
-				)
+				.map(({ url, indices }): UrlToken => ({
+					type: 'url',
+					text: url,
+					start: indices[0]
+				}))
 				.filter((token) => token.start === 0 || content[token.start - 1] !== '"') // ignore URLs in JSON
 		);
 		if (hashtags.length > 0) {
@@ -89,13 +85,11 @@ export class Content {
 					...content.matchAll(
 						new RegExp(`#(${hashtags.map(escapeStringRegexp).join('|')})`, 'gi')
 					)
-				].map(
-					(match): HashtagToken => ({
-						type: 'hashtag',
-						text: match[0],
-						start: match.index
-					})
-				)
+				].map((match): HashtagToken => ({
+					type: 'hashtag',
+					text: match[0],
+					start: match.index
+				}))
 			);
 		}
 		if (emojis.size > 0) {
@@ -123,32 +117,26 @@ export class Content {
 				...content.matchAll(
 					/\bnostr:((note|npub|naddr|nevent|nprofile)1\w{6,})\b|#\[(?<i>\d+)\]/g
 				)
-			].map(
-				(match): ReferenceToken => ({
-					type: 'reference',
-					text: match[0],
-					start: match.index,
-					tagIndex: match.groups?.i ? Number(match.groups.i) : undefined
-				})
-			)
+			].map((match): ReferenceToken => ({
+				type: 'reference',
+				text: match[0],
+				start: match.index,
+				tagIndex: match.groups?.i ? Number(match.groups.i) : undefined
+			}))
 		);
 		foundTokens.push(
-			...[...content.matchAll(/(?<=^|\s)(wss|ws):\/\/\S+/g)].map(
-				(match): RelayToken => ({
-					type: 'relay',
-					text: match[0],
-					start: match.index
-				})
-			)
+			...[...content.matchAll(/(?<=^|\s)(wss|ws):\/\/\S+/g)].map((match): RelayToken => ({
+				type: 'relay',
+				text: match[0],
+				start: match.index
+			}))
 		);
 		foundTokens.push(
-			...[...content.matchAll(/NIP-[0-9A-Z]{2,}/g)].map(
-				(match): NipToken => ({
-					type: 'nip',
-					text: match[0],
-					start: match.index
-				})
-			)
+			...[...content.matchAll(/NIP-[0-9A-Z]{2,}/g)].map((match): NipToken => ({
+				type: 'nip',
+				text: match[0],
+				start: match.index
+			}))
 		);
 
 		return composeTokens(content, foundTokens);

--- a/web/src/lib/preferences/AccountLocalPreferences.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.ts
@@ -4,8 +4,7 @@ import type { Persisted } from 'svelte-persisted-store';
 import type { Writable } from 'svelte/store';
 
 export type MediaUploaderPreference =
-	| { type: 'blossom'; server: string }
-	| { type: 'nip96'; server: string };
+	{ type: 'blossom'; server: string } | { type: 'nip96'; server: string };
 
 export type AccountLocalPreferences = {
 	mediaUploader?: MediaUploaderPreference;
@@ -29,9 +28,7 @@ function normalizeAccountLocalPreferences(
 	preferences: AccountLocalPreferences
 ): AccountLocalPreferences {
 	const mediaUploader = preferences.mediaUploader as
-		| MediaUploaderPreference
-		| { type: 'blossom'; server?: string }
-		| undefined;
+		MediaUploaderPreference | { type: 'blossom'; server?: string } | undefined;
 	if (mediaUploader?.type !== 'blossom' || typeof mediaUploader.server === 'string') {
 		return preferences;
 	}

--- a/web/src/lib/timelines/ListTimeline.ts
+++ b/web/src/lib/timelines/ListTimeline.ts
@@ -116,9 +116,9 @@ export async function loadListTimeline(): Promise<void> {
 				.subscribe({
 					next: (packet) => {
 						console.debug('[list timeline past event]', packet);
-						if (
-							!(since <= packet.event.created_at && packet.event.created_at < until)
-						) {
+						if (!(
+							since <= packet.event.created_at && packet.event.created_at < until
+						)) {
 							console.warn('[list timeline out of period]', packet, since, until);
 							return;
 						}

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/Notes.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/Notes.svelte
@@ -52,12 +52,9 @@
 					.subscribe({
 						next: (packet) => {
 							console.debug('[rx-nostr user timeline packet]', packet);
-							if (
-								!(
-									since <= packet.event.created_at &&
-									packet.event.created_at < until
-								)
-							) {
+							if (!(
+								since <= packet.event.created_at && packet.event.created_at < until
+							)) {
 								console.warn(
 									'[rx-nostr user timeline out of period]',
 									packet,

--- a/web/src/routes/(app)/[slug=npub]/(tabs)/media/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/(tabs)/media/+page.svelte
@@ -64,12 +64,9 @@
 					.subscribe({
 						next: async (packet) => {
 							console.log('[rx-nostr user media timeline packet]', packet);
-							if (
-								!(
-									since <= packet.event.created_at &&
-									packet.event.created_at < until
-								)
-							) {
+							if (!(
+								since <= packet.event.created_at && packet.event.created_at < until
+							)) {
 								console.warn(
 									'[rx-nostr user media timeline out of period]',
 									packet,

--- a/web/src/routes/(app)/notifications/+page.svelte
+++ b/web/src/routes/(app)/notifications/+page.svelte
@@ -114,12 +114,9 @@
 					.subscribe({
 						next: async (packet) => {
 							console.debug('[rx-nostr notification timeline packet]', packet);
-							if (
-								!(
-									since <= packet.event.created_at &&
-									packet.event.created_at < until
-								)
-							) {
+							if (!(
+								since <= packet.event.created_at && packet.event.created_at < until
+							)) {
 								console.warn(
 									'[rx-nostr notification timeline out of period]',
 									packet,

--- a/web/src/routes/(app)/relays/[url]/+page.svelte
+++ b/web/src/routes/(app)/relays/[url]/+page.svelte
@@ -61,12 +61,9 @@
 					.subscribe({
 						next: (packet) => {
 							console.log('[rx-nostr relay timeline packet]', packet);
-							if (
-								!(
-									since <= packet.event.created_at &&
-									packet.event.created_at < until
-								)
-							) {
+							if (!(
+								since <= packet.event.created_at && packet.event.created_at < until
+							)) {
 								console.warn(
 									'[rx-nostr relay timeline out of period]',
 									packet,


### PR DESCRIPTION
### Motivation

- Update repository formatting to match Prettier 3.9.6 so the dependabot Prettier upgrade PR can be merged without formatting conflicts.

### Description

- Ran the project's local Prettier (3.9.6) and applied formatting-only changes to files that showed differences under the new Prettier output, without modifying runtime logic.
- Updated formatting in these files: `web/src/lib/Content.ts`, `web/src/lib/preferences/AccountLocalPreferences.ts`, `web/src/lib/timelines/ListTimeline.ts`, `web/src/routes/(app)/[slug=npub]/(tabs)/media/+page.svelte`, `web/src/routes/(app)/[slug=npub]/(tabs)/Notes.svelte`, `web/src/routes/(app)/notifications/+page.svelte`, and `web/src/routes/(app)/relays/[url]/+page.svelte`.
- Did not hand-edit `package-lock.json`; the Dependabot patch for the Prettier version bump was applied as provided and no manual edits to lockfile were made.
- Changes were committed to the existing dependabot branch as commit `94254d23` with message "Apply Prettier 3.9.6 formatting" and no Conventional Commit prefix.

### Testing

- Attempted `npm install` with the environment Node/npm and observed engine mismatch (project requires Node 24.x and npm >= 11.10.0), so `npm_config_engine_strict=false npm install` was used to install dependencies successfully.
- Verified local Prettier binary is `3.9.6` via `./node_modules/.bin/prettier --version`.
- Ran `npm run format` to apply formatting and confirmed only formatting changes were produced.
- Ran `npm run lint` and Prettier check/ESLint completed successfully (Prettier reported "All matched files use Prettier code style!").
- Ran `npm run check` and `svelte-check` returned "0 errors and 0 warnings".
- Confirmed git state is clean after committing the formatting changes and that diffs contain only formatting edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97c32e93ec832eaa0e18541871740d)