### PR TITLE
Use only secure relays from other users' relay lists

### DIFF
--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -547,7 +547,7 @@
 					.flatMap(([, relayListEvent]) =>
 						getReadRelays(parseRelayList(relayListEvent.tags))
 					)
-					.filter((url) => !sendToRelays.includes(url));
+					.filter((url) => url.startsWith('wss://') && !sendToRelays.includes(url));
 				console.log('[rx-nostr send addition]', readRelays, relayListEventsMap);
 				if (readRelays.length === 0) {
 					return;

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -211,11 +211,16 @@ async function requestNip10References(
 		if (relayList === undefined) {
 			continue;
 		}
-		requestReference(reference.id, getWriteRelays(parseRelayList(relayList.tags)));
+		requestReference(
+			reference.id,
+			getWriteRelays(parseRelayList(relayList.tags)).filter((url) => url.startsWith('wss://'))
+		);
 	}
 	const relayList = relayLists.get(event.pubkey);
 	if (relayList !== undefined) {
-		const relays = getReadRelays(parseRelayList(relayList.tags));
+		const relays = getReadRelays(parseRelayList(relayList.tags)).filter((url) =>
+			url.startsWith('wss://')
+		);
 		const ids = unique(references.map((reference) => reference.id));
 		for (const id of ids) {
 			requestReference(id, relays);


### PR DESCRIPTION
Filter other users' kind 10002 relay lists to `wss://` immediately before reference fetching in `MainTimeline.ts` and additional reply publishing in `NoteComposer.svelte`. This prevents these additional connections from triggering NIP-11 HTTP requests for `ws://` relays.

Reference fetching preserves the current user's own relay list. No parser, relay settings, helper, or test changes.

Validated sequentially on Node.js v24.20.0: `npm run check`, `npm run lint`, and `npm test` (41 files, 383 tests passed). Final diff reviewed; only the two connection paths changed.
