### PR TITLE
Centralize relay URL policy and restrict insecure relays to loopback

### DIFF
--- a/web/src/lib/Constants.ts
+++ b/web/src/lib/Constants.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import { kinds as Kind, type Event as NostrEvent } from 'nostr-tools';
 import { unique } from './array';
 import { Emojisets } from 'nostr-tools/kinds';
@@ -95,7 +96,7 @@ export const categoriesKinds = {
 export const categories = Object.keys(categoriesKinds);
 
 const defaultRelayUrls = import.meta.env.VITE_DEFAULT_RELAYS
-	? import.meta.env.VITE_DEFAULT_RELAYS.split(',')
+	? normalizeRelayUrls(import.meta.env.VITE_DEFAULT_RELAYS.split(','))
 	: ['wss://nos.lol/', 'wss://relay.damus.io/'];
 
 export const defaultRelays = defaultRelayUrls.map((url) => ({
@@ -130,13 +131,13 @@ export const localizedRelays = {
 };
 
 const metadataRelayUrls = import.meta.env.VITE_METADATA_RELAYS
-	? import.meta.env.VITE_METADATA_RELAYS.split(',')
+	? normalizeRelayUrls(import.meta.env.VITE_METADATA_RELAYS.split(','))
 	: ['wss://purplepag.es/', 'wss://user.kindpag.es/', 'wss://directory.yabu.me/'];
 
 export const metadataRelays = metadataRelayUrls.map((url) => url.trim());
 
 const searchRelayUrls = import.meta.env.VITE_SEARCH_RELAYS
-	? import.meta.env.VITE_SEARCH_RELAYS.split(',')
+	? normalizeRelayUrls(import.meta.env.VITE_SEARCH_RELAYS.split(','))
 	: ['wss://nostr.wine/', 'wss://search.nos.today/'];
 
 export const searchRelays = searchRelayUrls.map((url) => url.trim());

--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrl } from '$lib/nostr/relay-url';
 import type { Event } from 'nostr-tools';
 import type { id } from './Types';
 import { hexRegexp, shortcodeRegexp } from './Constants';
@@ -77,13 +78,9 @@ export function parseRelayJson(content: string): Map<string, { read: boolean; wr
 			Object.entries(JSON.parse(content))
 		);
 		return new Map(
-			[...relays].filter(([relay]) => {
-				try {
-					const url = new URL(relay);
-					return url.protocol === 'wss:' || url.protocol === 'ws:';
-				} catch {
-					return false;
-				}
+			[...relays].flatMap(([relay, permission]) => {
+				const url = normalizeRelayUrl(relay);
+				return url === undefined ? [] : [[url, permission] as const];
 			})
 		);
 	} catch (error) {

--- a/web/src/lib/Poll.ts
+++ b/web/src/lib/Poll.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import { rxNostr } from './timelines/MainTimeline';
 
 export const pollKind = 1068;
@@ -11,6 +12,6 @@ export function vote(id: string, optionIds: string[], relays: string[]): void {
 			content: '',
 			tags: [['e', id], ...optionIds.map((id) => ['response', id])]
 		},
-		{ on: { defaultWriteRelays: true, relays } }
+		{ on: { defaultWriteRelays: true, relays: normalizeRelayUrls(relays) } }
 	);
 }

--- a/web/src/lib/RemoteSigner.ts
+++ b/web/src/lib/RemoteSigner.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import { NostrConnect } from 'nostr-tools/kinds';
 import { toBunkerURL } from 'nostr-tools/nip46';
 import { createRxForwardReq, createRxNostr, now, uniq, type RxNostr } from 'rx-nostr';
@@ -17,7 +18,8 @@ class RemoteSigner {
 	#subscription?: Subscription;
 
 	constructor(relays: string[] = []) {
-		this.#relays = relays.length > 0 ? relays : ['wss://ephemeral.snowflare.cc/'];
+		this.#relays =
+			relays.length > 0 ? normalizeRelayUrls(relays) : ['wss://ephemeral.snowflare.cc/'];
 		this.#secret = persistedStore<string>('remote-signer:secret', '');
 		this.#clientPubkey = persistedStore<string>('remote-signer:client-pubkey', '');
 		this.#rxNostr = createRxNostr({ verifier: verificationClient.verifier });

--- a/web/src/lib/RxNostrHelper.ts
+++ b/web/src/lib/RxNostrHelper.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import { referencesReqEmit, rxNostr, tie } from '$lib/timelines/MainTimeline';
 import type * as Nostr from 'nostr-typedef';
 import {
@@ -34,7 +35,7 @@ export async function fetchLastEvent(
 		let lastEvent: Nostr.Event | undefined;
 		const req = createRxBackwardReq();
 		rxNostr
-			.use(req, { on })
+			.use(req, { on: on && { ...on, relays: on.relays && normalizeRelayUrls(on.relays) } })
 			.pipe(tie, latest())
 			.subscribe({
 				next: ({ from, event }) => {
@@ -84,7 +85,7 @@ export async function fetchEvents(
 			}
 		});
 	if (relays !== undefined && relays.length > 0) {
-		req.emit(filters, { relays });
+		req.emit(filters, { relays: normalizeRelayUrls(relays) });
 	} else {
 		req.emit(filters);
 	}

--- a/web/src/lib/author/RelayList.ts
+++ b/web/src/lib/author/RelayList.ts
@@ -3,6 +3,7 @@ import { createRxBackwardReq, latestEach, uniq } from 'rx-nostr';
 import { rxNostr, tie } from '../timelines/MainTimeline';
 import { parseRelayJson } from '../EventHelper';
 import { WebStorage } from '../WebStorage';
+import { parseRelayList } from '$lib/nostr/nip65';
 import { metadataRelays } from '$lib/Constants';
 
 export class RelayList {
@@ -61,7 +62,7 @@ export class RelayList {
 		const kind10002 = eventsMap.get(10002);
 		const kind3 = eventsMap.get(3);
 		if (kind10002 !== undefined && kind10002.tags.length > 0) {
-			rxNostr.setDefaultRelays(kind10002.tags);
+			rxNostr.setDefaultRelays(parseRelayList(kind10002.tags));
 		} else if (kind3 !== undefined && kind3.content !== '') {
 			rxNostr.setDefaultRelays(
 				[...parseRelayJson(kind3.content)].map(([url, { read, write }]) => {

--- a/web/src/lib/components/Badges.svelte
+++ b/web/src/lib/components/Badges.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 	import { run } from 'svelte/legacy';
 
 	import { _ } from 'svelte-i18n';
@@ -51,7 +52,11 @@
 			let displayedEvent: Nostr.Event | undefined;
 			rxNostr
 				.use(profileBadgesReq, {
-					on: { defaultReadRelays: !isAuthor, defaultWriteRelays: isAuthor, relays }
+					on: {
+						defaultReadRelays: !isAuthor,
+						defaultWriteRelays: isAuthor,
+						relays: normalizeRelayUrls(relays)
+					}
 				})
 				.pipe(
 					tie,
@@ -86,9 +91,9 @@
 							definitions: new Set(definitionAddresses)
 						};
 
-						const awardRelays = awardTags
-							.map(([, , relay]) => relay)
-							.filter((relay) => relay !== undefined && URL.canParse(relay));
+						const awardRelays = normalizeRelayUrls(
+							awardTags.map(([, , relay]) => relay)
+						);
 
 						const awardsReq = createRxBackwardReq();
 						rxNostr
@@ -128,9 +133,9 @@
 							},
 							new Map<string, Set<string>>()
 						);
-						const definitionRelays = definitionTags
-							.map(([, , relay]) => relay)
-							.filter((relay) => relay !== undefined && URL.canParse(relay));
+						const definitionRelays = normalizeRelayUrls(
+							definitionTags.map(([, , relay]) => relay)
+						);
 
 						const definitionsReq = createRxBackwardReq();
 						rxNostr

--- a/web/src/lib/nostr-tools/nip47.ts
+++ b/web/src/lib/nostr-tools/nip47.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrl } from '$lib/nostr/relay-url';
 import { nip04, finalizeEvent, type VerifiedEvent } from 'nostr-tools';
 import { kinds } from 'nostr-tools';
 
@@ -10,7 +11,7 @@ interface NWCConnection {
 export function parseConnectionString(connectionString: string): NWCConnection {
 	const { hostname, pathname, searchParams } = new URL(connectionString);
 	const pubkey = hostname ? hostname : pathname.replaceAll('/', '');
-	const relay = searchParams.get('relay');
+	const relay = normalizeRelayUrl(searchParams.get('relay'));
 	const secret = searchParams.get('secret');
 
 	if (!pubkey || !relay || !secret) {

--- a/web/src/lib/nostr/nip65.test.ts
+++ b/web/src/lib/nostr/nip65.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { parseRelayList } from './nip65';
 
-const URL1 = 'wss://relay.example.com';
+const URL1 = 'wss://relay.example.com/';
 
 describe('parseRelayList', () => {
 	it('no marker → read and write', () => {
-		expect(parseRelayList([['r', URL1]])).toEqual([{ url: URL1, read: true, write: true }]);
+		expect(parseRelayList([['r', 'wss://RELAY.EXAMPLE.COM:443']])).toEqual([
+			{ url: URL1, read: true, write: true }
+		]);
 	});
 
 	it('"read" marker → read only', () => {
@@ -23,6 +25,7 @@ describe('parseRelayList', () => {
 	it('invalid relay URL → excluded', () => {
 		const result = parseRelayList([
 			['r', 'not-a-url'],
+			['r', 'ws://nos.lol'],
 			['r', URL1]
 		]);
 		expect(result).toHaveLength(1);

--- a/web/src/lib/nostr/nip65.ts
+++ b/web/src/lib/nostr/nip65.ts
@@ -1,22 +1,15 @@
+import { normalizeRelayUrl } from '$lib/nostr/relay-url';
 export interface RelayEntry {
 	url: string;
 	read: boolean;
 	write: boolean;
 }
 
-function isRelayUrl(value: string): boolean {
-	try {
-		const { protocol } = new URL(value);
-		return protocol === 'wss:' || protocol === 'ws:';
-	} catch {
-		return false;
-	}
-}
-
 export function parseRelayList(tags: string[][]): RelayEntry[] {
 	return tags.flatMap((tag): RelayEntry[] => {
-		const [name, url, marker] = tag;
-		if (name !== 'r' || !isRelayUrl(url)) return [];
+		const [name, value, marker] = tag;
+		const url = normalizeRelayUrl(value);
+		if (name !== 'r' || url === undefined) return [];
 
 		if (marker === undefined) return [{ url, read: true, write: true }];
 		if (marker === 'read') return [{ url, read: true, write: false }];

--- a/web/src/lib/nostr/relay-hints.ts
+++ b/web/src/lib/nostr/relay-hints.ts
@@ -2,6 +2,7 @@ import { createTie } from '$lib/RxNostrTie';
 
 export const [tie, seenOn] = createTie();
 
+// Share only secure relay hints; a recipient's loopback refers to a different machine.
 export function getRelayHint(id: string): string | undefined {
 	return seenOn
 		.get(id)

--- a/web/src/lib/nostr/relay-json.test.ts
+++ b/web/src/lib/nostr/relay-json.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from 'vitest';
+import { parseRelayJson } from '../EventHelper';
+
+it('normalizes legacy relay keys, filters unusable URLs, and preserves permissions', () => {
+	const relays = parseRelayJson(
+		JSON.stringify({
+			'wss://READ.EXAMPLE:443': { read: true, write: false },
+			'wss://write.example': { read: false, write: true },
+			'ws://nos.lol': { read: true, write: true }
+		})
+	);
+	expect([...relays]).toEqual([
+		['wss://read.example/', { read: true, write: false }],
+		['wss://write.example/', { read: false, write: true }]
+	]);
+});
+
+it('ignores malformed legacy JSON', () => {
+	expect(parseRelayJson('{')).toEqual(new Map());
+});

--- a/web/src/lib/nostr/relay-url.test.ts
+++ b/web/src/lib/nostr/relay-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRelayUrl, normalizeRelayUrls } from './relay-url';
+
+describe('normalizeRelayUrl', () => {
+	it.each([
+		['wss://relay.example.com', 'wss://relay.example.com/'],
+		['wss://relay.example.com:443/path', 'wss://relay.example.com/path'],
+		[' WSS://RELAY.EXAMPLE.COM:443/a/../path?x=1 ', 'wss://relay.example.com/path?x=1'],
+		['ws://localhost', 'ws://localhost/'],
+		['ws://localhost:7777', 'ws://localhost:7777/'],
+		['ws://localhost.', 'ws://localhost./'],
+		['ws://foo.localhost', 'ws://foo.localhost/'],
+		['ws://foo.localhost.', 'ws://foo.localhost./'],
+		['ws://FOO.LOCALHOST:80', 'ws://foo.localhost/'],
+		['ws://127.0.0.1', 'ws://127.0.0.1/'],
+		['ws://127.0.0.0', 'ws://127.0.0.0/'],
+		['ws://127.42.1.2:7777', 'ws://127.42.1.2:7777/'],
+		['ws://127.255.255.255', 'ws://127.255.255.255/'],
+		['ws://127.1', 'ws://127.0.0.1/'],
+		['ws://2130706433', 'ws://127.0.0.1/'],
+		['ws://0x7f000001', 'ws://127.0.0.1/'],
+		['ws://[::1]', 'ws://[::1]/'],
+		['ws://[::1]:7777', 'ws://[::1]:7777/'],
+		['ws://[0:0:0:0:0:0:0:1]', 'ws://[::1]/']
+	])('normalizes %s', (input, expected) => {
+		expect(normalizeRelayUrl(input)).toBe(expected);
+		expect(normalizeRelayUrl(expected)).toBe(expected);
+	});
+
+	it.each([
+		'ws://nos.lol',
+		'ws://nostr.mom',
+		'ws://umbrel.local',
+		'ws://192.168.1.1',
+		'ws://10.0.0.1',
+		'ws://172.16.0.1',
+		'ws://localhost.example.com',
+		'ws://notlocalhost',
+		'ws://127.0.0.1.example.com',
+		'ws://localhost@nos.lol',
+		'ws://126.255.255.255',
+		'ws://128.0.0.0',
+		'ws://[::]',
+		'ws://[::ffff:127.0.0.1]',
+		'http://relay.example.com',
+		'https://relay.example.com',
+		'ftp://relay.example.com',
+		'not-a-url',
+		'wss://',
+		'ws://127.0.0.999',
+		'ws://[::1',
+		'ws://localhost:99999',
+		'',
+		null,
+		undefined,
+		42
+	])('rejects %s', (input) => {
+		expect(normalizeRelayUrl(input)).toBeUndefined();
+	});
+});
+
+it('normalizes relay lists and excludes unusable entries', () => {
+	expect(normalizeRelayUrls(['wss://RELAY.EXAMPLE.COM:443', 'ws://nos.lol', undefined])).toEqual([
+		'wss://relay.example.com/'
+	]);
+});

--- a/web/src/lib/nostr/relay-url.ts
+++ b/web/src/lib/nostr/relay-url.ts
@@ -1,0 +1,25 @@
+/** Return a canonical relay URL, or undefined when nostter cannot use it. */
+export function normalizeRelayUrl(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	try {
+		const url = new URL(value);
+		if (url.protocol !== 'wss:' && url.protocol !== 'ws:') return undefined;
+		if (url.protocol === 'ws:') {
+			const hostname = url.hostname.replace(/\.$/, '');
+			// URL parsing canonicalizes IPv4 (including shortened/numeric forms) and IPv6.
+			const loopback =
+				hostname === 'localhost' ||
+				hostname.endsWith('.localhost') ||
+				/^127\.\d+\.\d+\.\d+$/.test(hostname) ||
+				hostname === '[::1]';
+			if (!loopback) return undefined;
+		}
+		return url.href;
+	} catch {
+		return undefined;
+	}
+}
+
+export function normalizeRelayUrls(values: readonly unknown[]): string[] {
+	return values.map(normalizeRelayUrl).filter((url) => url !== undefined);
+}

--- a/web/src/lib/signer-strategy.ts
+++ b/web/src/lib/signer-strategy.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import {
 	type Event,
 	nip19,
@@ -25,6 +26,8 @@ let nip46CachedPublicKey: string | undefined;
 export async function establishBunkerConnection(bunker: string): Promise<void> {
 	const bunkerPointer = await parseBunkerInput(bunker);
 	if (!bunkerPointer) throw new Error(`Failed to parse bunker URL`);
+	bunkerPointer.relays = normalizeRelayUrls(bunkerPointer.relays);
+	if (bunkerPointer.relays.length === 0) throw new Error('No usable bunker relays');
 
 	const storage = new WebStorage(localStorage);
 	const clientSeckeyHex = storage.get('login:bunker:client-seckey');

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import { get, writable } from 'svelte/store';
 import type * as Nostr from 'nostr-typedef';
 import { ShortTextNote } from 'nostr-tools/kinds';
@@ -141,7 +142,9 @@ function requestEventReferences(event: Nostr.Event, content: string): void {
 			return;
 		}
 		const requested = requestedRelays.get(id) ?? new Set<string>();
-		const candidates = new Map(candidateRelays.map((relay) => [relayKey(relay), relay]));
+		const candidates = new Map(
+			normalizeRelayUrls(candidateRelays).map((relay) => [relayKey(relay), relay])
+		);
 		const relays = [...candidates]
 			.filter(([key]) => !requested.has(key))
 			.map(([, relay]) => relay);
@@ -161,9 +164,7 @@ function requestEventReferences(event: Nostr.Event, content: string): void {
 			['e', 'q'].includes(tagName) &&
 			typeof id === 'string' &&
 			hexRegexp.test(id) &&
-			typeof relay === 'string' &&
-			relay.startsWith('wss://') &&
-			URL.canParse(relay)
+			typeof relay === 'string'
 	);
 	if (referenceTags.length > 0 || event.kind === ShortTextNote) {
 		// If not found, try relay hints, referenced authors' write relays, and the replying author's read relays.
@@ -255,15 +256,10 @@ function requestReplaceableReferences(event: Nostr.Event): void {
 					};
 		});
 		replaceableEventsReq.emit(filters);
-		const relays = aTags
-			.map(([, , relayUrl]) => relayUrl)
-			.filter(
-				(relayUrl) =>
-					typeof relayUrl === 'string' &&
-					relayUrl.startsWith('wss://') &&
-					URL.canParse(relayUrl) &&
-					!Object.entries(rxNostr.getDefaultRelays()).some(([url]) => url === relayUrl)
-			);
+		const relays = normalizeRelayUrls(aTags.map(([, , relayUrl]) => relayUrl)).filter(
+			(relayUrl) =>
+				!Object.entries(rxNostr.getDefaultRelays()).some(([url]) => url === relayUrl)
+		);
 		if (relays.length > 0) {
 			replaceableEventsReq.emit(filters, { relays });
 		}

--- a/web/src/routes/(app)/[slug=naddr]/+page.svelte
+++ b/web/src/routes/(app)/[slug=naddr]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 	import { _ } from 'svelte-i18n';
 	import { error } from '@sveltejs/kit';
 	import type { Event } from 'nostr-tools';
@@ -28,7 +29,7 @@
 		console.log('[naddr page]', data);
 
 		await Promise.allSettled(
-			data.relays.map((relay) =>
+			normalizeRelayUrls(data.relays).map((relay) =>
 				rxNostr.addDefaultRelays([{ url: relay, write: false, read: true }])
 			)
 		);

--- a/web/src/routes/(app)/[slug=npub]/pins/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/pins/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 	import { onDestroy } from 'svelte';
 	import { createRxNostr, createRxOneshotReq, latest, uniq } from 'rx-nostr';
 	import { firstValueFrom, EmptyError } from 'rxjs';
@@ -29,7 +30,7 @@
 		const slug = $page.params.slug;
 		console.debug('[pin page]', slug);
 
-		rxNostr.setDefaultRelays([...$readRelays, ...data.relays]);
+		rxNostr.setDefaultRelays([...$readRelays, ...normalizeRelayUrls(data.relays)]);
 
 		let event: Nostr.Event | undefined;
 		if (data.pubkey === $authorPubkey) {

--- a/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { normalizeRelayUrl } from '$lib/nostr/relay-url';
 	import { _ } from 'svelte-i18n';
 	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
@@ -67,15 +68,14 @@
 	function add(e: MouseEvent) {
 		e.preventDefault();
 		console.log('[add relay]', addingRelay);
-		try {
-			const relay = new URL(addingRelay).href;
-			relays.push({ url: relay, read: true, write: true });
-			relays = relays;
-			addingRelay = '';
-		} catch (error) {
-			console.log('[add relay error]', addingRelay, error);
+		const relay = normalizeRelayUrl(addingRelay);
+		if (relay === undefined) {
 			alert(`Failed to add ${addingRelay}.`);
+			return;
 		}
+		relays.push({ url: relay, read: true, write: true });
+		relays = relays;
+		addingRelay = '';
 	}
 
 	function remove(relay: string) {

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelChat.svelte.ts
@@ -1,3 +1,4 @@
+import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 import type { Event } from 'nostr-tools';
 import {
 	ChannelCreation,
@@ -67,9 +68,11 @@ export class ChannelChat {
 			on: {
 				defaultReadRelays: true,
 				relays: unique(
-					[...relays, ...contentRelays(kind40), ...contentRelays(kind41)].filter(
-						(relay) => relay.startsWith('wss://')
-					)
+					normalizeRelayUrls([
+						...relays,
+						...contentRelays(kind40),
+						...contentRelays(kind41)
+					])
 				)
 			}
 		};

--- a/web/src/routes/(app)/relays/[url]/+layout.server.ts
+++ b/web/src/routes/(app)/relays/[url]/+layout.server.ts
@@ -1,10 +1,13 @@
+import { normalizeRelayUrl } from '$lib/nostr/relay-url';
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import type * as Nostr from 'nostr-typedef';
 
 export const load: LayoutServerLoad = async ({ params }) => {
 	try {
-		const url = new URL(decodeURIComponent(params.url));
+		const relay = normalizeRelayUrl(decodeURIComponent(params.url));
+		if (relay === undefined) error(404, 'Not Found');
+		const url = new URL(relay);
 		url.protocol = url.protocol === 'ws:' ? 'http:' : 'https:';
 		const response = await fetch(url, {
 			headers: {

--- a/web/src/routes/(app)/relays/[url]/+page.svelte
+++ b/web/src/routes/(app)/relays/[url]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { normalizeRelayUrls } from '$lib/nostr/relay-url';
 	import { createRxOneshotReq, now } from 'rx-nostr';
 	import { tap } from 'rxjs';
 	import { afterNavigate } from '$app/navigation';
@@ -47,7 +48,7 @@
 				rxNostr
 					.use(pastEventsReq, {
 						on: {
-							relays: ['ws' + data.url.substring(4)],
+							relays: normalizeRelayUrls(['ws' + data.url.substring(4)]),
 							defaultReadRelays: false
 						}
 					})


### PR DESCRIPTION
Relay URL validation was scattered across NIP-65 parsing, legacy kind 3 JSON, relay settings, and other connection paths. This allowed public `ws://` relays to trigger unusable NIP-11 HTTP requests from the HTTPS app.

- Centralize validation and WHATWG URL normalization in `relay-url.ts`, returning a canonical URL or `undefined`.
- Allow `wss://` and restrict `ws://` to localhost (including subdomains and trailing dots), IPv4 127/8, and IPv6 ::1. Reject public/LAN `ws://` relays before use, preventing their unnecessary NIP-11 HTTP requests.
- Apply the policy to relay lists/settings, request relay hints, NWC, NIP-46/remote signer, and environment configuration. Preserve read/write markers and the existing secure-only sharing of relay hints.
- Add policy unit tests and legacy JSON coverage; update NIP-65 tests for normalization and filtering. CSP, rx-nostr, and NIP-11 URL conversion are unchanged.

Validation on Node.js v24.20.0, run sequentially:
- `npm run check` — passed, no errors or warnings
- `npm run lint` — passed
- `npm test` — 43 files, 431 tests passed
- `npm run test:e2e` — 1 test passed after installing missing Chromium and OS dependencies
- `git diff --check` and final diff review — passed

Based on the latest `main` (`afdb1ac8`), rechecked before publishing.
