### PR TITLE
Move NIP-01 event address helpers into nostr/protocol

### DIFF
--- a/web/src/lib/EventHelper.test.ts
+++ b/web/src/lib/EventHelper.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { aTagContent, isLegacyEncryption, parseAddress } from './EventHelper';
+import { isLegacyEncryption } from './EventHelper';
 import { generateSecretKey, getPublicKey, nip04, nip44 } from 'nostr-tools';
-
-describe('aTagContent', () => {
-	it('distinguishes normal replaceable and addressable coordinates', () => {
-		const base = { pubkey: 'pubkey', content: '', created_at: 0, id: '', sig: '' };
-		expect(aTagContent({ ...base, kind: 10003, tags: [['d', 'ignored']] })).toBe(
-			'10003:pubkey:'
-		);
-		expect(aTagContent({ ...base, kind: 30001, tags: [['d', 'bookmark']] })).toBe(
-			'30001:pubkey:bookmark'
-		);
-	});
-});
 
 describe('isLegacyEncryption', () => {
 	const seckey = generateSecretKey();
@@ -25,34 +13,5 @@ describe('isLegacyEncryption', () => {
 		const conversationKey = nip44.getConversationKey(seckey, pubkey);
 		const nip44Content = nip44.encrypt('content', conversationKey);
 		expect(isLegacyEncryption(nip44Content)).toBe(false);
-	});
-});
-
-describe('parseAddress', () => {
-	const seckey = generateSecretKey();
-	const pubkey = getPublicKey(seckey);
-	it('valid address', () => {
-		expect(parseAddress(`123:${pubkey}:identifier`)).toEqual([123, pubkey, 'identifier']);
-	});
-	it('valid address without identifier', () => {
-		expect(parseAddress(`123:${pubkey}`)).toEqual([123, pubkey, '']);
-	});
-	it('valid address with empty identifier', () => {
-		expect(parseAddress(`123:${pubkey}:`)).toEqual([123, pubkey, '']);
-	});
-	it('valid address with : in identifier', () => {
-		expect(parseAddress(`123:${pubkey}:iden:tifier`)).toEqual([123, pubkey, 'iden:tifier']);
-	});
-	it('invalid address with non-numeric kind', () => {
-		expect(parseAddress(`abc:${pubkey}:identifier`)).toBeUndefined();
-	});
-	it('invalid address with missing pubkey', () => {
-		expect(parseAddress('123')).toBeUndefined();
-	});
-	it('invalid address with empty string', () => {
-		expect(parseAddress('')).toBeUndefined();
-	});
-	it('invalid address with non-hex pubkey', () => {
-		expect(parseAddress('123:nonhex:identifier')).toBeUndefined();
 	});
 });

--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -1,7 +1,6 @@
 import type { Event } from 'nostr-tools';
-import { isAddressableKind } from 'nostr-tools/kinds';
 import type { id } from './Types';
-import { hexRegexp, shortcodeRegexp } from './Constants';
+import { shortcodeRegexp } from './Constants';
 
 export function isReply(event: Event): boolean {
 	if (!event.tags.some(([tagName]) => tagName === 'p')) {
@@ -89,11 +88,6 @@ export function getTagContent(tagName: string, tags: string[][]): string {
 	return tagContent ?? (tagName === 'd' ? '' : getTagContent('d', tags));
 }
 
-export function aTagContent(event: Event): string {
-	const identifier = isAddressableKind(event.kind) ? (findIdentifier(event.tags) ?? '') : '';
-	return `${event.kind}:${event.pubkey}:${identifier}`;
-}
-
 export function isNostrHex(hex: string): boolean {
 	return /[0-9a-f]{64}/.test(hex);
 }
@@ -103,11 +97,3 @@ export function getTitle(tags: string[][]): string | undefined {
 }
 
 export const isLegacyEncryption = (content: string): boolean => content.includes('?iv=');
-
-export const parseAddress = (address: string): [number, string, string] | undefined => {
-	const [kind, pubkey, ...identifier] = address.split(':');
-	if (!kind || isNaN(Number(kind)) || !pubkey || !hexRegexp.test(pubkey)) {
-		return undefined;
-	}
-	return [Number(kind), pubkey, identifier.join(':')];
-};

--- a/web/src/lib/author/CustomEmojis.ts
+++ b/web/src/lib/author/CustomEmojis.ts
@@ -4,7 +4,9 @@ import { filter, firstValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { chunk } from '$lib/array';
 import { maxFilters } from '$lib/Constants';
-import { aTagContent, filterEmojiTags, findIdentifier, parseAddress } from '$lib/EventHelper';
+import type { AddressPointer } from 'nostr-tools/nip19';
+import { filterEmojiTags, findIdentifier } from '$lib/EventHelper';
+import { getEventAddress, parseEventAddress } from '$lib/nostr/protocol/event-address';
 import { rxNostr, tie } from '$lib/timelines/MainTimeline';
 import { Queue } from '$lib/Queue';
 import { WebStorage } from '$lib/WebStorage';
@@ -72,10 +74,10 @@ export function storeCustomEmojis(event: Nostr.Event): void {
 		});
 
 	const filters: LazyFilter[] = addressTags
-		.map(([, address]) => parseAddress(address))
-		.filter((parsed): parsed is [number, string, string] => parsed !== undefined)
-		.filter(([kind]) => kind === Emojisets)
-		.map(([kind, pubkey, identifier]) => {
+		.map(([, address]) => parseEventAddress(address))
+		.filter((parsed): parsed is AddressPointer => parsed !== undefined)
+		.filter(({ kind }) => kind === Emojisets)
+		.map(({ kind, pubkey, identifier }) => {
 			return {
 				kinds: [Number(kind)],
 				authors: [pubkey],
@@ -96,7 +98,7 @@ export function findCustomEmojiSetAddress(shortcode: string, url: string): strin
 				([, _shortcode, _url]) => `:${_shortcode}:` === shortcode && _url === url
 			)
 		) {
-			return aTagContent(event);
+			return getEventAddress(event);
 		}
 	}
 	return undefined;

--- a/web/src/lib/author/Delete.ts
+++ b/web/src/lib/author/Delete.ts
@@ -5,7 +5,8 @@ import type * as Nostr from 'nostr-typedef';
 import { pubkey as authorPubkey } from '$lib/stores/Author';
 import { rxNostr } from '$lib/timelines/MainTimeline';
 import { Signer } from '$lib/Signer';
-import { aTagContent, filterTags } from '$lib/EventHelper';
+import { filterTags } from '$lib/EventHelper';
+import { getEventAddress } from '$lib/nostr/protocol/event-address';
 
 export const deletedEventIds = writable(new Set<string>());
 export const deletedEventIdsByPubkey = writable(new Map<string, Set<string>>());
@@ -47,7 +48,7 @@ export async function requestEventDeletion(
 	for (const event of events) {
 		const tag =
 			isReplaceableKind(event.kind) || isAddressableKind(event.kind)
-				? ['a', aTagContent(event)]
+				? ['a', getEventAddress(event)]
 				: ['e', event.id];
 		targetTags.set(`${tag[0]}:${tag[1]}`, tag);
 	}

--- a/web/src/lib/author/PeopleLists.ts
+++ b/web/src/lib/author/PeopleLists.ts
@@ -2,7 +2,8 @@ import { get, writable } from 'svelte/store';
 import { createRxBackwardReq, filterAsync, latestEach, now, uniq } from 'rx-nostr';
 import type * as Nostr from 'nostr-typedef';
 import { isDecodable } from '$lib/Encryption';
-import { aTagContent, findIdentifier } from '$lib/EventHelper';
+import { findIdentifier } from '$lib/EventHelper';
+import { getEventAddress } from '$lib/nostr/protocol/event-address';
 import { pubkey as authorPubkey } from '$lib/stores/Author';
 import { rxNostr, tie } from '$lib/timelines/MainTimeline';
 import { Signer } from '$lib/Signer';
@@ -17,7 +18,7 @@ export const processing = writable(false);
 
 export function storePeopleList(event: Nostr.Event): void {
 	const $peopleLists = get(peopleLists);
-	const key = aTagContent(event);
+	const key = getEventAddress(event);
 	const cache = $peopleLists.get(key);
 	if (cache === undefined || cache.created_at < event.created_at) {
 		$peopleLists.set(key, event);
@@ -33,7 +34,7 @@ export function fetchPeopleLists(): void {
 		.pipe(
 			tie,
 			uniq(),
-			latestEach(({ event }) => aTagContent(event)),
+			latestEach(({ event }) => getEventAddress(event)),
 			filterAsync(({ event }) => isPeopleList(event))
 		)
 		.subscribe(({ event }) => {

--- a/web/src/lib/components/Badges.svelte
+++ b/web/src/lib/components/Badges.svelte
@@ -9,7 +9,8 @@
 	import { browser } from '$app/environment';
 	import ExternalLink from './ExternalLink.svelte';
 	import type * as Nostr from 'nostr-typedef';
-	import { aTagContent, findIdentifier, parseAddress } from '$lib/EventHelper';
+	import { findIdentifier } from '$lib/EventHelper';
+	import { getEventAddress, parseEventAddress } from '$lib/nostr/protocol/event-address';
 	import { nip19 } from 'nostr-tools';
 	import { SvelteMap } from 'svelte/reactivity';
 	import {
@@ -115,11 +116,11 @@
 
 						const definitionAddressesGroupedByPubkey = definitionAddresses.reduce(
 							(definitions, address) => {
-								const parsed = parseAddress(address);
+								const parsed = parseEventAddress(address);
 								if (!parsed) {
 									return definitions;
 								}
-								const [, pubkey, identifier] = parsed;
+								const { pubkey, identifier } = parsed;
 								if (!definitions.has(pubkey)) {
 									definitions.set(pubkey, new Set());
 								}
@@ -140,12 +141,12 @@
 							.pipe(
 								tie,
 								uniq(),
-								latestEach(({ event }) => aTagContent(event))
+								latestEach(({ event }) => getEventAddress(event))
 							)
 							.subscribe({
 								next: ({ event }) => {
 									console.debug('[badges definition]', event);
-									updateBadgeDefinitions(aTagContent(event), event);
+									updateBadgeDefinitions(getEventAddress(event), event);
 								}
 							});
 						for (const [

--- a/web/src/lib/components/actions/CustomEmojiMenuButton.svelte
+++ b/web/src/lib/components/actions/CustomEmojiMenuButton.svelte
@@ -2,7 +2,8 @@
 	import { _ } from 'svelte-i18n';
 	import { nip19 } from 'nostr-tools';
 	import type * as Nostr from 'nostr-typedef';
-	import { aTagContent, findIdentifier } from '$lib/EventHelper';
+	import { findIdentifier } from '$lib/EventHelper';
+	import { getEventAddress } from '$lib/nostr/protocol/event-address';
 	import {
 		IconDots,
 		IconExternalLink,
@@ -44,7 +45,7 @@
 
 	let menuElement: HTMLElement | undefined;
 
-	let address = $derived(aTagContent(event));
+	let address = $derived(getEventAddress(event));
 	let naddr = $derived(
 		nip19.naddrEncode({
 			kind: event.kind,

--- a/web/src/lib/components/actions/ListDialog.svelte
+++ b/web/src/lib/components/actions/ListDialog.svelte
@@ -16,7 +16,7 @@
 		removeFromPeopleList
 	} from '$lib/author/PeopleLists';
 	import { getListTitle } from '$lib/List';
-	import { aTagContent } from '$lib/EventHelper';
+	import { getEventAddress } from '$lib/nostr/protocol/event-address';
 	import { pubkey as authorPubkey } from '$lib/stores/Author';
 	import { clearListTimelineIfActive } from '$lib/timelines/ListTimeline';
 	import ModalDialog from '../ModalDialog.svelte';
@@ -45,7 +45,7 @@
 	function toggled(e: Event, event: Nostr.Event): void {
 		const target = e.target as HTMLInputElement;
 		console.debug('[people list toggled]', target.checked);
-		const key = aTagContent(event);
+		const key = getEventAddress(event);
 		if (changedLists.has(key)) {
 			changedLists.delete(key);
 		} else {

--- a/web/src/lib/components/content/CustomEmojiPopup.svelte
+++ b/web/src/lib/components/content/CustomEmojiPopup.svelte
@@ -11,7 +11,7 @@
 	import EventComponent from '../items/EventComponent.svelte';
 	import { EventItem } from '$lib/Items';
 	import { tap } from 'rxjs';
-	import { parseAddress } from '$lib/EventHelper';
+	import { parseEventAddress } from '$lib/nostr/protocol/event-address';
 
 	interface Props {
 		text?: string;
@@ -34,11 +34,11 @@
 			return;
 		}
 
-		const parsed = parseAddress(address);
+		const parsed = parseEventAddress(address);
 		if (!parsed) {
 			return;
 		}
-		const [kind, pubkey, identifier] = parsed;
+		const { kind, pubkey, identifier } = parsed;
 		const req = createRxBackwardReq();
 		rxNostr
 			.use(req)

--- a/web/src/lib/components/items/BadgeAward.svelte
+++ b/web/src/lib/components/items/BadgeAward.svelte
@@ -4,7 +4,8 @@
 	import { nip19 } from 'nostr-tools';
 	import { acceptBadge, profileBadgesEvent } from '$lib/author/ProfileBadges';
 	import { replaceableEventsStore, metadataStore } from '$lib/cache/Events';
-	import { aTagContent, filterTags } from '$lib/EventHelper';
+	import { filterTags } from '$lib/EventHelper';
+	import { getEventAddress } from '$lib/nostr/protocol/event-address';
 	import { type Item } from '$lib/Items';
 	import { rom } from '$lib/stores/Author';
 	import { developerMode } from '$lib/stores/Preference';
@@ -52,7 +53,7 @@
 	function accept(badgeDefinitionEvent: Nostr.Event): void {
 		console.log('[badge accept]', badgeDefinitionEvent, event);
 
-		const a = aTagContent(badgeDefinitionEvent);
+		const a = getEventAddress(badgeDefinitionEvent);
 		acceptBadge(a, event.id);
 	}
 </script>
@@ -83,7 +84,7 @@
 		{#each badgeDefinitions as event}
 			<BadgeDefinition {event}>
 				{#if !readonly && !$rom}
-					{@const own = myBadgeDefinitionsA.includes(aTagContent(event))}
+					{@const own = myBadgeDefinitionsA.includes(getEventAddress(event))}
 					<button class="round" disabled={own} onclick={() => accept(event)}>
 						{#if own}
 							{$_('badge.accepted')}

--- a/web/src/lib/components/items/Highlight.svelte
+++ b/web/src/lib/components/items/Highlight.svelte
@@ -10,7 +10,7 @@
 	import { metadataStore, replaceableEventsStore } from '$lib/cache/Events';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 	import { IconQuoteFilled } from '@tabler/icons-svelte-runes';
-	import { parseAddress } from '$lib/EventHelper';
+	import { parseEventAddress } from '$lib/nostr/protocol/event-address';
 
 	interface Props {
 		item: Item;
@@ -85,7 +85,8 @@
 								</div>
 							{/if}
 							{#if sourceAddress}
-								{@const [kind, pubkey, identifier] = parseAddress(sourceAddress)!}
+								{@const { kind, pubkey, identifier } =
+									parseEventAddress(sourceAddress)!}
 								{@const naddr = nip19.naddrEncode({
 									kind,
 									pubkey,

--- a/web/src/lib/nostr/protocol/event-address.test.ts
+++ b/web/src/lib/nostr/protocol/event-address.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { generateSecretKey, getPublicKey } from 'nostr-tools';
+import { getEventAddress, parseEventAddress } from './event-address';
+
+describe('getEventAddress', () => {
+	it('distinguishes normal replaceable and addressable coordinates', () => {
+		const base = { pubkey: 'pubkey', content: '', created_at: 0, id: '', sig: '' };
+		expect(getEventAddress({ ...base, kind: 10003, tags: [['d', 'ignored']] })).toBe(
+			'10003:pubkey:'
+		);
+		expect(getEventAddress({ ...base, kind: 30001, tags: [['d', 'bookmark']] })).toBe(
+			'30001:pubkey:bookmark'
+		);
+	});
+
+	it('uses an empty identifier for an addressable kind without a d tag', () => {
+		const base = { pubkey: 'pubkey', content: '', created_at: 0, id: '', sig: '' };
+		expect(getEventAddress({ ...base, kind: 30001, tags: [] })).toBe('30001:pubkey:');
+	});
+});
+
+describe('parseEventAddress', () => {
+	const seckey = generateSecretKey();
+	const pubkey = getPublicKey(seckey);
+	it('valid address', () => {
+		expect(parseEventAddress(`123:${pubkey}:identifier`)).toEqual({
+			kind: 123,
+			pubkey,
+			identifier: 'identifier'
+		});
+	});
+	it('valid address without identifier', () => {
+		expect(parseEventAddress(`123:${pubkey}`)).toEqual({
+			kind: 123,
+			pubkey,
+			identifier: ''
+		});
+	});
+	it('valid address with empty identifier', () => {
+		expect(parseEventAddress(`123:${pubkey}:`)).toEqual({
+			kind: 123,
+			pubkey,
+			identifier: ''
+		});
+	});
+	it('valid address with : in identifier', () => {
+		expect(parseEventAddress(`123:${pubkey}:iden:tifier`)).toEqual({
+			kind: 123,
+			pubkey,
+			identifier: 'iden:tifier'
+		});
+	});
+	it('invalid address with non-numeric kind', () => {
+		expect(parseEventAddress(`abc:${pubkey}:identifier`)).toBeUndefined();
+	});
+	it('invalid address with missing pubkey', () => {
+		expect(parseEventAddress('123')).toBeUndefined();
+	});
+	it('invalid address with empty string', () => {
+		expect(parseEventAddress('')).toBeUndefined();
+	});
+	it('invalid address with non-hex pubkey', () => {
+		expect(parseEventAddress('123:nonhex:identifier')).toBeUndefined();
+	});
+});

--- a/web/src/lib/nostr/protocol/event-address.ts
+++ b/web/src/lib/nostr/protocol/event-address.ts
@@ -13,7 +13,7 @@ export function getEventAddress(event: Event): string {
 
 export function parseEventAddress(value: string): AddressPointer | undefined {
 	const [kind, pubkey, ...identifier] = value.split(':');
-	if (!kind || isNaN(Number(kind)) || !pubkey || !isValidPubkey(pubkey)) {
+	if (!kind || isNaN(Number(kind)) || !isValidPubkey(pubkey)) {
 		return undefined;
 	}
 	return {

--- a/web/src/lib/nostr/protocol/event-address.ts
+++ b/web/src/lib/nostr/protocol/event-address.ts
@@ -1,0 +1,24 @@
+import type { Event } from 'nostr-tools';
+import { isAddressableKind } from 'nostr-tools/kinds';
+import type { AddressPointer } from 'nostr-tools/nip19';
+import { isValidPubkey } from './pubkey';
+
+export function getEventAddress(event: Event): string {
+	const identifier = isAddressableKind(event.kind)
+		? (event.tags.find(([name]) => name === 'd')?.[1] ?? '')
+		: '';
+
+	return `${event.kind}:${event.pubkey}:${identifier}`;
+}
+
+export function parseEventAddress(value: string): AddressPointer | undefined {
+	const [kind, pubkey, ...identifier] = value.split(':');
+	if (!kind || isNaN(Number(kind)) || !pubkey || !isValidPubkey(pubkey)) {
+		return undefined;
+	}
+	return {
+		kind: Number(kind),
+		pubkey,
+		identifier: identifier.join(':')
+	};
+}

--- a/web/src/lib/timelines/MainTimeline.ts
+++ b/web/src/lib/timelines/MainTimeline.ts
@@ -13,7 +13,8 @@ import {
 } from 'rx-nostr';
 import { tap, bufferTime } from 'rxjs';
 import { addressRegexp, filterLimitItems, hexRegexp, timeout } from '$lib/Constants';
-import { aTagContent, filterTags, parseAddress } from '$lib/EventHelper';
+import { filterTags } from '$lib/EventHelper';
+import { getEventAddress, parseEventAddress } from '$lib/nostr/protocol/event-address';
 import { Metadata, type EventItem } from '$lib/Items';
 import {
 	eventItemStore,
@@ -248,7 +249,7 @@ function requestReplaceableReferences(event: Nostr.Event): void {
 	aTags.push(...qTags);
 	if (aTags.length > 0) {
 		const filters: LazyFilter[] = aTags.map(([, address]) => {
-			const [kind, pubkey, identifier] = parseAddress(address)!;
+			const { kind, pubkey, identifier } = parseEventAddress(address)!;
 			return isReplaceableKind(kind)
 				? {
 						kinds: [kind],
@@ -299,12 +300,12 @@ rxNostr
 	.pipe(
 		tie,
 		uniq(),
-		latestEach(({ event }) => aTagContent(event)),
+		latestEach(({ event }) => getEventAddress(event)),
 		tap(({ event }) => referencesReqEmit(event, true))
 	)
 	.subscribe((packet) => {
 		console.debug('[rx-nostr replaceable event]', packet);
-		const a = aTagContent(packet.event);
+		const a = getEventAddress(packet.event);
 		const $replaceableEventsStore = get(replaceableEventsStore);
 		const cache = $replaceableEventsStore.get(a);
 		if (cache === undefined || cache.created_at < packet.event.created_at) {


### PR DESCRIPTION
## Summary

- Move the NIP-01 event address helpers from `EventHelper.ts` into `nostr/protocol/event-address.ts`
- Rename the API to `getEventAddress()` / `parseEventAddress()` and drop the old names
- Return `nostr-tools/nip19.AddressPointer` from `parseEventAddress()` instead of a `[kind, pubkey, identifier]` tuple
- Reuse the existing `isValidPubkey()` instead of relying on `Constants.hexRegexp`
- Runtime semantics are intentionally unchanged