### PR TITLE
Update snow-actions/nostr to v2.0.0

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - id: publish
-        uses: snow-actions/nostr@c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3
+        uses: snow-actions/nostr@b19cca880d568f17d602894c3e9de020e2bacde4 # v2.0.0
         with:
           relays: ${{ vars.NOSTR_RELAYS }}
           private-key: ${{ secrets.NOSTR_PRIVATE_KEY }}
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - id: publish
-        uses: snow-actions/nostr@c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3
+        uses: snow-actions/nostr@b19cca880d568f17d602894c3e9de020e2bacde4 # v2.0.0
         with:
           relays: ${{ vars.NOSTR_RELAYS }}
           private-key: ${{ secrets.NOSTR_PRIVATE_KEY }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - run: echo "expiration=$(date +%s --date '12 hours')" >> $GITHUB_ENV
       - id: publish
-        uses: snow-actions/nostr@c0cdc2289ef176219cffc2cf1100f1d9b1c95f2e # v1.8.3
+        uses: snow-actions/nostr@b19cca880d568f17d602894c3e9de020e2bacde4 # v2.0.0
         with:
           relays: ${{ vars.NOSTR_RELAYS }}
           private-key: ${{ secrets.NOSTR_PRIVATE_KEY }}


### PR DESCRIPTION
### Summary

- Update `snow-actions/nostr` from v1.8.3 to v2.0.0.
- Migrate the action runtime from Node.js 20 to Node.js 24.

### Testing

- Verified the existing action inputs and output remain compatible.