### PR TITLE
Move NIP-04 detection to protocol module

### DIFF
--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -70,5 +70,3 @@ export function getTagContent(tagName: string, tags: string[][]): string {
 export function getTitle(tags: string[][]): string | undefined {
 	return filterTags('title', tags).at(0);
 }
-
-export const isLegacyEncryption = (content: string): boolean => content.includes('?iv=');

--- a/web/src/lib/List.ts
+++ b/web/src/lib/List.ts
@@ -3,7 +3,8 @@ import { createRxOneshotReq, latest } from 'rx-nostr';
 import { lastValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { rxNostr, tie } from './timelines/MainTimeline';
-import { filterTags, findIdentifier, getTitle, isLegacyEncryption } from './EventHelper';
+import { filterTags, findIdentifier, getTitle } from './EventHelper';
+import { isLegacyEncryption } from './nostr/protocol/nip04';
 import { pubkey } from './stores/Author';
 import { Signer } from './Signer';
 

--- a/web/src/lib/author/BookmarkCopy.ts
+++ b/web/src/lib/author/BookmarkCopy.ts
@@ -4,7 +4,7 @@ import { filter, firstValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { kinds as Kind } from 'nostr-tools';
 import { legacyBookmarkIdentifier } from '$lib/Constants';
-import { isLegacyEncryption } from '$lib/EventHelper';
+import { isLegacyEncryption } from '$lib/nostr/protocol/nip04';
 import { Signer } from '$lib/Signer';
 import { pubkey } from '$lib/stores/Author';
 import { rxNostr, tie } from '$lib/timelines/MainTimeline';

--- a/web/src/lib/nostr/protocol/nip04.test.ts
+++ b/web/src/lib/nostr/protocol/nip04.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { isLegacyEncryption } from './EventHelper';
 import { generateSecretKey, getPublicKey, nip04, nip44 } from 'nostr-tools';
+import { isLegacyEncryption } from './nip04';
 
 describe('isLegacyEncryption', () => {
 	const seckey = generateSecretKey();

--- a/web/src/lib/nostr/protocol/nip04.ts
+++ b/web/src/lib/nostr/protocol/nip04.ts
@@ -1,0 +1,1 @@
+export const isLegacyEncryption = (content: string): boolean => content.includes('?iv=');


### PR DESCRIPTION
## Summary

- Move the existing NIP-04 ciphertext detection helper into `nostr/protocol/nip04.ts`
- Update existing consumers (`List.ts`, `BookmarkCopy.ts`) and relocate its tests to `nip04.test.ts`
- Preserve the existing detection behavior