### PR TITLE
Use author write relays for reply reference fallback

### DIFF
--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -1,6 +1,6 @@
 import { get, writable } from 'svelte/store';
 import type * as Nostr from 'nostr-typedef';
-import { kinds as Kind } from 'nostr-tools';
+import { ShortTextNote } from 'nostr-tools/kinds';
 import * as nip10 from 'nostr-tools/nip10';
 import {
 	batch,
@@ -130,8 +130,8 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 				relay.startsWith('wss://') &&
 				URL.canParse(relay)
 		);
-		if (referenceTags.length > 0 || event.kind === Kind.ShortTextNote) {
-			// If not found, look up from the relay hint
+		if (referenceTags.length > 0 || event.kind === ShortTextNote) {
+			// If not found, try relay hints and the referenced author's write relays.
 			setTimeout(async () => {
 				const undiscoveredReferenceTags = referenceTags.filter(
 					([, id]) => !get(eventItemStore).has(id)
@@ -142,7 +142,7 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 						{ relays: undiscoveredReferenceTags.map(([, , relay]) => relay) }
 					);
 				}
-				if (event.kind !== Kind.ShortTextNote) {
+				if (event.kind !== ShortTextNote) {
 					return;
 				}
 				const { root, reply } = nip10.parse(event);

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -1,5 +1,7 @@
 import { get, writable } from 'svelte/store';
 import type * as Nostr from 'nostr-typedef';
+import { kinds as Kind } from 'nostr-tools';
+import * as nip10 from 'nostr-tools/nip10';
 import {
 	batch,
 	createRxBackwardReq,
@@ -29,6 +31,8 @@ import { rxNostr } from '$lib/nostr/client';
 export { rxNostr, verificationClient } from '$lib/nostr/client';
 export { tie, seenOn, getRelayHint, getSeenOnRelays } from '$lib/nostr/relay-hints';
 import { tie } from '$lib/nostr/relay-hints';
+import { RelayList } from '$lib/RelayList';
+import { getWriteRelays, parseRelayList } from '$lib/nostr/nip65';
 
 //#region Connection States
 
@@ -126,19 +130,45 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 				relay.startsWith('wss://') &&
 				URL.canParse(relay)
 		);
-		if (referenceTags.length > 0) {
+		if (referenceTags.length > 0 || event.kind === Kind.ShortTextNote) {
 			// If not found, look up from the relay hint
-			setTimeout(() => {
+			setTimeout(async () => {
 				const undiscoveredReferenceTags = referenceTags.filter(
-					([, id]) => !$eventItemStore.has(id)
+					([, id]) => !get(eventItemStore).has(id)
 				);
-				if (undiscoveredReferenceTags.length === 0) {
+				if (undiscoveredReferenceTags.length > 0) {
+					referencesReq.emit(
+						{ ids: undiscoveredReferenceTags.map(([, id]) => id) },
+						{ relays: undiscoveredReferenceTags.map(([, , relay]) => relay) }
+					);
+				}
+				if (event.kind !== Kind.ShortTextNote) {
 					return;
 				}
-				referencesReq.emit(
-					{ ids: undiscoveredReferenceTags.map(([, id]) => id) },
-					{ relays: undiscoveredReferenceTags.map(([, , relay]) => relay) }
-				);
+				const { root, reply } = nip10.parse(event);
+				const references = new Map<string, string>();
+				for (const reference of [root, reply]) {
+					if (reference?.author && !get(eventItemStore).has(reference.id)) {
+						references.set(reference.id, reference.author);
+					}
+				}
+				if (references.size === 0) {
+					return;
+				}
+				const relayLists = await RelayList.fetchEvents([...new Set(references.values())]);
+				for (const [id, author] of references) {
+					if (get(eventItemStore).has(id)) {
+						continue;
+					}
+					const relayList = relayLists.get(author);
+					if (relayList === undefined) {
+						continue;
+					}
+					const relays = [...new Set(getWriteRelays(parseRelayList(relayList.tags)))];
+					if (relays.length > 0) {
+						referencesReq.emit({ ids: [id] }, { relays });
+					}
+				}
 			}, timeout);
 		}
 	}

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -23,7 +23,7 @@ import {
 	storeEventItem,
 	storeMetadata
 } from '../cache/Events';
-import { chunk } from '$lib/Array';
+import { chunk, unique } from '$lib/Array';
 import { Content } from '$lib/Content';
 import { sleep } from '$lib/Helper';
 import { isReplaceableKind } from 'nostr-tools/kinds';
@@ -134,7 +134,7 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 			// If not found, try relay hints and the referenced author's write relays.
 			setTimeout(async () => {
 				const undiscoveredReferenceTags = referenceTags.filter(
-					([, id]) => !get(eventItemStore).has(id)
+					([, id]) => !$eventItemStore.has(id)
 				);
 				if (undiscoveredReferenceTags.length > 0) {
 					referencesReq.emit(
@@ -148,23 +148,23 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 				const { root, reply } = nip10.parse(event);
 				const references = new Map<string, string>();
 				for (const reference of [root, reply]) {
-					if (reference?.author && !get(eventItemStore).has(reference.id)) {
+					if (reference?.author && !$eventItemStore.has(reference.id)) {
 						references.set(reference.id, reference.author);
 					}
 				}
 				if (references.size === 0) {
 					return;
 				}
-				const relayLists = await RelayList.fetchEvents([...new Set(references.values())]);
+				const relayLists = await RelayList.fetchEvents(unique([...references.values()]));
 				for (const [id, author] of references) {
-					if (get(eventItemStore).has(id)) {
+					if ($eventItemStore.has(id)) {
 						continue;
 					}
 					const relayList = relayLists.get(author);
 					if (relayList === undefined) {
 						continue;
 					}
-					const relays = [...new Set(getWriteRelays(parseRelayList(relayList.tags)))];
+					const relays = unique(getWriteRelays(parseRelayList(relayList.tags)));
 					if (relays.length > 0) {
 						referencesReq.emit({ ids: [id] }, { relays });
 					}


### PR DESCRIPTION
Preserve default-relay lookups and the existing relay-hint fallback. After the existing timeout, use the official NIP-10 parser to collect missing kind 1 root/reply references with explicit authors, deduplicate IDs and authors, and fetch their relay lists with `RelayList.fetchEvents()`.

Use `parseRelayList()` and `getWriteRelays()` to request each reference from its author's deduplicated write relays, checking the event store again after relay-list fetching. References without authors are skipped without inferring authors from p tags.

Validation on Node.js v24.20.0:
- Relevant NIP-65 tests: 7 passed.
- `npm test -- --run --no-file-parallelism --maxWorkers=1`: 41 files, 383 tests passed.
- `npm run check`: 0 errors, 0 warnings.
- `npm run lint`: passed.
- GitHub Actions: unit-test, e2e-test, `npm run check`, and `npm run lint` passed (run 34380558212).

