### PR TITLE
Apply prettier-plugin-svelte v4 formatting to composer Svelte files

### DIFF
--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -651,8 +651,7 @@
 				oninput={onInput}
 				onpaste={paste}
 				ondragover={dragover}
-				ondrop={drop}
-			></textarea>
+				ondrop={drop}></textarea>
 			{#if containsNsec}
 				<div class="warning">{$_('editor.warning.nsec')}</div>
 			{/if}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -227,8 +227,7 @@
 			placeholder={$_('channel.placeholder')}
 			onkeydown={onKeydown}
 			onpaste={paste}
-			ondrop={drop}
-		></textarea>
+			ondrop={drop}></textarea>
 		<button
 			class="send"
 			title="{$_('channel.send')} (Ctrl + Enter)"


### PR DESCRIPTION
### Motivation
- Bring the formatting in the Dependabot branch inline with Prettier 3.9.6 + `prettier-plugin-svelte` 4.1.1 so the existing Prettier check in PR #2364 passes.

### Description
- Reformatted only `web/src/lib/components/composer/NoteComposer.svelte` and `web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte` to match the plugin v4 output (closing `</textarea>` moved to the same line as the `ondrop={drop}` attribute).
- No changes were made to application logic, Prettier configuration, `package.json`, or `package-lock.json`.
- Changes were committed directly to the existing branch `dependabot/npm_and_yarn/web/prettier-plugin-svelte-4.1.1` with the message `Apply prettier-plugin-svelte 4 formatting`.

### Testing
- `nvm use 24.20.0 && npm ci` succeeded using the repository-required Node version (Node 24) and installed dependencies.
- Installed `prettier@3.9.6` and `prettier-plugin-svelte@4.1.1` locally and ran `npx prettier --write` on the two target files, producing the expected diffs.
- `npm run lint` completed successfully with Prettier and ESLint checks passing.
- `npm run check` completed successfully and `git diff --exit-code -- web/package.json web/package-lock.json` confirmed no package files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97c7ccaff4832e8f46642632368447)