### PR TITLE
Move pubkey validation into Nostr protocol

### DIFF
--- a/web/src/lib/nostr/protocol/pubkey.test.ts
+++ b/web/src/lib/nostr/protocol/pubkey.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isValidPubkey } from './pubkey';
+
+const a = 'a'.repeat(64);
+
+describe('isValidPubkey', () => {
+	it('accepts 64-char lowercase hex', () => {
+		expect(isValidPubkey(a)).toBe(true);
+		expect(isValidPubkey('0123456789abcdef'.repeat(4))).toBe(true);
+	});
+
+	it('rejects invalid values', () => {
+		expect(isValidPubkey('a'.repeat(63))).toBe(false);
+		expect(isValidPubkey('a'.repeat(65))).toBe(false);
+		expect(isValidPubkey('A'.repeat(64))).toBe(false);
+		expect(isValidPubkey('g'.repeat(64))).toBe(false);
+		expect(isValidPubkey('')).toBe(false);
+		expect(isValidPubkey(undefined)).toBe(false);
+		expect(isValidPubkey(null)).toBe(false);
+		expect(isValidPubkey(0)).toBe(false);
+		expect(isValidPubkey({})).toBe(false);
+	});
+});

--- a/web/src/lib/nostr/protocol/pubkey.ts
+++ b/web/src/lib/nostr/protocol/pubkey.ts
@@ -1,0 +1,5 @@
+import { isHex32 } from 'nostr-tools/utils';
+
+export function isValidPubkey(value: unknown): value is string {
+	return typeof value === 'string' && isHex32(value);
+}

--- a/web/src/lib/pubkey.test.ts
+++ b/web/src/lib/pubkey.test.ts
@@ -1,24 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { isValidPubkey, pubkeysFromTags } from './pubkey';
+import { pubkeysFromTags } from './pubkey';
 
 const a = 'a'.repeat(64);
 const b = 'b'.repeat(64);
-
-describe('isValidPubkey', () => {
-	it('accepts 64-char lowercase hex', () => {
-		expect(isValidPubkey(a)).toBe(true);
-		expect(isValidPubkey('0123456789abcdef'.repeat(4))).toBe(true);
-	});
-
-	it('rejects invalid values', () => {
-		expect(isValidPubkey('a'.repeat(63))).toBe(false);
-		expect(isValidPubkey('a'.repeat(65))).toBe(false);
-		expect(isValidPubkey('A'.repeat(64))).toBe(false);
-		expect(isValidPubkey('g'.repeat(64))).toBe(false);
-		expect(isValidPubkey('')).toBe(false);
-		expect(isValidPubkey(undefined)).toBe(false);
-	});
-});
 
 describe('pubkeysFromTags', () => {
 	it('extracts valid pubkeys from p tags', () => {

--- a/web/src/lib/pubkey.ts
+++ b/web/src/lib/pubkey.ts
@@ -1,9 +1,5 @@
 import { unique } from './array';
-import { hexRegexp } from './Constants';
-
-export function isValidPubkey(value: string | undefined): value is string {
-	return value !== undefined && hexRegexp.test(value);
-}
+import { isValidPubkey } from './nostr/protocol/pubkey';
 
 export function pubkeysFromTags(tags: string[][]): string[] {
 	return unique(


### PR DESCRIPTION
## Summary

- Move Nostr pubkey validation and its tests into nostr/protocol/pubkey.ts and pubkey.test.ts
- Generalize isValidPubkey to an unknown-accepting runtime type guard
- Use nostr-tools/utils isHex32 to preserve the existing lowercase 64-character hexadecimal string validation semantics
- Keep pubkeysFromTags and its tests in the root pubkey modules while importing the protocol validator

## Runtime behavior

Existing string validation and pubkeysFromTags behavior are unchanged. The validator additionally handles non-string runtime inputs safely.

## Verification

- npm test -- src/lib/nostr/protocol/pubkey.test.ts src/lib/pubkey.test.ts
- npm test
- npm run check
- npm run lint