### PR TITLE
Avoid duplicate reference relay requests

### DIFF
--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -118,7 +118,25 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 	].filter((id) => !$eventItemStore.has(id));
 
 	if (ids.length > 0) {
+		const defaultReadRelays = Object.keys(rxNostr.getDefaultRelays({ filter: 'read-all' }));
+		const requestedRelays = new Map(ids.map((id) => [id, new Set(defaultReadRelays)]));
 		referencesReq.emit({ ids });
+
+		const requestReference = (id: string, candidateRelays: string[]): void => {
+			if ($eventItemStore.has(id)) {
+				return;
+			}
+			const requested = requestedRelays.get(id) ?? new Set<string>();
+			const relays = unique(candidateRelays).filter((relay) => !requested.has(relay));
+			if (relays.length === 0) {
+				return;
+			}
+			referencesReq.emit({ ids: [id] }, { relays });
+			for (const relay of relays) {
+				requested.add(relay);
+			}
+			requestedRelays.set(id, requested);
+		};
 
 		const referenceTags = event.tags.filter(
 			([tagName, id, relay]) =>
@@ -133,14 +151,8 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 		if (referenceTags.length > 0 || event.kind === ShortTextNote) {
 			// If not found, try relay hints, referenced authors' write relays, and the replying author's read relays.
 			setTimeout(async () => {
-				const undiscoveredReferenceTags = referenceTags.filter(
-					([, id]) => !$eventItemStore.has(id)
-				);
-				if (undiscoveredReferenceTags.length > 0) {
-					referencesReq.emit(
-						{ ids: undiscoveredReferenceTags.map(([, id]) => id) },
-						{ relays: undiscoveredReferenceTags.map(([, , relay]) => relay) }
-					);
+				for (const [, id, relay] of referenceTags) {
+					requestReference(id, [relay]);
 				}
 				if (event.kind !== ShortTextNote) {
 					return;
@@ -174,19 +186,14 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 					if (relayList === undefined) {
 						continue;
 					}
-					const relays = unique(getWriteRelays(parseRelayList(relayList.tags)));
-					if (relays.length > 0) {
-						referencesReq.emit({ ids: [reference.id] }, { relays });
-					}
+					requestReference(reference.id, getWriteRelays(parseRelayList(relayList.tags)));
 				}
 				const relayList = relayLists.get(event.pubkey);
 				if (relayList !== undefined) {
-					const relays = unique(getReadRelays(parseRelayList(relayList.tags)));
-					const ids = unique(references.map((reference) => reference.id)).filter(
-						(id) => !$eventItemStore.has(id)
-					);
-					if (ids.length > 0 && relays.length > 0) {
-						referencesReq.emit({ ids }, { relays });
+					const relays = getReadRelays(parseRelayList(relayList.tags));
+					const ids = unique(references.map((reference) => reference.id));
+					for (const id of ids) {
+						requestReference(id, relays);
 					}
 				}
 			}, timeout);

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -118,7 +118,10 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 	].filter((id) => !$eventItemStore.has(id));
 
 	if (ids.length > 0) {
-		const defaultReadRelays = Object.keys(rxNostr.getDefaultRelays({ filter: 'read-all' }));
+		const relayKey = (relay: string): string => new URL(relay).href;
+		const defaultReadRelays = Object.keys(rxNostr.getDefaultRelays({ filter: 'read-all' })).map(
+			relayKey
+		);
 		const requestedRelays = new Map(ids.map((id) => [id, new Set(defaultReadRelays)]));
 		referencesReq.emit({ ids });
 
@@ -127,13 +130,16 @@ export function referencesReqEmit(event: Nostr.Event, metadataOnly: boolean = fa
 				return;
 			}
 			const requested = requestedRelays.get(id) ?? new Set<string>();
-			const relays = unique(candidateRelays).filter((relay) => !requested.has(relay));
+			const candidates = new Map(candidateRelays.map((relay) => [relayKey(relay), relay]));
+			const relays = [...candidates]
+				.filter(([key]) => !requested.has(key))
+				.map(([, relay]) => relay);
 			if (relays.length === 0) {
 				return;
 			}
 			referencesReq.emit({ ids: [id] }, { relays });
 			for (const relay of relays) {
-				requested.add(relay);
+				requested.add(relayKey(relay));
 			}
 			requestedRelays.set(id, requested);
 		};


### PR DESCRIPTION
Track requested reference ID × relay URL pairs locally within `referencesReqEmit()`, starting with the current default read relays while preserving the initial implicit-relay REQ.

Route all fallback requests through a local helper that skips cached events and previously requested pairs. Apply each relay hint only to its tagged reference ID, eliminating cross-product requests. Preserve fallback order, the existing timeout, and root/reply deduplication semantics.

Validation on Node.js v24.20.0, run sequentially:
- Relevant NIP-65 and Array tests: 9 passed.
- `CI=true npm test -- --no-file-parallelism --maxWorkers=1`: 41 files, 383 tests passed.
- `npm run check`: 0 errors, 0 warnings.
- `npm run lint`: passed.
