### PR TITLE
Split action target lookup into NIP-18 and NIP-25 helpers

### DIFF
--- a/web/src/lib/EventHelper.ts
+++ b/web/src/lib/EventHelper.ts
@@ -1,5 +1,4 @@
 import type { Event } from 'nostr-tools';
-import type { id } from './Types';
 
 export function isReply(event: Event): boolean {
 	if (!event.tags.some(([tagName]) => tagName === 'p')) {
@@ -25,14 +24,6 @@ export function findIdentifier(tags: string[][]): string | undefined {
 		return undefined;
 	}
 	return tag.at(1) ?? '';
-}
-
-export function findLastId(tags: string[][]): id | undefined {
-	const ids = filterTags('e', tags);
-	if (ids.length === 0) {
-		return undefined;
-	}
-	return ids[ids.length - 1];
 }
 
 export function filterTags(tagName: string, tags: string[][]) {

--- a/web/src/lib/author/Action.ts
+++ b/web/src/lib/author/Action.ts
@@ -4,7 +4,9 @@ import { bufferTime, bufferWhen, filter, interval, share } from 'rxjs';
 import type * as Nostr from 'nostr-typedef';
 import { rxNostr, tie } from '$lib/timelines/MainTimeline';
 import { maxFilters } from '$lib/Constants';
-import { filterTags, findLastId } from '$lib/EventHelper';
+import { filterTags } from '$lib/EventHelper';
+import { getRepostTargetEventId } from '$lib/nostr/protocol/nip18';
+import { getReactionTargetEventId } from '$lib/nostr/protocol/nip25';
 import type { id } from '$lib/Types';
 import { pubkey } from '../stores/Author';
 import { deletedEventIdsByPubkey, storeDeletedEvents } from './Delete';
@@ -18,7 +20,7 @@ export function updateRepostedEvents(events: Nostr.Event[]): void {
 	for (const event of events.filter(
 		(event) => event.kind === Repost && event.pubkey === get(pubkey) // Ensure
 	)) {
-		const id = findLastId(event.tags);
+		const id = getRepostTargetEventId(event.tags);
 		if (id === undefined) {
 			continue;
 		}
@@ -39,7 +41,7 @@ export function updateReactionedEvents(events: Nostr.Event[]): void {
 	for (const event of events.filter(
 		(event) => event.kind === Reaction && event.pubkey === get(pubkey) // Ensure
 	)) {
-		const id = findLastId(event.tags);
+		const id = getReactionTargetEventId(event.tags);
 		if (id === undefined) {
 			continue;
 		}

--- a/web/src/lib/nostr/protocol/nip18.test.ts
+++ b/web/src/lib/nostr/protocol/nip18.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getRepostTargetEventId } from './nip18';
+
+describe('getRepostTargetEventId', () => {
+	it('returns the value of a single valid e tag', () => {
+		expect(getRepostTargetEventId([['e', 'target1']])).toBe('target1');
+	});
+
+	it('returns the last value of multiple valid e tags', () => {
+		expect(
+			getRepostTargetEventId([
+				['e', 'target1'],
+				['e', 'target2']
+			])
+		).toBe('target2');
+	});
+
+	it('ignores an empty string e tag', () => {
+		expect(
+			getRepostTargetEventId([
+				['e', ''],
+				['e', 'target1']
+			])
+		).toBe('target1');
+	});
+
+	it('ignores an e tag without content', () => {
+		expect(getRepostTargetEventId([['e'], ['e', 'target1']])).toBe('target1');
+	});
+
+	it('returns undefined when there is no valid e tag', () => {
+		expect(getRepostTargetEventId([])).toBe(undefined);
+		expect(getRepostTargetEventId([['e', '']])).toBe(undefined);
+		expect(getRepostTargetEventId([['e']])).toBe(undefined);
+	});
+
+	it('ignores non-e tags', () => {
+		expect(
+			getRepostTargetEventId([
+				['p', 'target1'],
+				['t', 'target2']
+			])
+		).toBe(undefined);
+	});
+});

--- a/web/src/lib/nostr/protocol/nip18.test.ts
+++ b/web/src/lib/nostr/protocol/nip18.test.ts
@@ -1,44 +1,91 @@
 import { describe, expect, it } from 'vitest';
 import { getRepostTargetEventId } from './nip18';
 
+const targetId1 = 'a'.repeat(64);
+const targetId2 = 'b'.repeat(64);
+
 describe('getRepostTargetEventId', () => {
-	it('returns the value of a single valid e tag', () => {
-		expect(getRepostTargetEventId([['e', 'target1']])).toBe('target1');
+	it('returns a single valid event ID', () => {
+		expect(getRepostTargetEventId([['e', targetId1]])).toBe(targetId1);
 	});
 
-	it('returns the last value of multiple valid e tags', () => {
+	it('returns the last valid event ID of multiple e tags', () => {
 		expect(
 			getRepostTargetEventId([
-				['e', 'target1'],
-				['e', 'target2']
+				['e', targetId1],
+				['e', targetId2]
 			])
-		).toBe('target2');
+		).toBe(targetId2);
 	});
 
-	it('ignores an empty string e tag', () => {
+	it('ignores an empty value', () => {
 		expect(
 			getRepostTargetEventId([
 				['e', ''],
-				['e', 'target1']
+				['e', targetId1]
 			])
-		).toBe('target1');
+		).toBe(targetId1);
 	});
 
-	it('ignores an e tag without content', () => {
-		expect(getRepostTargetEventId([['e'], ['e', 'target1']])).toBe('target1');
+	it('ignores a missing value', () => {
+		expect(getRepostTargetEventId([['e'], ['e', targetId1]])).toBe(targetId1);
 	});
 
-	it('returns undefined when there is no valid e tag', () => {
+	it('ignores a non-hex value', () => {
+		expect(
+			getRepostTargetEventId([
+				['e', 'g'.repeat(64)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+	});
+
+	it('ignores 63-character and 65-character values', () => {
+		expect(
+			getRepostTargetEventId([
+				['e', 'a'.repeat(63)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+		expect(
+			getRepostTargetEventId([
+				['e', 'a'.repeat(65)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+	});
+
+	it('ignores an uppercase hex value', () => {
+		expect(
+			getRepostTargetEventId([
+				['e', 'A'.repeat(64)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+	});
+
+	it('returns an earlier valid event ID when the last e tag is invalid', () => {
+		expect(
+			getRepostTargetEventId([
+				['e', targetId1],
+				['e', 'invalid']
+			])
+		).toBe(targetId1);
+	});
+
+	it('returns undefined when there is no valid event ID', () => {
 		expect(getRepostTargetEventId([])).toBe(undefined);
 		expect(getRepostTargetEventId([['e', '']])).toBe(undefined);
 		expect(getRepostTargetEventId([['e']])).toBe(undefined);
+		expect(getRepostTargetEventId([['e', 'g'.repeat(64)]])).toBe(undefined);
+		expect(getRepostTargetEventId([['e', 'A'.repeat(64)]])).toBe(undefined);
 	});
 
 	it('ignores non-e tags', () => {
 		expect(
 			getRepostTargetEventId([
-				['p', 'target1'],
-				['t', 'target2']
+				['p', targetId1],
+				['t', targetId1]
 			])
 		).toBe(undefined);
 	});

--- a/web/src/lib/nostr/protocol/nip18.ts
+++ b/web/src/lib/nostr/protocol/nip18.ts
@@ -1,6 +1,5 @@
+import { isValidEventId } from './event-id';
+
 export function getRepostTargetEventId(tags: string[][]): string | undefined {
-	const eventIds = tags
-		.filter(([name, value]) => name === 'e' && value !== undefined && value !== '')
-		.map(([, value]) => value);
-	return eventIds.at(-1);
+	return tags.findLast(([name, value]) => name === 'e' && isValidEventId(value))?.[1];
 }

--- a/web/src/lib/nostr/protocol/nip18.ts
+++ b/web/src/lib/nostr/protocol/nip18.ts
@@ -1,0 +1,6 @@
+export function getRepostTargetEventId(tags: string[][]): string | undefined {
+	const eventIds = tags
+		.filter(([name, value]) => name === 'e' && value !== undefined && value !== '')
+		.map(([, value]) => value);
+	return eventIds.at(-1);
+}

--- a/web/src/lib/nostr/protocol/nip25.test.ts
+++ b/web/src/lib/nostr/protocol/nip25.test.ts
@@ -1,44 +1,91 @@
 import { describe, expect, it } from 'vitest';
 import { getReactionTargetEventId } from './nip25';
 
+const targetId1 = 'a'.repeat(64);
+const targetId2 = 'b'.repeat(64);
+
 describe('getReactionTargetEventId', () => {
-	it('returns the value of a single valid e tag', () => {
-		expect(getReactionTargetEventId([['e', 'target1']])).toBe('target1');
+	it('returns a single valid event ID', () => {
+		expect(getReactionTargetEventId([['e', targetId1]])).toBe(targetId1);
 	});
 
-	it('returns the last value of multiple valid e tags', () => {
+	it('returns the last valid event ID of multiple e tags', () => {
 		expect(
 			getReactionTargetEventId([
-				['e', 'target1'],
-				['e', 'target2']
+				['e', targetId1],
+				['e', targetId2]
 			])
-		).toBe('target2');
+		).toBe(targetId2);
 	});
 
-	it('ignores an empty string e tag', () => {
+	it('ignores an empty value', () => {
 		expect(
 			getReactionTargetEventId([
 				['e', ''],
-				['e', 'target1']
+				['e', targetId1]
 			])
-		).toBe('target1');
+		).toBe(targetId1);
 	});
 
-	it('ignores an e tag without content', () => {
-		expect(getReactionTargetEventId([['e'], ['e', 'target1']])).toBe('target1');
+	it('ignores a missing value', () => {
+		expect(getReactionTargetEventId([['e'], ['e', targetId1]])).toBe(targetId1);
 	});
 
-	it('returns undefined when there is no valid e tag', () => {
+	it('ignores a non-hex value', () => {
+		expect(
+			getReactionTargetEventId([
+				['e', 'g'.repeat(64)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+	});
+
+	it('ignores 63-character and 65-character values', () => {
+		expect(
+			getReactionTargetEventId([
+				['e', 'a'.repeat(63)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+		expect(
+			getReactionTargetEventId([
+				['e', 'a'.repeat(65)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+	});
+
+	it('ignores an uppercase hex value', () => {
+		expect(
+			getReactionTargetEventId([
+				['e', 'A'.repeat(64)],
+				['e', targetId1]
+			])
+		).toBe(targetId1);
+	});
+
+	it('returns an earlier valid event ID when the last e tag is invalid', () => {
+		expect(
+			getReactionTargetEventId([
+				['e', targetId1],
+				['e', 'invalid']
+			])
+		).toBe(targetId1);
+	});
+
+	it('returns undefined when there is no valid event ID', () => {
 		expect(getReactionTargetEventId([])).toBe(undefined);
 		expect(getReactionTargetEventId([['e', '']])).toBe(undefined);
 		expect(getReactionTargetEventId([['e']])).toBe(undefined);
+		expect(getReactionTargetEventId([['e', 'g'.repeat(64)]])).toBe(undefined);
+		expect(getReactionTargetEventId([['e', 'A'.repeat(64)]])).toBe(undefined);
 	});
 
 	it('ignores non-e tags', () => {
 		expect(
 			getReactionTargetEventId([
-				['p', 'target1'],
-				['t', 'target2']
+				['p', targetId1],
+				['t', targetId1]
 			])
 		).toBe(undefined);
 	});

--- a/web/src/lib/nostr/protocol/nip25.test.ts
+++ b/web/src/lib/nostr/protocol/nip25.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getReactionTargetEventId } from './nip25';
+
+describe('getReactionTargetEventId', () => {
+	it('returns the value of a single valid e tag', () => {
+		expect(getReactionTargetEventId([['e', 'target1']])).toBe('target1');
+	});
+
+	it('returns the last value of multiple valid e tags', () => {
+		expect(
+			getReactionTargetEventId([
+				['e', 'target1'],
+				['e', 'target2']
+			])
+		).toBe('target2');
+	});
+
+	it('ignores an empty string e tag', () => {
+		expect(
+			getReactionTargetEventId([
+				['e', ''],
+				['e', 'target1']
+			])
+		).toBe('target1');
+	});
+
+	it('ignores an e tag without content', () => {
+		expect(getReactionTargetEventId([['e'], ['e', 'target1']])).toBe('target1');
+	});
+
+	it('returns undefined when there is no valid e tag', () => {
+		expect(getReactionTargetEventId([])).toBe(undefined);
+		expect(getReactionTargetEventId([['e', '']])).toBe(undefined);
+		expect(getReactionTargetEventId([['e']])).toBe(undefined);
+	});
+
+	it('ignores non-e tags', () => {
+		expect(
+			getReactionTargetEventId([
+				['p', 'target1'],
+				['t', 'target2']
+			])
+		).toBe(undefined);
+	});
+});

--- a/web/src/lib/nostr/protocol/nip25.ts
+++ b/web/src/lib/nostr/protocol/nip25.ts
@@ -1,0 +1,6 @@
+export function getReactionTargetEventId(tags: string[][]): string | undefined {
+	const eventIds = tags
+		.filter(([name, value]) => name === 'e' && value !== undefined && value !== '')
+		.map(([, value]) => value);
+	return eventIds.at(-1);
+}

--- a/web/src/lib/nostr/protocol/nip25.ts
+++ b/web/src/lib/nostr/protocol/nip25.ts
@@ -1,6 +1,5 @@
+import { isValidEventId } from './event-id';
+
 export function getReactionTargetEventId(tags: string[][]): string | undefined {
-	const eventIds = tags
-		.filter(([name, value]) => name === 'e' && value !== undefined && value !== '')
-		.map(([, value]) => value);
-	return eventIds.at(-1);
+	return tags.findLast(([name, value]) => name === 'e' && isValidEventId(value))?.[1];
 }


### PR DESCRIPTION
## Summary

- Replace the generic `findLastId()` helper with NIP-18 and NIP-25 target lookup helpers
- Use protocol-specific helpers for repost and reaction handling
- Preserve the existing last non-empty `e` tag behavior