### PR TITLE
Move persisted store into platform storage

### DIFF
--- a/web/src/lib/RemoteSigner.test.ts
+++ b/web/src/lib/RemoteSigner.test.ts
@@ -36,7 +36,7 @@ vi.mock('./timelines/MainTimeline', () => ({
 	verificationClient: { verifier: vi.fn() }
 }));
 
-vi.mock('./persisted-store', () => ({
+vi.mock('$lib/platform/storage/persisted-store', () => ({
 	persistedStore: (_key: string, initialValue: string) => {
 		let value = initialValue;
 		const subscribers = new Set<(value: string) => void>();

--- a/web/src/lib/RemoteSigner.ts
+++ b/web/src/lib/RemoteSigner.ts
@@ -4,7 +4,7 @@ import { createRxForwardReq, createRxNostr, now, uniq, type RxNostr } from 'rx-n
 import { get } from 'svelte/store';
 import { pubkey } from './stores/Author';
 import type { Subscription } from 'rxjs';
-import { persistedStore } from './persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 import type { Persisted } from 'svelte-persisted-store';
 import { Signer } from './Signer';
 import { verificationClient } from './timelines/MainTimeline';

--- a/web/src/lib/SeenOnRelayIcon.ts
+++ b/web/src/lib/SeenOnRelayIcon.ts
@@ -1,3 +1,3 @@
-import { persistedStore } from '$lib/persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 
 export const seenOnRelayIcon = persistedStore<boolean>('preference:seen-on-relay-icon', false);

--- a/web/src/lib/ShowVia.ts
+++ b/web/src/lib/ShowVia.ts
@@ -1,3 +1,3 @@
-import { persistedStore } from '$lib/persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 
 export const showVia = persistedStore<boolean>('preference:show-via', false);

--- a/web/src/lib/author/Via.ts
+++ b/web/src/lib/author/Via.ts
@@ -1,5 +1,5 @@
 import { appName } from '$lib/Constants';
-import { persistedStore } from '$lib/persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 import { Handlerinformation } from 'nostr-tools/kinds';
 
 export const ViaOption = ['none', 'once', 'always'] as const;

--- a/web/src/lib/components/ZapDialog.svelte
+++ b/web/src/lib/components/ZapDialog.svelte
@@ -3,7 +3,7 @@
 	import QRCode from 'qrcode';
 	import { writeRelays } from '$lib/stores/Author';
 	import { createEventDispatcher } from 'svelte';
-	import { persistedStore } from '$lib/persisted-store';
+	import { persistedStore } from '$lib/platform/storage/persisted-store';
 	import { WebStorage } from '$lib/WebStorage';
 	import { Signer } from '$lib/Signer';
 	import { zapWithWalletConnect } from '$lib/Zap';

--- a/web/src/lib/platform/storage/persisted-store.ts
+++ b/web/src/lib/platform/storage/persisted-store.ts
@@ -1,5 +1,5 @@
 import { persisted, type Options, type Persisted } from 'svelte-persisted-store';
-import { appName } from './Constants';
+import { appName } from '../../Constants';
 
 export function persistedStore<StoreType, SerializerType = StoreType>(
 	key: string,

--- a/web/src/lib/preferences/AccountLocalPreferences.ts
+++ b/web/src/lib/preferences/AccountLocalPreferences.ts
@@ -1,4 +1,4 @@
-import { persistedStore } from '$lib/persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 import { defaultBlossomServerUrl } from '$lib/Constants';
 import type { Persisted } from 'svelte-persisted-store';
 import type { Writable } from 'svelte/store';

--- a/web/src/lib/preferences/AccountLocalPreferencesStore.test.ts
+++ b/web/src/lib/preferences/AccountLocalPreferencesStore.test.ts
@@ -23,7 +23,7 @@ const { persistedStore, storedValues } = vi.hoisted(() => {
 	};
 });
 
-vi.mock('$lib/persisted-store', () => ({ persistedStore }));
+vi.mock('$lib/platform/storage/persisted-store', () => ({ persistedStore }));
 
 import { getAccountLocalPreferences } from './AccountLocalPreferences';
 

--- a/web/src/lib/preferences/NotificationVisibility.svelte.ts
+++ b/web/src/lib/preferences/NotificationVisibility.svelte.ts
@@ -1,6 +1,6 @@
 import { followeesOfFollowees } from '$lib/author/MuteAutomatically';
 import { followees } from '$lib/stores/Author';
-import { persistedStore } from '$lib/persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 import { get } from 'svelte/store';
 
 export const notificationVisibilities = ['all', 'follows_of_follows', 'follows'] as const;

--- a/web/src/lib/preferences/UserStatus.ts
+++ b/web/src/lib/preferences/UserStatus.ts
@@ -1,3 +1,3 @@
-import { persistedStore } from '$lib/persisted-store';
+import { persistedStore } from '$lib/platform/storage/persisted-store';
 
 export const showUserStatus = persistedStore('preference:user-status', true);

--- a/web/src/routes/(app)/search/SearchForm.svelte
+++ b/web/src/routes/(app)/search/SearchForm.svelte
@@ -14,7 +14,7 @@
 	import { ChannelMessage, LongFormArticle, Poll, ShortTextNote } from 'nostr-tools/kinds';
 	import { writable } from 'svelte/store';
 	import { _ } from 'svelte-i18n';
-	import { persistedStore } from '$lib/persisted-store';
+	import { persistedStore } from '$lib/platform/storage/persisted-store';
 	import { pushSearchHistory, rankSearchHistory } from '$lib/SearchHistory';
 	import { IconX, IconTrash } from '@tabler/icons-svelte-runes';
 


### PR DESCRIPTION
## Summary

- Move the generic persisted storage helper into the platform/storage area defined by ARCHITECTURE.md
- Update all production imports and test mock paths to the new module location
- Remove the obsolete root-level module without adding a compatibility wrapper or barrel

## Runtime behavior

No runtime behavior changes. Persisted keys, the nostter key namespace, types, and serialization behavior are unchanged.

## Verification

- npm test -- src/lib/RemoteSigner.test.ts src/lib/preferences/AccountLocalPreferencesStore.test.ts
- npm test
- npm run check
- npm run lint