### PR TITLE
Move legacy relay list parser to NIP-24 module

### DIFF
--- a/web/src/lib/Author.ts
+++ b/web/src/lib/Author.ts
@@ -14,7 +14,8 @@ import {
 } from './stores/Author';
 import { RelayList } from './author/RelayList';
 import { auth } from './auth.svelte';
-import { filterTags, findIdentifier, parseRelayJson } from './EventHelper';
+import { filterTags, findIdentifier } from './EventHelper';
+import { parseLegacyRelayList } from './nostr/protocol/nip24';
 import { customEmojiListEvent, storeCustomEmojis } from './author/CustomEmojis';
 import type { User } from '../routes/types';
 import { lastReadAt } from './author/Notifications';
@@ -67,7 +68,7 @@ export class Author {
 			if (contactsEvent.content === '') {
 				console.log('[relays in kind 3] empty');
 			} else {
-				const validRelays = [...parseRelayJson(contactsEvent.content)];
+				const validRelays = [...parseLegacyRelayList(contactsEvent.content)];
 				readRelays.set(
 					Array.from(
 						new Set(validRelays.filter(([, { read }]) => read).map(([relay]) => relay))

--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -41,27 +41,6 @@ export function filterTags(tagName: string, tags: string[][]) {
 		.map(([, content]) => content);
 }
 
-export function parseRelayJson(content: string): Map<string, { read: boolean; write: boolean }> {
-	try {
-		const relays = new Map<string, { read: boolean; write: boolean }>(
-			Object.entries(JSON.parse(content))
-		);
-		return new Map(
-			[...relays].filter(([relay]) => {
-				try {
-					const url = new URL(relay);
-					return url.protocol === 'wss:' || url.protocol === 'ws:';
-				} catch {
-					return false;
-				}
-			})
-		);
-	} catch (error) {
-		console.error('[kind 3 content parse error]', error);
-		return new Map();
-	}
-}
-
 export function getTagContent(tagName: string, tags: string[][]): string {
 	const tagContent = tags.find(([n]) => n === tagName)?.at(1);
 	return tagContent ?? (tagName === 'd' ? '' : getTagContent('d', tags));

--- a/web/src/lib/author/RelayList.ts
+++ b/web/src/lib/author/RelayList.ts
@@ -1,7 +1,7 @@
 import { kinds as Kind, type Event } from 'nostr-tools';
 import { createRxBackwardReq, latestEach, uniq } from 'rx-nostr';
 import { rxNostr, tie } from '../timelines/MainTimeline';
-import { parseRelayJson } from '../EventHelper';
+import { parseLegacyRelayList } from '../nostr/protocol/nip24';
 import { WebStorage } from '../WebStorage';
 import { metadataRelays } from '$lib/Constants';
 
@@ -64,7 +64,7 @@ export class RelayList {
 			rxNostr.setDefaultRelays(kind10002.tags);
 		} else if (kind3 !== undefined && kind3.content !== '') {
 			rxNostr.setDefaultRelays(
-				[...parseRelayJson(kind3.content)].map(([url, { read, write }]) => {
+				[...parseLegacyRelayList(kind3.content)].map(([url, { read, write }]) => {
 					return { url, read, write };
 				})
 			);

--- a/web/src/lib/nostr/protocol/nip24.test.ts
+++ b/web/src/lib/nostr/protocol/nip24.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseLegacyRelayList } from './nip24';
+
+describe('parseLegacyRelayList', () => {
+	it('returns valid ws: and wss: relay entries', () => {
+		const content = JSON.stringify({
+			'wss://relay.example.com': { read: true, write: true },
+			'ws://relay.example.com': { read: true, write: false }
+		});
+		expect(parseLegacyRelayList(content)).toEqual(
+			new Map([
+				['wss://relay.example.com', { read: true, write: true }],
+				['ws://relay.example.com', { read: true, write: false }]
+			])
+		);
+	});
+
+	it('excludes non-WebSocket URLs', () => {
+		const content = JSON.stringify({
+			'wss://relay.example.com': { read: true, write: true },
+			'https://example.com': { read: true, write: false },
+			'http://example.com': { read: true, write: false }
+		});
+		expect(parseLegacyRelayList(content)).toEqual(
+			new Map([['wss://relay.example.com', { read: true, write: true }]])
+		);
+	});
+
+	it('excludes invalid URLs', () => {
+		const content = JSON.stringify({
+			'wss://relay.example.com': { read: true, write: true },
+			'not a url': { read: true, write: false }
+		});
+		expect(parseLegacyRelayList(content)).toEqual(
+			new Map([['wss://relay.example.com', { read: true, write: true }]])
+		);
+	});
+
+	it('returns an empty Map for malformed JSON', () => {
+		expect(parseLegacyRelayList('{invalid')).toEqual(new Map());
+	});
+});

--- a/web/src/lib/nostr/protocol/nip24.ts
+++ b/web/src/lib/nostr/protocol/nip24.ts
@@ -1,0 +1,22 @@
+export function parseLegacyRelayList(
+	content: string
+): Map<string, { read: boolean; write: boolean }> {
+	try {
+		const relays = new Map<string, { read: boolean; write: boolean }>(
+			Object.entries(JSON.parse(content))
+		);
+		return new Map(
+			[...relays].filter(([relay]) => {
+				try {
+					const url = new URL(relay);
+					return url.protocol === 'wss:' || url.protocol === 'ws:';
+				} catch {
+					return false;
+				}
+			})
+		);
+	} catch (error) {
+		console.error('[kind 3 content parse error]', error);
+		return new Map();
+	}
+}

--- a/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
@@ -11,7 +11,7 @@
 	import { developerMode } from '$lib/stores/Preference';
 	import { kinds as Kind } from 'nostr-tools';
 	import Relay from './Relay.svelte';
-	import { parseRelayJson } from '$lib/EventHelper';
+	import { parseLegacyRelayList } from '$lib/nostr/protocol/nip24';
 	import { parseRelayList } from '$lib/nostr/protocol/nip65';
 	import { Contacts } from '$lib/Contacts';
 	import IconPencil from '@tabler/icons-svelte-runes/icons/pencil';
@@ -53,7 +53,7 @@
 		if (kind10002 !== undefined) {
 			relays = parseRelayList(kind10002.tags);
 		} else if (kind3 !== undefined && kind3.content !== '') {
-			relays = [...parseRelayJson(kind3.content)].map(([relay, permission]) => {
+			relays = [...parseLegacyRelayList(kind3.content)].map(([relay, permission]) => {
 				return { url: relay, ...permission };
 			});
 		} else {


### PR DESCRIPTION
## Summary

- Move the deprecated kind 3 relay list parser into `nostr/protocol/nip24.ts`
- Rename `parseRelayJson()` to `parseLegacyRelayList()` to clarify its compatibility purpose
- Preserve the existing parsing behavior