### PR TITLE
Accept readonly arrays in array utilities

### DIFF
--- a/web/src/lib/array.ts
+++ b/web/src/lib/array.ts
@@ -1,13 +1,13 @@
-export function chunk<T>(array: T[], size: number): T[][] {
+export function chunk<T>(array: readonly T[], size: number): T[][] {
 	return Array.from({ length: Math.ceil(array.length / size) }, (v, i) =>
 		array.slice(i * size, i * size + size)
 	);
 }
 
-export function diff<T>(array1: T[], array2: T[]): T[] {
+export function diff<T>(array1: readonly T[], array2: readonly T[]): T[] {
 	return array1.filter((x) => !array2.includes(x));
 }
 
-export function unique<T>(array: T[]): T[] {
+export function unique<T>(array: readonly T[]): T[] {
 	return [...new Set<T>(array)];
 }


### PR DESCRIPTION
- `chunk` / `diff` / `unique` の入力パラメータを `readonly T[]` に変更し、readonly arrays を受け取れるようにした
- runtime behavior は変更していない (return types・実装ロジックは変更なし)

## 検証結果

- `npm test`: 41 test files passed, 383 tests passed
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: prettier passed; eslint on all affected files: exit 0 (full-project eslint SIGTERM は main ブランチでも再現する既存の環境問題)