### PR TITLE
Add coding guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,6 @@ npx playwright install
 See the [coding guidelines](docs/coding-guidelines.md) for conventions that apply to `web/src`.
 
 - Keep changes focused on the purpose of the pull request.
-- Follow the existing code style.
 - Add or update tests when changing behavior.
 - Avoid unrelated refactoring or formatting changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ npx playwright install
 
 ## Making changes
 
+See the [coding guidelines](docs/coding-guidelines.md) for conventions that apply to `web/src`.
+
 - Keep changes focused on the purpose of the pull request.
 - Follow the existing code style.
 - Add or update tests when changing behavior.

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -1,0 +1,19 @@
+# Coding Guidelines
+
+These guidelines apply to `web/src`.
+
+## Naming
+
+Use kebab-case for new files and directories.
+
+Framework- or tool-defined names are exempt and should follow their respective conventions.
+
+Existing files and directories do not need to be renamed solely to comply with this convention.
+
+## Formatting
+
+Formatting is defined by [Prettier](../web/.prettierrc) and [EditorConfig](../.editorconfig).
+
+## Linting
+
+Linting rules are defined by [ESLint](../web/eslint.config.mjs).


### PR DESCRIPTION
## Summary

- add coding guidelines for `web/src`
- document kebab-case naming with framework- and tool-defined exceptions
- link the guidelines from `CONTRIBUTING.md`

## Validation

- `npx prettier --check ../docs/coding-guidelines.md`
- `git diff --cached --check` (before commit)