### PR TITLE
Move zap sender extraction into NIP-57 protocol

### DIFF
--- a/web/src/lib/EventHelper.test.ts
+++ b/web/src/lib/EventHelper.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { aTagContent, getZapperPubkey, isLegacyEncryption, parseAddress } from './EventHelper';
+import { aTagContent, isLegacyEncryption, parseAddress } from './EventHelper';
 import { generateSecretKey, getPublicKey, nip04, nip44 } from 'nostr-tools';
 
 describe('aTagContent', () => {
@@ -11,65 +11,6 @@ describe('aTagContent', () => {
 		expect(aTagContent({ ...base, kind: 30001, tags: [['d', 'bookmark']] })).toBe(
 			'30001:pubkey:bookmark'
 		);
-	});
-});
-
-describe('getZapperPubkey', () => {
-	it('P tag', () => {
-		expect(
-			getZapperPubkey({
-				pubkey: 'wallet',
-				kind: 9735,
-				content: '',
-				tags: [
-					['p', 'author'],
-					['P', 'zapper']
-				],
-				created_at: 0,
-				id: '',
-				sig: ''
-			})
-		).toBe('zapper');
-	});
-	it('description pubkey', () => {
-		expect(
-			getZapperPubkey({
-				pubkey: 'wallet',
-				kind: 9735,
-				content: '',
-				tags: [
-					['p', 'author'],
-					['description', JSON.stringify({ pubkey: 'zapper' })]
-				],
-				created_at: 0,
-				id: '',
-				sig: ''
-			})
-		).toBe('zapper');
-	});
-	it('none', () => {
-		expect(
-			getZapperPubkey({
-				pubkey: 'wallet',
-				kind: 9735,
-				content: '',
-				tags: [['p', 'author']],
-				created_at: 0,
-				id: '',
-				sig: ''
-			})
-		).toBe(undefined);
-		expect(
-			getZapperPubkey({
-				pubkey: 'wallet',
-				kind: 1,
-				content: '',
-				tags: [['p', 'author']],
-				created_at: 0,
-				id: '',
-				sig: ''
-			})
-		).toBe(undefined);
 	});
 });
 

--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -103,30 +103,6 @@ export function aTagContent(event: Event): string {
 	return `${event.kind}:${event.pubkey}:${identifier}`;
 }
 
-export function getZapperPubkey(event: Event): string | undefined {
-	if (event.kind !== 9735) {
-		return undefined;
-	}
-
-	const pubkey = filterTags('P', event.tags).at(0);
-	if (pubkey !== undefined) {
-		return pubkey;
-	}
-
-	const description = filterTags('description', event.tags).at(0);
-	if (description === undefined) {
-		return undefined;
-	}
-
-	try {
-		const event9734 = JSON.parse(description) as Event;
-		return event9734.pubkey;
-	} catch (error) {
-		console.warn('[kind 9735 description decode error]', event, error);
-		return undefined;
-	}
-}
-
 export function isNostrHex(hex: string): boolean {
 	return /[0-9a-f]{64}/.test(hex);
 }

--- a/web/src/lib/nostr/protocol/nip57.test.ts
+++ b/web/src/lib/nostr/protocol/nip57.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { getZapSenderPubkey } from './nip57';
+
+describe('getZapSenderPubkey', () => {
+	it('P tag', () => {
+		expect(
+			getZapSenderPubkey({
+				pubkey: 'wallet',
+				kind: 9735,
+				content: '',
+				tags: [
+					['p', 'author'],
+					['P', 'zapper']
+				],
+				created_at: 0,
+				id: '',
+				sig: ''
+			})
+		).toBe('zapper');
+	});
+	it('description pubkey', () => {
+		expect(
+			getZapSenderPubkey({
+				pubkey: 'wallet',
+				kind: 9735,
+				content: '',
+				tags: [
+					['p', 'author'],
+					['description', JSON.stringify({ pubkey: 'zapper' })]
+				],
+				created_at: 0,
+				id: '',
+				sig: ''
+			})
+		).toBe('zapper');
+	});
+	it('none', () => {
+		expect(
+			getZapSenderPubkey({
+				pubkey: 'wallet',
+				kind: 9735,
+				content: '',
+				tags: [['p', 'author']],
+				created_at: 0,
+				id: '',
+				sig: ''
+			})
+		).toBe(undefined);
+		expect(
+			getZapSenderPubkey({
+				pubkey: 'wallet',
+				kind: 1,
+				content: '',
+				tags: [['p', 'author']],
+				created_at: 0,
+				id: '',
+				sig: ''
+			})
+		).toBe(undefined);
+	});
+});

--- a/web/src/lib/nostr/protocol/nip57.ts
+++ b/web/src/lib/nostr/protocol/nip57.ts
@@ -1,18 +1,21 @@
 import type { Event } from 'nostr-tools';
 import { Zap } from 'nostr-tools/kinds';
-import { filterTags } from '../../EventHelper';
 
 export function getZapSenderPubkey(event: Event): string | undefined {
 	if (event.kind !== Zap) {
 		return undefined;
 	}
 
-	const pubkey = filterTags('P', event.tags).at(0);
+	const pubkey = event.tags.find(
+		([name, value]) => name === 'P' && value !== undefined && value !== ''
+	)?.[1];
 	if (pubkey !== undefined) {
 		return pubkey;
 	}
 
-	const description = filterTags('description', event.tags).at(0);
+	const description = event.tags.find(
+		([name, value]) => name === 'description' && value !== undefined && value !== ''
+	)?.[1];
 	if (description === undefined) {
 		return undefined;
 	}

--- a/web/src/lib/nostr/protocol/nip57.ts
+++ b/web/src/lib/nostr/protocol/nip57.ts
@@ -1,0 +1,27 @@
+import type { Event } from 'nostr-tools';
+import { Zap } from 'nostr-tools/kinds';
+import { filterTags } from '../../EventHelper';
+
+export function getZapSenderPubkey(event: Event): string | undefined {
+	if (event.kind !== Zap) {
+		return undefined;
+	}
+
+	const pubkey = filterTags('P', event.tags).at(0);
+	if (pubkey !== undefined) {
+		return pubkey;
+	}
+
+	const description = filterTags('description', event.tags).at(0);
+	if (description === undefined) {
+		return undefined;
+	}
+
+	try {
+		const event9734 = JSON.parse(description) as Event;
+		return event9734.pubkey;
+	} catch (error) {
+		console.warn('[kind 9735 description decode error]', event, error);
+		return undefined;
+	}
+}

--- a/web/src/lib/stores/Author.ts
+++ b/web/src/lib/stores/Author.ts
@@ -4,7 +4,8 @@ import type { User } from '../../routes/types';
 import type { Event } from 'nostr-tools';
 import { defaultRelays } from '$lib/Constants';
 import type { Author } from '$lib/Author';
-import { filterTags, findIdentifier, getZapperPubkey } from '$lib/EventHelper';
+import { filterTags, findIdentifier } from '$lib/EventHelper';
+import { getZapSenderPubkey } from '$lib/nostr/protocol/nip57';
 import { getReadRelays, getWriteRelays, parseRelayList } from '$lib/nostr/protocol/nip65';
 import { decryptListContent } from '$lib/List';
 import { auth } from '$lib/auth.svelte';
@@ -81,7 +82,7 @@ export const isMuteEvent = (event: Event) => {
 	}
 
 	if (event.kind === 9735) {
-		const zapperPubkey = getZapperPubkey(event);
+		const zapperPubkey = getZapSenderPubkey(event);
 		if (zapperPubkey !== undefined && isMutePubkey(zapperPubkey)) {
 			return true;
 		}
@@ -98,7 +99,7 @@ export const isMuteEvent = (event: Event) => {
 	const mutedPubkeysByKind = $mutedPubkeysByKindMap.get(event.kind);
 	if (mutedPubkeysByKind !== undefined) {
 		if (event.kind === 9735) {
-			const zapperPubkey = getZapperPubkey(event);
+			const zapperPubkey = getZapSenderPubkey(event);
 			if (zapperPubkey !== undefined && mutedPubkeysByKind.has(zapperPubkey)) {
 				return true;
 			}


### PR DESCRIPTION
## Summary

- Move NIP-57 zap sender extraction and its existing tests into nostr/protocol/nip57.ts and nip57.test.ts
- Rename getZapperPubkey to getZapSenderPubkey and update all consumers
- Keep nip57.ts as a pure protocol module without a dependency on EventHelper.ts
- Use the nostr-tools Zap kind constant inside the helper

## Runtime behavior

No runtime behavior changes. P-tag precedence, non-empty tag selection, description fallback, decode warning behavior, and undefined results are unchanged.

## Verification

- npm test -- src/lib/nostr/protocol/nip57.test.ts
- npm test
- npm run check
- npm run lint