### PR TITLE
Update quote requests when event changes

### DIFF
--- a/web/src/routes/(app)/[slug=note]/quotes/+page.svelte
+++ b/web/src/routes/(app)/[slug=note]/quotes/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
 	import { createRxBackwardReq, uniq } from 'rx-nostr';
-	import { afterNavigate } from '$app/navigation';
 	import { EventItem } from '$lib/Items';
 	import { chronologicalItem } from '$lib/Constants';
 	import type { pubkey } from '$lib/Types';
@@ -17,7 +16,6 @@
 
 	let { data }: Props = $props();
 
-	let id: string | undefined;
 	let itemsMap = new SvelteMap<pubkey, EventItem>();
 
 	let items = $derived(
@@ -33,13 +31,11 @@
 			itemsMap.set(packet.event.id, new EventItem(packet.event));
 		});
 
-	afterNavigate(() => {
-		console.log('[quotes page]', data.eventId);
-		if (id === data.eventId) {
-			return;
-		}
+	$effect(() => {
+		const eventId = data.eventId;
+		console.log('[quotes page]', eventId);
 		itemsMap.clear();
-		quotesReq.emit([{ kinds: [1], '#q': [data.eventId] }]);
+		quotesReq.emit([{ kinds: [1], '#q': [eventId] }]);
 	});
 </script>
 


### PR DESCRIPTION
## Summary

- Previously, afterNavigate reacted to navigation as a whole when reissuing quote requests.
- Track the actual request dependency, data.eventId, with $effect and clear the current quotes before requesting the new event.
- Remove the manual id-based duplicate prevention, which was never updated.

## Validation

- npm run check
- npm run lint