### PR TITLE
Extract relay hint ownership

### DIFF
--- a/web/src/lib/RelayList.ts
+++ b/web/src/lib/RelayList.ts
@@ -2,7 +2,8 @@ import { createRxBackwardReq, latestEach, uniq } from 'rx-nostr';
 import { kinds as Kind } from 'nostr-tools';
 import type * as Nostr from 'nostr-typedef';
 import type { pubkey } from './Types';
-import { rxNostr, tie } from './timelines/MainTimeline';
+import { rxNostr } from '$lib/nostr/client';
+import { tie } from '$lib/nostr/relay-hints';
 import { cacheFolloweeReplaceableEvent, followeeEventCache } from './cache/Events';
 
 export class RelayList {

--- a/web/src/lib/nostr/relay-hints.ts
+++ b/web/src/lib/nostr/relay-hints.ts
@@ -1,0 +1,19 @@
+import { createTie } from '$lib/RxNostrTie';
+
+export const [tie, seenOn] = createTie();
+
+export function getRelayHint(id: string): string | undefined {
+	return seenOn
+		.get(id)
+		?.values()
+		.filter((value) => value.startsWith('wss://'))
+		.next().value;
+}
+
+export function getSeenOnRelays(id: string): string[] | undefined {
+	const relays = seenOn.get(id);
+	if (relays === undefined) {
+		return undefined;
+	}
+	return [...relays].filter((value) => value.startsWith('wss://'));
+}

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -24,32 +24,11 @@ import {
 import { chunk } from '$lib/Array';
 import { Content } from '$lib/Content';
 import { sleep } from '$lib/Helper';
-import { createTie } from '$lib/RxNostrTie';
 import { isReplaceableKind } from 'nostr-tools/kinds';
 import { rxNostr } from '$lib/nostr/client';
 export { rxNostr, verificationClient } from '$lib/nostr/client';
-
-//#region Relay hints
-
-export const [tie, seenOn] = createTie();
-
-export function getRelayHint(id: string): string | undefined {
-	return seenOn
-		.get(id)
-		?.values()
-		.filter((value) => value.startsWith('wss://'))
-		.next().value;
-}
-
-export function getSeenOnRelays(id: string): string[] | undefined {
-	const relays = seenOn.get(id);
-	if (relays === undefined) {
-		return undefined;
-	}
-	return [...relays].filter((value) => value.startsWith('wss://'));
-}
-
-//#endregion
+export { tie, seenOn, getRelayHint, getSeenOnRelays } from '$lib/nostr/relay-hints';
+import { tie } from '$lib/nostr/relay-hints';
 
 //#region Connection States
 


### PR DESCRIPTION
## Changes

- relay hint state / helpers (`tie`, `seenOn`, `getRelayHint`, `getSeenOnRelays`) を `web/src/lib/nostr/relay-hints.ts` へ移動
- `MainTimeline.ts` からは上記を re-export しているため、既存の import は変更不要
- `RelayList.ts` が `MainTimeline.ts` に依存しなくなった（`rxNostr` は `$lib/nostr/client`、`tie` は `$lib/nostr/relay-hints` から直接 import）
- runtime behavior は変更していない

## Verification

- `npm test`: 41 files, 383 tests passed
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: Prettier + ESLint all passed