### PR TITLE
Allow Cloudflare Web Analytics beacon through CSP

### DIFF
--- a/web/src/hooks.server.test.ts
+++ b/web/src/hooks.server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
-import { notFound } from './hooks.server';
+import { csp, notFound } from './hooks.server';
 
 type Resolve = Parameters<typeof notFound>[0]['resolve'];
 
@@ -35,6 +35,25 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+});
+
+describe('content security policy', () => {
+	it('allows only the Cloudflare Web Analytics beacon script URL', async () => {
+		const response = await csp({
+			event: createEvent(),
+			resolve: createResolve(new Response())
+		});
+
+		const scriptSources = response.headers
+			.get('Content-Security-Policy')
+			?.split('; ')
+			.find((directive) => directive.startsWith('script-src '))
+			?.split(' ')
+			.slice(1);
+
+		expect(scriptSources).toContain('https://static.cloudflareinsights.com/beacon.min.js');
+		expect(scriptSources).not.toContain('https://static.cloudflareinsights.com');
+	});
 });
 
 describe('404 request logging', () => {

--- a/web/src/hooks.server.test.ts
+++ b/web/src/hooks.server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
-import { csp, notFound } from './hooks.server';
+import { notFound } from './hooks.server';
 
 type Resolve = Parameters<typeof notFound>[0]['resolve'];
 
@@ -35,25 +35,6 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks();
-});
-
-describe('content security policy', () => {
-	it('allows only the Cloudflare Web Analytics beacon script URL', async () => {
-		const response = await csp({
-			event: createEvent(),
-			resolve: createResolve(new Response())
-		});
-
-		const scriptSources = response.headers
-			.get('Content-Security-Policy')
-			?.split('; ')
-			.find((directive) => directive.startsWith('script-src '))
-			?.split(' ')
-			.slice(1);
-
-		expect(scriptSources).toContain('https://static.cloudflareinsights.com/beacon.min.js');
-		expect(scriptSources).not.toContain('https://static.cloudflareinsights.com');
-	});
 });
 
 describe('404 request logging', () => {

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -56,7 +56,7 @@ const contentSecurityPolicy = Object.entries(cspDirectives)
 	.map(([directive, values]) => `${directive} ${values.join(' ')}`)
 	.join('; ');
 
-export const csp: Handle = async ({ event, resolve }) => {
+const csp: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
 	response.headers.set('Content-Security-Policy', contentSecurityPolicy);
 	return response;

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -24,6 +24,7 @@ const cspDirectives: Record<string, string[]> = {
 		"'self'",
 		"'unsafe-inline'",
 		"'wasm-unsafe-eval'",
+		'https://static.cloudflareinsights.com/beacon.min.js',
 		'https://platform.twitter.com',
 		'https://www.googletagmanager.com',
 		'https://embed.nicovideo.jp'
@@ -55,7 +56,7 @@ const contentSecurityPolicy = Object.entries(cspDirectives)
 	.map(([directive, values]) => `${directive} ${values.join(' ')}`)
 	.join('; ');
 
-const csp: Handle = async ({ event, resolve }) => {
+export const csp: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
 	response.headers.set('Content-Security-Policy', contentSecurityPolicy);
 	return response;


### PR DESCRIPTION
### Motivation
- Cloudflare Web Analytics' injected beacon script (`https://static.cloudflareinsights.com/beacon.min.js`) was being blocked by the current Content Security Policy served from `web/src/hooks.server.ts`.

### Description
- Add the exact beacon URL `https://static.cloudflareinsights.com/beacon.min.js` to the `script-src` directive in `web/src/hooks.server.ts` without permitting the entire `https://static.cloudflareinsights.com` origin.
- Leave the other CSP directives unchanged and do not add a manual Cloudflare Web Analytics embed.

### Testing
- GitHub Actions passed: `unit-test`, `lint` / `check`, and `e2e-test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa1fed9c780832ea1a0a883b5537b2f)