### PR TITLE
Support replaceable event deletion requests

### DIFF
--- a/web/src/lib/EventHelper.test.ts
+++ b/web/src/lib/EventHelper.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { getZapperPubkey, isLegacyEncryption, parseAddress, referTags } from './EventHelper';
+import {
+	aTagContent,
+	getZapperPubkey,
+	isLegacyEncryption,
+	parseAddress,
+	referTags
+} from './EventHelper';
 import { generateSecretKey, getPublicKey, nip04, nip44 } from 'nostr-tools';
+
+describe('aTagContent', () => {
+	it('distinguishes normal replaceable and addressable coordinates', () => {
+		const base = { pubkey: 'pubkey', content: '', created_at: 0, id: '', sig: '' };
+		expect(aTagContent({ ...base, kind: 10003, tags: [['d', 'ignored']] })).toBe(
+			'10003:pubkey:'
+		);
+		expect(aTagContent({ ...base, kind: 30001, tags: [['d', 'bookmark']] })).toBe(
+			'30001:pubkey:bookmark'
+		);
+	});
+});
 
 describe('referTags', () => {
 	it('root', () => {

--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -1,4 +1,5 @@
 import type { Event } from 'nostr-tools';
+import { isAddressableKind } from 'nostr-tools/kinds';
 import type { id } from './Types';
 import { hexRegexp, shortcodeRegexp } from './Constants';
 
@@ -124,7 +125,8 @@ export function getTagContent(tagName: string, tags: string[][]): string {
 }
 
 export function aTagContent(event: Event): string {
-	return `${event.kind}:${event.pubkey}:${findIdentifier(event.tags) ?? ''}`;
+	const identifier = isAddressableKind(event.kind) ? (findIdentifier(event.tags) ?? '') : '';
+	return `${event.kind}:${event.pubkey}:${identifier}`;
 }
 
 export function getZapperPubkey(event: Event): string | undefined {

--- a/web/src/lib/author/Delete.test.ts
+++ b/web/src/lib/author/Delete.test.ts
@@ -17,8 +17,13 @@ vi.mock('$lib/timelines/MainTimeline', () => ({ rxNostr: { send: mocks.send } })
 
 import { requestEventDeletion } from './Delete';
 
-function event(id: string, kind: number, pubkey = mocks.userPubkey): Nostr.Event {
-	return { id, kind, pubkey, content: '', tags: [], created_at: 1, sig: 'sig' };
+function event(
+	id: string,
+	kind: number,
+	pubkey = mocks.userPubkey,
+	tags: string[][] = []
+): Nostr.Event {
+	return { id, kind, pubkey, content: '', tags, created_at: 1, sig: 'sig' };
 }
 
 beforeEach(() => {
@@ -31,12 +36,18 @@ beforeEach(() => {
 });
 
 describe('requestEventDeletion', () => {
-	it('signs a kind 5 request and waits for a relay acceptance', async () => {
+	it('signs a mixed kind 5 request and waits for a relay acceptance', async () => {
 		const responses = new Subject<{ ok: boolean }>();
 		mocks.send.mockReturnValue(responses);
 		let resolved = false;
 		const request = requestEventDeletion(
-			[event('first', 1), event('second', 7), event('third', 1)],
+			[
+				event('regular', 1),
+				event('replaceable', 10003, mocks.userPubkey, [['d', 'ignored']]),
+				event('newer-replaceable', 10003, mocks.userPubkey, [['d', 'also-ignored']]),
+				event('addressable', 30001, mocks.userPubkey, [['d', 'bookmark']]),
+				event('newer-addressable', 30001, mocks.userPubkey, [['d', 'bookmark']])
+			],
 			'duplicate'
 		).then(() => {
 			resolved = true;
@@ -49,11 +60,12 @@ describe('requestEventDeletion', () => {
 				pubkey: mocks.userPubkey,
 				content: 'duplicate',
 				tags: [
-					['e', 'first'],
-					['e', 'second'],
-					['e', 'third'],
+					['e', 'regular'],
+					['a', `10003:${mocks.userPubkey}:`],
+					['a', `30001:${mocks.userPubkey}:bookmark`],
 					['k', '1'],
-					['k', '7']
+					['k', '10003'],
+					['k', '30001']
 				]
 			})
 		);

--- a/web/src/lib/author/Delete.ts
+++ b/web/src/lib/author/Delete.ts
@@ -45,10 +45,9 @@ export async function requestEventDeletion(
 
 	const targetTags = new Map<string, string[]>();
 	for (const event of events) {
-		const tag = isAddressableKind(event.kind)
-			? ['a', aTagContent(event)]
-			: isReplaceableKind(event.kind)
-				? ['a', `${event.kind}:${event.pubkey}:`]
+		const tag =
+			isReplaceableKind(event.kind) || isAddressableKind(event.kind)
+				? ['a', aTagContent(event)]
 				: ['e', event.id];
 		targetTags.set(`${tag[0]}:${tag[1]}`, tag);
 	}

--- a/web/src/lib/author/Delete.ts
+++ b/web/src/lib/author/Delete.ts
@@ -1,10 +1,11 @@
 import { get, writable } from 'svelte/store';
 import { now } from 'rx-nostr';
+import { isAddressableKind, isReplaceableKind } from 'nostr-tools/kinds';
 import type * as Nostr from 'nostr-typedef';
 import { pubkey as authorPubkey } from '$lib/stores/Author';
 import { rxNostr } from '$lib/timelines/MainTimeline';
 import { Signer } from '$lib/Signer';
-import { filterTags } from '$lib/EventHelper';
+import { aTagContent, filterTags } from '$lib/EventHelper';
 
 export const deletedEventIds = writable(new Set<string>());
 export const deletedEventIdsByPubkey = writable(new Map<string, Set<string>>());
@@ -42,12 +43,22 @@ export async function requestEventDeletion(
 		throw new Error('Cannot request deletion of an event by another author');
 	}
 
+	const targetTags = new Map<string, string[]>();
+	for (const event of events) {
+		const tag = isAddressableKind(event.kind)
+			? ['a', aTagContent(event)]
+			: isReplaceableKind(event.kind)
+				? ['a', `${event.kind}:${event.pubkey}:`]
+				: ['e', event.id];
+		targetTags.set(`${tag[0]}:${tag[1]}`, tag);
+	}
+
 	const event = await Signer.signEvent({
 		kind: 5,
 		pubkey: $authorPubkey,
 		content: reason,
 		tags: [
-			...events.map((event) => ['e', event.id]),
+			...targetTags.values(),
 			...[...new Set(events.map((event) => event.kind))].map((kind) => ['k', `${kind}`])
 		],
 		created_at: now()


### PR DESCRIPTION
- Generate `e` deletion references for regular events and `a` references for replaceable and addressable events.
- Use NIP-01 coordinates and deduplicate multiple versions of the same deletion target.
- Keep the existing relay acceptance and subscription behavior.

Related to #2309.
