### PR TITLE
Remove viewport width from splash screen

### DIFF
--- a/web/src/routes/SplashScreen.svelte
+++ b/web/src/routes/SplashScreen.svelte
@@ -10,7 +10,6 @@
 
 <style>
 	:global(html, body) {
-		width: 100vw;
 		height: 100vh;
 	}
 


### PR DESCRIPTION
### Motivation

- Remove `width: 100vw` from `html, body` because viewport-relative `vw` can include the scrollbar width and caused horizontal overflow, and applying `width: auto` in production was observed to remove the horizontal scroll.

### Description

- Deleted `width: 100vw` from `:global(html, body)` in `web/src/routes/SplashScreen.svelte` while keeping `height: 100vh` and making no other changes.

### Testing

- Ran `git diff --check` and `npm run check` (which runs `svelte-kit sync && svelte-check`) and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9997b8793c832e87c014788043cdd5)