### PR TITLE
Use event ID validator in NoteLink

### DIFF
--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -88,10 +88,6 @@ export function getTagContent(tagName: string, tags: string[][]): string {
 	return tagContent ?? (tagName === 'd' ? '' : getTagContent('d', tags));
 }
 
-export function isNostrHex(hex: string): boolean {
-	return /[0-9a-f]{64}/.test(hex);
-}
-
 export function getTitle(tags: string[][]): string | undefined {
 	return filterTags('title', tags).at(0);
 }

--- a/web/src/lib/components/items/NoteLink.svelte
+++ b/web/src/lib/components/items/NoteLink.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
 	import { nip19 } from 'nostr-tools';
-	import { isNostrHex } from '$lib/EventHelper';
+	import { isValidEventId } from '$lib/nostr/protocol/event-id';
 	import { developerMode } from '$lib/stores/Preference';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';
 
@@ -15,7 +15,7 @@
 </script>
 
 <article class="timeline-item">
-	{#if isNostrHex(eventId)}
+	{#if isValidEventId(eventId)}
 		<a href="/{nevent}">
 			{nevent.substring(0, 'nevent1'.length + 7)}
 		</a>


### PR DESCRIPTION
## Summary

- Replace the loose `isNostrHex()` check in `NoteLink.svelte` with the existing protocol-level `isValidEventId()`
- Remove the redundant `isNostrHex()` helper from `EventHelper.ts`
- No unrelated behavior or architecture changes