### PR TITLE
Localize badge tag fallback logic

### DIFF
--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -41,11 +41,6 @@ export function filterTags(tagName: string, tags: string[][]) {
 		.map(([, content]) => content);
 }
 
-export function getTagContent(tagName: string, tags: string[][]): string {
-	const tagContent = tags.find(([n]) => n === tagName)?.at(1);
-	return tagContent ?? (tagName === 'd' ? '' : getTagContent('d', tags));
-}
-
 export function getTitle(tags: string[][]): string | undefined {
 	return filterTags('title', tags).at(0);
 }

--- a/web/src/lib/components/items/BadgeDefinition.svelte
+++ b/web/src/lib/components/items/BadgeDefinition.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type * as Nostr from 'nostr-typedef';
-	import { getTagContent } from '$lib/EventHelper';
 
 	interface Props {
 		event: Nostr.Event;
@@ -8,6 +7,11 @@
 	}
 
 	let { event, children }: Props = $props();
+
+	function getTagContent(tagName: string, tags: string[][]): string {
+		const tagContent = tags.find(([n]) => n === tagName)?.at(1);
+		return tagContent ?? (tagName === 'd' ? '' : getTagContent('d', tags));
+	}
 
 	let name = $derived(getTagContent('name', event.tags));
 	let description = $derived(getTagContent('description', event.tags));


### PR DESCRIPTION
## Summary

- Move the Badge Definition-specific tag fallback logic out of `EventHelper.ts`
- Keep the helper local to `BadgeDefinition.svelte`
- Preserve the existing fallback behavior