### PR TITLE
Split event deletion into feature modules

### DIFF
--- a/web/src/lib/ToastNotification.ts
+++ b/web/src/lib/ToastNotification.ts
@@ -4,7 +4,7 @@ import type { pubkey } from './Types';
 import type { Metadata } from './Items';
 import { metadataStore } from './cache/Events';
 import { isMuteEvent } from './stores/Author';
-import { deletedEventIdsByPubkey } from './author/Delete';
+import { deletedEventIdsByPubkey } from './features/event-deletion/application/deletion-state';
 import { isVisibleNotification } from './preferences/NotificationVisibility.svelte';
 
 export const unsentToastNotifications = new Map<pubkey, Nostr.Event[]>();

--- a/web/src/lib/author/Action.ts
+++ b/web/src/lib/author/Action.ts
@@ -9,7 +9,10 @@ import { getRepostTargetEventId } from '$lib/nostr/protocol/nip18';
 import { getReactionTargetEventId } from '$lib/nostr/protocol/nip25';
 import type { id } from '$lib/Types';
 import { pubkey } from '../stores/Author';
-import { deletedEventIdsByPubkey, storeDeletedEvents } from './Delete';
+import {
+	deletedEventIdsByPubkey,
+	markEventsDeleted
+} from '../features/event-deletion/application/deletion-state';
 import { Reaction, Repost } from 'nostr-tools/kinds';
 
 export const repostedEvents = writable(new Map<id, Nostr.Event[]>());
@@ -63,7 +66,7 @@ const observable = rxNostr
 	.pipe(tie, uniq(), share());
 observable.pipe(filterByKind(5)).subscribe(({ event }) => {
 	console.debug('[deleted]', event);
-	storeDeletedEvents(event);
+	markEventsDeleted(event);
 });
 observable
 	.pipe(

--- a/web/src/lib/author/Reaction.ts
+++ b/web/src/lib/author/Reaction.ts
@@ -3,7 +3,7 @@ import type * as Nostr from 'nostr-typedef';
 import { reactionedEvents, updateReactionedEvents } from './Action';
 import { getRelayHint, rxNostr, seenOn } from '$lib/timelines/MainTimeline';
 import { Signer } from '$lib/Signer';
-import { requestEventDeletion } from './Delete';
+import { requestEventDeletion } from '../features/event-deletion/application/request-event-deletion';
 import { sortEvents } from 'nostr-tools';
 import { get } from 'svelte/store';
 import { findCustomEmojiSetAddress } from './CustomEmojis';

--- a/web/src/lib/author/Repost.ts
+++ b/web/src/lib/author/Repost.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import { repostedEvents } from './Action';
 import { sortEvents, type Event } from 'nostr-tools';
-import { requestEventDeletion } from './Delete';
+import { requestEventDeletion } from '../features/event-deletion/application/request-event-deletion';
 
 export function undoRepost(target: Event): void {
 	const $repostedEvents = get(repostedEvents);

--- a/web/src/lib/author/legacy-bookmark-delete.test.ts
+++ b/web/src/lib/author/legacy-bookmark-delete.test.ts
@@ -20,7 +20,9 @@ vi.mock('./Bookmark.svelte', async () => {
 	const { writable } = await import('svelte/store');
 	return { legacyBookmarkEvent: writable() };
 });
-vi.mock('./Delete', () => ({ requestEventDeletion: mocks.requestEventDeletion }));
+vi.mock('../features/event-deletion/application/request-event-deletion', () => ({
+	requestEventDeletion: mocks.requestEventDeletion
+}));
 
 import { WebStorage } from '$lib/WebStorage';
 import { legacyBookmarkEvent } from './Bookmark.svelte';

--- a/web/src/lib/author/legacy-bookmark-delete.ts
+++ b/web/src/lib/author/legacy-bookmark-delete.ts
@@ -3,7 +3,7 @@ import { legacyBookmarkIdentifier } from '$lib/Constants';
 import { WebStorage } from '$lib/WebStorage';
 import { legacyBookmarkEvent } from './Bookmark.svelte';
 import { isLegacyBookmarkEvent } from './BookmarkMigration';
-import { requestEventDeletion } from './Delete';
+import { requestEventDeletion } from '../features/event-deletion/application/request-event-deletion';
 
 export async function deleteLegacyBookmarks(): Promise<void> {
 	const legacyEvent = get(legacyBookmarkEvent);

--- a/web/src/lib/components/MenuButton.svelte
+++ b/web/src/lib/components/MenuButton.svelte
@@ -30,7 +30,7 @@
 		IconTrash,
 		IconVolumeOff
 	} from '@tabler/icons-svelte-runes';
-	import { requestEventDeletion } from '$lib/author/Delete';
+	import { requestEventDeletion } from '$lib/features/event-deletion/application/request-event-deletion';
 	import { mute, unmute } from '$lib/author/Mute';
 	import { extractThreadReferenceTags } from '$lib/nostr/protocol/nip10';
 	import { getSeenOnRelays } from '$lib/timelines/MainTimeline';

--- a/web/src/lib/components/Timeline.svelte
+++ b/web/src/lib/components/Timeline.svelte
@@ -2,7 +2,7 @@
 	import { onMount, tick, untrack } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import { EventItem } from '$lib/Items';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { author, isMuteEvent } from '$lib/stores/Author';
 	import Loading from './Loading.svelte';
 	import EventComponent from './items/EventComponent.svelte';

--- a/web/src/lib/components/content/Reference.svelte
+++ b/web/src/lib/components/content/Reference.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nip19 } from 'nostr-tools';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { isMuteEvent } from '$lib/stores/Author';
 	import { userEvents } from '$lib/stores/UserEvents';
 	import Note from '../items/Note.svelte';

--- a/web/src/lib/components/content/ReferenceNip27.svelte
+++ b/web/src/lib/components/content/ReferenceNip27.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nip19 } from 'nostr-tools';
 	import { onMount } from 'svelte';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { events } from '$lib/stores/Events';
 	import { isMuteEvent } from '$lib/stores/Author';
 	import Text from './Text.svelte';

--- a/web/src/lib/components/items/Reaction.svelte
+++ b/web/src/lib/components/items/Reaction.svelte
@@ -5,7 +5,7 @@
 	import IconHeart from '@tabler/icons-svelte-runes/icons/heart';
 	import IconHeartBroken from '@tabler/icons-svelte-runes/icons/heart-broken';
 	import { nip19 } from 'nostr-tools';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { isMuteEvent } from '$lib/stores/Author';
 	import { developerMode } from '$lib/stores/Preference';
 	import CreatedAt from '$lib/components/CreatedAt.svelte';

--- a/web/src/lib/components/items/RepostedNote.svelte
+++ b/web/src/lib/components/items/RepostedNote.svelte
@@ -4,7 +4,7 @@
 	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
 	import IconRepeat from '@tabler/icons-svelte-runes/icons/repeat';
 	import { nip19 } from 'nostr-tools';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { isMuteEvent } from '$lib/stores/Author';
 	import { developerMode } from '$lib/stores/Preference';
 	import CreatedAt from '$lib/components/CreatedAt.svelte';

--- a/web/src/lib/components/items/Zap.svelte
+++ b/web/src/lib/components/items/Zap.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { nip19 } from 'nostr-tools';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { getSeenOnRelays, metadataReqEmit } from '$lib/timelines/MainTimeline';
 	import { ZapEventItem, type EventItem, type Item, type Metadata } from '$lib/Items';
 	import { eventItemStore, metadataStore } from '$lib/cache/Events';

--- a/web/src/lib/features/event-deletion/application/deletion-state.test.ts
+++ b/web/src/lib/features/event-deletion/application/deletion-state.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import type * as Nostr from 'nostr-typedef';
+import { deletedEventIdsByPubkey, markEventsDeleted } from './deletion-state';
+
+function deletionRequest(id: string, pubkey: string, tags: string[][] = []): Nostr.Event {
+	return { id, kind: 5, pubkey, content: '', tags, created_at: 1, sig: 'sig' };
+}
+
+beforeEach(() => {
+	deletedEventIdsByPubkey.set(new Map());
+});
+
+describe('markEventsDeleted', () => {
+	it('records e tag event IDs per request author pubkey', () => {
+		const pubkey = 'a'.repeat(64);
+		markEventsDeleted(
+			deletionRequest('d1', pubkey, [
+				['e', 'id1'],
+				['e', 'id2']
+			])
+		);
+
+		expect(get(deletedEventIdsByPubkey).get(pubkey)).toEqual(new Set(['id1', 'id2']));
+	});
+
+	it('adds IDs from multiple requests while preserving existing ones', () => {
+		const pubkey = 'a'.repeat(64);
+		markEventsDeleted(deletionRequest('d1', pubkey, [['e', 'id1']]));
+		markEventsDeleted(deletionRequest('d2', pubkey, [['e', 'id2']]));
+
+		expect(get(deletedEventIdsByPubkey).get(pubkey)).toEqual(new Set(['id1', 'id2']));
+	});
+
+	it('does not change state when the event has no e tags', () => {
+		const pubkey = 'a'.repeat(64);
+		markEventsDeleted(deletionRequest('d1', pubkey, [['p', 'x']]));
+
+		expect(get(deletedEventIdsByPubkey).size).toBe(0);
+	});
+});

--- a/web/src/lib/features/event-deletion/application/deletion-state.ts
+++ b/web/src/lib/features/event-deletion/application/deletion-state.ts
@@ -1,0 +1,25 @@
+import { get, writable } from 'svelte/store';
+import type * as Nostr from 'nostr-typedef';
+import { filterTags } from '$lib/EventHelper';
+
+export const deletedEventIdsByPubkey = writable(new Map<string, Set<string>>());
+
+export function markEventsDeleted(event: Nostr.Event): void {
+	const pubkey = event.pubkey;
+	const ids = filterTags('e', event.tags);
+
+	if (ids.length > 0) {
+		const $deletedEventIdsByPubkey = get(deletedEventIdsByPubkey);
+		const $deletedEventIds = $deletedEventIdsByPubkey.get(pubkey);
+		if ($deletedEventIds === undefined) {
+			$deletedEventIdsByPubkey.set(pubkey, new Set(ids));
+		} else {
+			for (const id of ids) {
+				$deletedEventIds.add(id);
+			}
+			$deletedEventIdsByPubkey.set(pubkey, $deletedEventIds);
+		}
+		deletedEventIdsByPubkey.set($deletedEventIdsByPubkey);
+		console.debug('[delete ids store]', $deletedEventIds);
+	}
+}

--- a/web/src/lib/features/event-deletion/application/request-event-deletion.test.ts
+++ b/web/src/lib/features/event-deletion/application/request-event-deletion.test.ts
@@ -13,9 +13,9 @@ vi.mock('$lib/stores/Author', async () => {
 	return { pubkey: writable(mocks.userPubkey) };
 });
 vi.mock('$lib/Signer', () => ({ Signer: { signEvent: mocks.signEvent } }));
-vi.mock('$lib/timelines/MainTimeline', () => ({ rxNostr: { send: mocks.send } }));
+vi.mock('$lib/nostr/relay/client', () => ({ rxNostr: { send: mocks.send } }));
 
-import { requestEventDeletion } from './Delete';
+import { requestEventDeletion } from './request-event-deletion';
 
 function event(
 	id: string,

--- a/web/src/lib/features/event-deletion/application/request-event-deletion.ts
+++ b/web/src/lib/features/event-deletion/application/request-event-deletion.ts
@@ -1,35 +1,11 @@
-import { get, writable } from 'svelte/store';
+import { get } from 'svelte/store';
 import { now } from 'rx-nostr';
 import { isAddressableKind, isReplaceableKind } from 'nostr-tools/kinds';
 import type * as Nostr from 'nostr-typedef';
 import { pubkey as authorPubkey } from '$lib/stores/Author';
-import { rxNostr } from '$lib/timelines/MainTimeline';
+import { rxNostr } from '$lib/nostr/relay/client';
 import { Signer } from '$lib/Signer';
-import { filterTags } from '$lib/EventHelper';
 import { getEventAddress } from '$lib/nostr/protocol/event-address';
-
-export const deletedEventIds = writable(new Set<string>());
-export const deletedEventIdsByPubkey = writable(new Map<string, Set<string>>());
-
-export function storeDeletedEvents(event: Nostr.Event): void {
-	const pubkey = event.pubkey;
-	const ids = filterTags('e', event.tags);
-
-	if (ids.length > 0) {
-		const $deletedEventIdsByPubkey = get(deletedEventIdsByPubkey);
-		const $deletedEventIds = $deletedEventIdsByPubkey.get(pubkey);
-		if ($deletedEventIds === undefined) {
-			$deletedEventIdsByPubkey.set(pubkey, new Set(ids));
-		} else {
-			for (const id of ids) {
-				$deletedEventIds.add(id);
-			}
-			$deletedEventIdsByPubkey.set(pubkey, $deletedEventIds);
-		}
-		deletedEventIdsByPubkey.set($deletedEventIdsByPubkey);
-		console.debug('[delete ids store]', $deletedEventIds);
-	}
-}
 
 export async function requestEventDeletion(
 	events: readonly Nostr.Event[],

--- a/web/src/lib/timelines/HomeTimeline.ts
+++ b/web/src/lib/timelines/HomeTimeline.ts
@@ -57,7 +57,7 @@ import {
 import { lastReadAt, notifiedEventItems } from '../author/Notifications';
 import { saveLastNote } from '../stores/LastNotes';
 import { isPeopleList, storePeopleList } from '$lib/author/PeopleLists';
-import { storeDeletedEvents } from '$lib/author/Delete';
+import { markEventsDeleted } from '$lib/features/event-deletion/application/deletion-state';
 import { NewTimeline } from './Timeline.svelte';
 import { excludeKinds } from '$lib/TimelineFilter';
 import { fetchMinutes } from '$lib/Helper';
@@ -203,7 +203,7 @@ export class HomeTimeline extends NewTimeline {
 			.subscribe(({ event }) => storeMetadata(event));
 		observable$
 			.pipe(filterByKind(Kind.EventDeletion))
-			.subscribe(({ event }) => storeDeletedEvents(event));
+			.subscribe(({ event }) => markEventsDeleted(event));
 		observable$
 			.pipe(filterByKind(Kind.BadgeAward))
 			.subscribe(({ event, from }) => storeSeenOn(event.id, from)); // TODO: Migrate to tie

--- a/web/src/routes/(app)/TimelineView.svelte
+++ b/web/src/routes/(app)/TimelineView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Item } from '$lib/Items';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import { author, isMuteEvent } from '$lib/stores/Author';
 	import Loading from '$lib/components/Loading.svelte';
 	import EventComponent from '$lib/components/items/EventComponent.svelte';

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelMessageList.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelMessageList.svelte
@@ -6,7 +6,7 @@
 	import { innerHeight, scrollY } from 'svelte/reactivity/window';
 	import { IconArrowDown } from '@tabler/icons-svelte-runes';
 	import { isMuteEvent } from '$lib/stores/Author';
-	import { deletedEventIdsByPubkey } from '$lib/author/Delete';
+	import { deletedEventIdsByPubkey } from '$lib/features/event-deletion/application/deletion-state';
 	import Loading from '$lib/components/Loading.svelte';
 	import type { ChannelChat } from './ChannelChat.svelte';
 	import ChannelMessage from './ChannelMessage.svelte';


### PR DESCRIPTION
## Summary

- Split `web/src/lib/author/Delete.ts` into feature-owned application modules
- Add `features/event-deletion/application/deletion-state.ts` with `markEventsDeleted()`
- Add `features/event-deletion/application/request-event-deletion.ts` for the deletion use case
- Import `rxNostr` from the canonical `nostr/relay/client` owner
- Remove the unused `deletedEventIds` store