### PR TITLE
Avoid probing SimpleX SMP servers

### DIFF
--- a/web/src/lib/components/Content.svelte
+++ b/web/src/lib/components/Content.svelte
@@ -14,6 +14,7 @@
 	import { Twitter } from '$lib/Twitter';
 	import { nicovideoRegexp } from '$lib/Constants';
 	import { mediaExtensionRegexp } from '$lib/media/MediaType';
+	import { isSimplexSmpUrl } from '$lib/url';
 	import type * as Nostr from 'nostr-typedef';
 	import type { LocalMediaPreview } from '$lib/media/LocalAttachment';
 	import LocalMedia from './content/LocalMedia.svelte';
@@ -65,7 +66,9 @@
 	{/each}
 	{#if $enablePreview && browser}
 		{#each urls as url}
-			{#if Twitter.isTweetUrl(url)}
+			{#if isSimplexSmpUrl(url)}
+				<!-- SimpleX SMP -->
+			{:else if Twitter.isTweetUrl(url)}
 				<!-- Twitter -->
 			{:else if Spotify.isSpotifyUrl(url)}
 				<!-- Spotify -->

--- a/web/src/lib/components/content/Url.svelte
+++ b/web/src/lib/components/content/Url.svelte
@@ -58,6 +58,7 @@
 	import { Spotify } from '$lib/Spotify';
 	import { Twitter } from '$lib/Twitter';
 	import { enablePreview } from '$lib/stores/Preference';
+	import { isSimplexSmpUrl } from '$lib/url';
 	import Text from './Text.svelte';
 	import ExternalLink from '$lib/components/ExternalLink.svelte';
 	import SoundCloudPlayer from '$lib/components/content/SoundCloud.svelte';
@@ -159,6 +160,8 @@
 {:else if link.hostname.endsWith('nicovideo.jp') && nicovideoRegexp.test(link.href)}
 	<Nicovideo {link} />
 {:else if link.hostname === 'amzn.to' || link.hostname === 'amzn.asia' || /^(.+\.)*amazon\.co\.jp$/s.test(link.hostname)}
+	<ExternalLink {link} />
+{:else if isSimplexSmpUrl(link)}
 	<ExternalLink {link} />
 {:else if mediaKind !== undefined}
 	{@render media(link, mediaKind)}

--- a/web/src/lib/url.test.ts
+++ b/web/src/lib/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isHttpUrl } from './url';
+import { isHttpUrl, isSimplexSmpUrl } from './url';
 
 describe('isHttpUrl', () => {
 	it.each([
@@ -10,5 +10,18 @@ describe('isHttpUrl', () => {
 		['data:', 'data:text/html,example', false]
 	])('returns the expected result for %s URLs', (_scheme, value, expected) => {
 		expect(isHttpUrl(new URL(value))).toBe(expected);
+	});
+});
+
+describe('isSimplexSmpUrl', () => {
+	it.each([
+		['preset SMP server', 'https://smp11.simplex.im', true],
+		['SMP server with port and path', 'https://smp8.simplex.im:443/example', true],
+		['XFTP server', 'https://xftp8.simplex.im', false],
+		['other SimpleX subdomain', 'https://www.simplex.im', false],
+		['SMP-like nested subdomain', 'https://smp8.simplex.im.example.com', false],
+		['SMP hostname without a number', 'https://smp.simplex.im', false]
+	])('identifies %s', (_description, value, expected) => {
+		expect(isSimplexSmpUrl(new URL(value))).toBe(expected);
 	});
 });

--- a/web/src/lib/url.ts
+++ b/web/src/lib/url.ts
@@ -1,3 +1,7 @@
 export function isHttpUrl(url: URL): boolean {
 	return url.protocol === 'https:' || url.protocol === 'http:';
 }
+
+export function isSimplexSmpUrl(url: URL): boolean {
+	return /^smp\d+\.simplex\.im$/s.test(url.hostname);
+}


### PR DESCRIPTION
### Motivation
- Prevent automatic browser client-certificate selection dialogs and unnecessary network requests when rendering links that point to SimpleX SMP preset servers by avoiding automatic probing and OGP generation for those hosts.
- Limit the exception to numeric SMP hosts like `smp8.simplex.im`/`smp11.simplex.im` and do not change behavior for other `simplex.im` subdomains or globally proxy all external requests.

### Description
- Add a URL helper `isSimplexSmpUrl(url: URL)` in `web/src/lib/url.ts` that returns true only for hostnames matching the pattern `smp<number>.simplex.im` (checked against `URL.hostname`).
- Update `web/src/lib/components/content/Url.svelte` to skip calling `fetchContentType()` (the direct `HEAD` probe and proxy fallback) for hosts where `isSimplexSmpUrl` returns true and render them as normal external links instead.
- Update `web/src/lib/components/Content.svelte` to skip creating an `Ogp` component for `isSimplexSmpUrl` hosts so no OGP proxy or direct fetch fallback is triggered for those links.
- Add targeted unit tests in `web/src/lib/url.test.ts` to verify correct identification of numeric SMP hosts and to ensure similar-looking subdomains (e.g. `xftp8.simplex.im`, nested domains, or `smp.simplex.im`) are not matched.
- No global proxying or new blacklist abstractions were introduced and link-click behavior remains unchanged.

### Testing
- Ran the focused unit tests with `npm test -- --run src/lib/url.test.ts`, which passed (1 file, 10 tests).
- Ran type/Svelte checks with `npm run check` (Svelte/TypeScript diagnostics) which reported `0 errors` and `0 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a993b9598d8832e9e206f094184b270)