### PR TITLE
Allow versioned Cloudflare Web Analytics beacon paths

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -25,6 +25,7 @@ const cspDirectives: Record<string, string[]> = {
 		"'unsafe-inline'",
 		"'wasm-unsafe-eval'",
 		'https://static.cloudflareinsights.com/beacon.min.js',
+		'https://static.cloudflareinsights.com/beacon.min.js/',
 		'https://platform.twitter.com',
 		'https://www.googletagmanager.com',
 		'https://embed.nicovideo.jp'


### PR DESCRIPTION
### Motivation
- Cloudflare Web Analytics serves the beacon script using versioned paths like `/beacon.min.js/v...`, which the existing exact CSP source did not match and therefore blocked.

### Description
- Add `https://static.cloudflareinsights.com/beacon.min.js/` to the `script-src` in `web/src/hooks.server.ts` so versioned beacon paths are allowed while keeping the exact `https://static.cloudflareinsights.com/beacon.min.js` entry and not widening the origin or other directives.

### Testing
- On Node.js v24 ran `npm run lint`, `npm run check`, and `npm test -- --run`, and verified `git diff --check` to ensure only the intended CSP line change exists, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa20d0b281c832eb6e912ab90b800ee)