### PR TITLE
Remove redundant title tag helper

### DIFF
--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -40,7 +40,3 @@ export function filterTags(tagName: string, tags: string[][]) {
 		.filter(([name, content]) => name === tagName && content !== undefined && content !== '')
 		.map(([, content]) => content);
 }
-
-export function getTitle(tags: string[][]): string | undefined {
-	return filterTags('title', tags).at(0);
-}

--- a/web/src/lib/List.ts
+++ b/web/src/lib/List.ts
@@ -3,7 +3,7 @@ import { createRxOneshotReq, latest } from 'rx-nostr';
 import { lastValueFrom } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { rxNostr, tie } from './timelines/MainTimeline';
-import { filterTags, findIdentifier, getTitle } from './EventHelper';
+import { filterTags, findIdentifier } from './EventHelper';
 import { isLegacyEncryption } from './nostr/protocol/nip04';
 import { pubkey } from './stores/Author';
 import { Signer } from './Signer';
@@ -26,7 +26,7 @@ export async function fetchListEvent(
 }
 
 export function getListTitle(tags: string[][]): string {
-	return getTitle(tags) ?? findIdentifier(tags) ?? '-';
+	return filterTags('title', tags).at(0) ?? findIdentifier(tags) ?? '-';
 }
 
 export async function getListPubkeys(event: Nostr.Event): Promise<string[]> {

--- a/web/src/lib/components/items/Picture.svelte
+++ b/web/src/lib/components/items/Picture.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getTitle } from '$lib/EventHelper';
+	import { filterTags } from '$lib/EventHelper';
 	import type { EventItem, Item } from '$lib/Items';
 	import ActionMenu from '../actions/ActionMenu.svelte';
 	import Content from '../Content.svelte';
@@ -15,7 +15,7 @@
 	let { item, readonly, createdAtFormat = 'auto' }: Props = $props();
 
 	let eventItem = $derived(item as EventItem);
-	let title = $derived(getTitle(item.event.tags));
+	let title = $derived(filterTags('title', item.event.tags).at(0));
 	let pictures = $derived(item.event.tags.filter(([tagName]) => tagName === 'imeta'));
 </script>
 


### PR DESCRIPTION
## Summary

- Remove the redundant `getTitle()` wrapper from `EventHelper.ts`
- Read title tags directly at the existing call sites
- Preserve the existing title selection behavior