### PR TITLE
Keep NIP-05 status labels intact on narrow screens

### DIFF
--- a/web/src/lib/components/NostrAddress.svelte
+++ b/web/src/lib/components/NostrAddress.svelte
@@ -16,16 +16,22 @@
 
 {#if normalizedNip05}
 	<div class="nip05">
-		<span>{normalizedNip05}</span>
+		<span class="address">{normalizedNip05}</span>
 		{#await nip05.queryProfile(normalizedNip05) then pointer}
 			{#if pointer === null}
-				<IconAlertTriangle color="orange" />
-				<span class="label">{$_('profile.nip05.unknown')}</span>
+				<span class="status">
+					<IconAlertTriangle color="orange" />
+					<span class="label">{$_('profile.nip05.unknown')}</span>
+				</span>
 			{:else if pointer.pubkey === metadata.event.pubkey}
-				<IconRosetteDiscountCheck color="skyblue" />
+				<span class="status">
+					<IconRosetteDiscountCheck color="skyblue" />
+				</span>
 			{:else}
-				<IconAlertTriangle color="red" />
-				<span class="label">{$_('profile.nip05.impersonation')}</span>
+				<span class="status">
+					<IconAlertTriangle color="red" />
+					<span class="label">{$_('profile.nip05.impersonation')}</span>
+				</span>
 			{/if}
 		{/await}
 	</div>
@@ -35,12 +41,21 @@
 	.nip05 {
 		margin: 0.35rem 0;
 		display: inline-flex;
-		flex-direction: row;
-		align-items: center;
+		align-items: flex-start;
+		gap: 0.2rem;
+		max-width: 100%;
 	}
 
-	.nip05 span {
-		margin-right: 0.2rem;
-		word-break: break-all;
+	.address {
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
+
+	.status {
+		display: inline-flex;
+		flex: none;
+		align-items: center;
+		gap: 0.2rem;
+		white-space: nowrap;
 	}
 </style>


### PR DESCRIPTION
### Motivation
- The previous `.nip05 span` rule applied `word-break: break-all` to both long NIP-05 addresses and short status labels, causing short labels like “不明”/“なりすまし” to be broken into individual characters and the validation icon to be allowed to shrink or move under tight widths.

### Description
- Separate the address and the status into distinct elements in `web/src/lib/components/NostrAddress.svelte`: the address is rendered in `span.address` and icon+label are wrapped in `span.status`.
- Apply `overflow-wrap: anywhere` and `min-width: 0` to `.address` so long addresses wrap without overflowing, and apply `white-space: nowrap` plus `flex: none` to `.status` so the icon and short status labels stay together and are not broken.
- Adjust `.nip05` layout to use `gap` and `max-width: 100%` to avoid flex-driven shrinking issues; the validation/query logic and i18n strings were not changed.

### Testing
- Ran `npm run check` in `web` and it completed with no blocking errors (svelte-check run). (success)
- Ran `npm run lint` in `web` and Prettier/ESLint passed formatting and lint checks. (success)
- Ran `git diff --check` to ensure no whitespace/patch issues. (success)
- Verified Node version with `node --version` (`v24.20.0`). (info)
- Attempted a Playwright-based visual check and `npx playwright install chromium` failed due to CDN HTTP 403 in this environment, so automated visual verification could not be completed here. (failed — environment network restriction)
- Attempted to fetch the W3C CSS Text spec and to fetch remote git refs; both external requests were blocked by HTTP 403 in this environment and could not be completed. (failed — environment network restriction)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9afbe6dee0832e9ddae65f0ef2483f)