### PR TITLE
Validate NIP-57 sender pubkeys

### DIFF
--- a/web/src/lib/nostr/protocol/nip57.test.ts
+++ b/web/src/lib/nostr/protocol/nip57.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { getZapSenderPubkey } from './nip57';
 
+const zapSenderPubkey = 'a'.repeat(64);
+
 describe('getZapSenderPubkey', () => {
-	it('P tag', () => {
+	it('valid P tag takes precedence over description pubkey', () => {
 		expect(
 			getZapSenderPubkey({
 				pubkey: 'wallet',
@@ -10,7 +12,24 @@ describe('getZapSenderPubkey', () => {
 				content: '',
 				tags: [
 					['p', 'author'],
-					['P', 'zapper']
+					['P', zapSenderPubkey],
+					['description', JSON.stringify({ pubkey: 'description-zapper' })]
+				],
+				created_at: 0,
+				id: '',
+				sig: ''
+			})
+		).toBe(zapSenderPubkey);
+	});
+	it('invalid P tag falls back to description pubkey', () => {
+		expect(
+			getZapSenderPubkey({
+				pubkey: 'wallet',
+				kind: 9735,
+				content: '',
+				tags: [
+					['P', 'invalid'],
+					['description', JSON.stringify({ pubkey: 'zapper' })]
 				],
 				created_at: 0,
 				id: '',

--- a/web/src/lib/nostr/protocol/nip57.ts
+++ b/web/src/lib/nostr/protocol/nip57.ts
@@ -1,15 +1,14 @@
 import type { Event } from 'nostr-tools';
 import { Zap } from 'nostr-tools/kinds';
+import { isValidPubkey } from './pubkey';
 
 export function getZapSenderPubkey(event: Event): string | undefined {
 	if (event.kind !== Zap) {
 		return undefined;
 	}
 
-	const pubkey = event.tags.find(
-		([name, value]) => name === 'P' && value !== undefined && value !== ''
-	)?.[1];
-	if (pubkey !== undefined) {
+	const pubkey = event.tags.find(([name]) => name === 'P')?.[1];
+	if (isValidPubkey(pubkey)) {
 		return pubkey;
 	}
 


### PR DESCRIPTION
## Summary

- Validate a NIP-57 zap receipt P tag with isValidPubkey before returning it as the zap sender pubkey
- Continue to the existing description fallback when the P tag is missing or invalid
- Preserve valid P-tag precedence over the embedded zap request

## Scope

Embedded zap request validation, receipt validation, and signature verification remain out of scope. The handling of description.pubkey is unchanged.

## Verification

- npm test -- src/lib/nostr/protocol/nip57.test.ts src/lib/nostr/protocol/pubkey.test.ts
- npm test
- npm run check
- npm run lint