### PR TITLE
Centralize NIP-65 relay list parsing

### DIFF
--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -51,21 +51,6 @@ export function filterTags(tagName: string, tags: string[][]) {
 		.map(([, content]) => content);
 }
 
-export function filterRelayTags(tags: string[][]): string[][] {
-	return tags.filter(([tagName, relay]) => {
-		if (tagName !== 'r') {
-			return false;
-		}
-
-		try {
-			const url = new URL(relay);
-			return url.protocol === 'wss:' || url.protocol === 'ws:';
-		} catch {
-			return false;
-		}
-	});
-}
-
 export const filterEmojiTags = (tags: string[][]): string[][] => {
 	return tags.filter(([tagName, shortcode, imageUrl]) => {
 		if (tagName !== 'emoji') {
@@ -85,18 +70,6 @@ export const filterEmojiTags = (tags: string[][]): string[][] => {
 		}
 	});
 };
-
-export function relayTagsToMap(tags: string[][]): Map<string, { read: boolean; write: boolean }> {
-	return new Map(
-		filterRelayTags(tags).map(([, relay, permission]) => [
-			relay,
-			{
-				read: permission === undefined || permission === 'read',
-				write: permission === undefined || permission === 'write'
-			}
-		])
-	);
-}
 
 export function parseRelayJson(content: string): Map<string, { read: boolean; write: boolean }> {
 	try {

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -15,6 +15,7 @@
 	} from '$lib/TextEventComposer';
 	import { Content } from '$lib/Content';
 	import { filterTags } from '$lib/EventHelper';
+	import { getReadRelays, parseRelayList } from '$lib/nostr/nip65';
 	import { metadataStore } from '$lib/cache/Events';
 	import { EventItem, Metadata } from '$lib/Items';
 	import type * as Nostr from 'nostr-typedef';
@@ -543,12 +544,9 @@
 				}
 
 				const readRelays = [...relayListEventsMap]
-					.flatMap(([, relayListEvent]) => relayListEvent.tags)
-					.filter(
-						([tagName, , marker]) =>
-							tagName === 'r' && (marker === undefined || marker === 'read')
+					.flatMap(([, relayListEvent]) =>
+						getReadRelays(parseRelayList(relayListEvent.tags))
 					)
-					.map(([, url]) => url)
 					.filter((url) => !sendToRelays.includes(url));
 				console.log('[rx-nostr send addition]', readRelays, relayListEventsMap);
 				if (readRelays.length === 0) {

--- a/web/src/lib/nostr/nip65.test.ts
+++ b/web/src/lib/nostr/nip65.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { parseRelayList } from './nip65';
+
+const URL1 = 'wss://relay.example.com';
+
+describe('parseRelayList', () => {
+	it('no marker → read and write', () => {
+		expect(parseRelayList([['r', URL1]])).toEqual([{ url: URL1, read: true, write: true }]);
+	});
+
+	it('"read" marker → read only', () => {
+		expect(parseRelayList([['r', URL1, 'read']])).toEqual([
+			{ url: URL1, read: true, write: false }
+		]);
+	});
+
+	it('"write" marker → write only', () => {
+		expect(parseRelayList([['r', URL1, 'write']])).toEqual([
+			{ url: URL1, read: false, write: true }
+		]);
+	});
+
+	it('invalid relay URL → excluded', () => {
+		const result = parseRelayList([
+			['r', 'not-a-url'],
+			['r', URL1]
+		]);
+		expect(result).toHaveLength(1);
+		expect(result[0].url).toBe(URL1);
+	});
+
+	it('unknown marker → excluded', () => {
+		expect(parseRelayList([['r', URL1, 'admin']])).toHaveLength(0);
+	});
+
+	it('empty-string marker → excluded', () => {
+		expect(parseRelayList([['r', URL1, '']])).toHaveLength(0);
+	});
+
+	it('duplicate URL with different markers → both entries preserved', () => {
+		const result = parseRelayList([
+			['r', URL1, 'read'],
+			['r', URL1, 'write']
+		]);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({ url: URL1, read: true, write: false });
+		expect(result[1]).toEqual({ url: URL1, read: false, write: true });
+	});
+});

--- a/web/src/lib/nostr/nip65.ts
+++ b/web/src/lib/nostr/nip65.ts
@@ -1,0 +1,35 @@
+export interface RelayEntry {
+	url: string;
+	read: boolean;
+	write: boolean;
+}
+
+function isRelayUrl(value: string): boolean {
+	try {
+		const { protocol } = new URL(value);
+		return protocol === 'wss:' || protocol === 'ws:';
+	} catch {
+		return false;
+	}
+}
+
+export function parseRelayList(tags: string[][]): RelayEntry[] {
+	return tags.flatMap((tag): RelayEntry[] => {
+		const [name, url, marker] = tag;
+		if (name !== 'r' || !isRelayUrl(url)) return [];
+
+		if (marker === undefined) return [{ url, read: true, write: true }];
+		if (marker === 'read') return [{ url, read: true, write: false }];
+		if (marker === 'write') return [{ url, read: false, write: true }];
+
+		return [];
+	});
+}
+
+export function getReadRelays(entries: RelayEntry[]): string[] {
+	return entries.filter((e) => e.read).map((e) => e.url);
+}
+
+export function getWriteRelays(entries: RelayEntry[]): string[] {
+	return entries.filter((e) => e.write).map((e) => e.url);
+}

--- a/web/src/lib/stores/Author.ts
+++ b/web/src/lib/stores/Author.ts
@@ -4,7 +4,8 @@ import type { User } from '../../routes/types';
 import type { Event } from 'nostr-tools';
 import { defaultRelays } from '$lib/Constants';
 import type { Author } from '$lib/Author';
-import { filterRelayTags, filterTags, findIdentifier, getZapperPubkey } from '$lib/EventHelper';
+import { filterTags, findIdentifier, getZapperPubkey } from '$lib/EventHelper';
+import { getReadRelays, getWriteRelays, parseRelayList } from '$lib/nostr/nip65';
 import { decryptListContent } from '$lib/List';
 import { auth } from '$lib/auth.svelte';
 import { type LoginType, signerCanSign } from '$lib/signer-capability';
@@ -117,27 +118,9 @@ export const isMuteEvent = (event: Event) => {
 
 export const updateRelays = (event: Event) => {
 	console.debug('[relays before]', get(readRelays), get(writeRelays));
-	const validRelayTags = filterRelayTags(event.tags);
-	readRelays.set(
-		Array.from(
-			new Set(
-				validRelayTags
-					.filter(([, , permission]) => permission === undefined || permission === 'read')
-					.map(([, relay]) => relay)
-			)
-		)
-	);
-	writeRelays.set(
-		Array.from(
-			new Set(
-				validRelayTags
-					.filter(
-						([, , permission]) => permission === undefined || permission === 'write'
-					)
-					.map(([, relay]) => relay)
-			)
-		)
-	);
+	const entries = parseRelayList(event.tags);
+	readRelays.set([...new Set(getReadRelays(entries))]);
+	writeRelays.set([...new Set(getWriteRelays(entries))]);
 	console.debug('[relays after]', get(readRelays), get(writeRelays));
 };
 

--- a/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
@@ -11,7 +11,8 @@
 	import { developerMode } from '$lib/stores/Preference';
 	import { kinds as Kind } from 'nostr-tools';
 	import Relay from './Relay.svelte';
-	import { filterRelayTags, parseRelayJson } from '$lib/EventHelper';
+	import { parseRelayJson } from '$lib/EventHelper';
+	import { parseRelayList } from '$lib/nostr/nip65';
 	import { Contacts } from '$lib/Contacts';
 	import IconPencil from '@tabler/icons-svelte-runes/icons/pencil';
 	import IconDeviceFloppy from '@tabler/icons-svelte-runes/icons/device-floppy';
@@ -50,13 +51,7 @@
 		const kind10002 = events.get(Kind.RelayList);
 		const kind3 = events.get(Kind.Contacts);
 		if (kind10002 !== undefined) {
-			relays = filterRelayTags(kind10002.tags).map(([, relay, permission]) => {
-				return {
-					url: relay,
-					read: permission === undefined || permission === 'read',
-					write: permission === undefined || permission === 'write'
-				};
-			});
+			relays = parseRelayList(kind10002.tags);
 		} else if (kind3 !== undefined && kind3.content !== '') {
 			relays = [...parseRelayJson(kind3.content)].map(([relay, permission]) => {
 				return { url: relay, ...permission };


### PR DESCRIPTION
Add `$lib/nostr/nip65.ts` as the single place that interprets NIP-65 kind 10002 relay-list semantics.

## Changes

**New: `$lib/nostr/nip65.ts`**
- `RelayEntry` model: `{ url, read, write }`
- `parseRelayList(tags)` — converts `r` tags to `RelayEntry[]`
  - marker absent → read+write, `read` → read only, `write` → write only
  - unknown markers and invalid relay URLs are excluded
  - duplicate URLs are not merged; each valid tag produces one entry
- `getReadRelays(entries)` / `getWriteRelays(entries)`

**New: `$lib/nostr/nip65.test.ts`**

**Updated call sites** (replaced inline `r`-tag iteration):
- `stores/Author.ts` — `updateRelays()`
- `NoteComposer.svelte` — `postNote()` read-relay selection
- `routes/(app)/[slug=npub]/relays/+page.svelte`

**Removed from `EventHelper.ts`**: `filterRelayTags()`, `relayTagsToMap()`

## Verification

- `npm test`: 41 files, 383 tests passed
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: all files pass