### PR TITLE
Move legacy bookmark copy use case to feature application module

### DIFF
--- a/web/src/lib/features/bookmarks/application/copy-legacy-bookmarks.test.ts
+++ b/web/src/lib/features/bookmarks/application/copy-legacy-bookmarks.test.ts
@@ -32,9 +32,14 @@ vi.mock('$lib/Signer', () => ({
 		encryptNip44: mocks.encryptNip44
 	}
 }));
-vi.mock('$lib/timelines/MainTimeline', () => ({
-	rxNostr: { send: mocks.send, use: mocks.use },
+vi.mock('$lib/nostr/relay/client', () => ({
+	rxNostr: { send: mocks.send, use: mocks.use }
+}));
+vi.mock('$lib/nostr/relay/relay-hints', () => ({
 	tie: <T>(source: T): T => source
+}));
+vi.mock('$lib/timelines/MainTimeline', () => ({
+	rxNostr: { send: mocks.send }
 }));
 vi.mock('$lib/WebStorage', () => ({
 	WebStorage: class {
@@ -54,8 +59,8 @@ import {
 	bookmarkEvent,
 	bookmarkOperationState,
 	legacyBookmarkEvent
-} from './Bookmark.svelte';
-import { copyLegacyBookmarks } from './BookmarkCopy';
+} from '../../../author/Bookmark.svelte';
+import { copyLegacyBookmarks } from './copy-legacy-bookmarks';
 
 const eventId = 'a'.repeat(64);
 const otherEventId = 'b'.repeat(64);

--- a/web/src/lib/features/bookmarks/application/copy-legacy-bookmarks.ts
+++ b/web/src/lib/features/bookmarks/application/copy-legacy-bookmarks.ts
@@ -5,15 +5,13 @@ import type * as Nostr from 'nostr-typedef';
 import { kinds as Kind } from 'nostr-tools';
 import { legacyBookmarkIdentifier } from '$lib/Constants';
 import { isLegacyEncryption } from '$lib/nostr/protocol/nip04';
+import { rxNostr } from '$lib/nostr/relay/client';
+import { tie } from '$lib/nostr/relay/relay-hints';
 import { Signer } from '$lib/Signer';
 import { pubkey } from '$lib/stores/Author';
-import { rxNostr, tie } from '$lib/timelines/MainTimeline';
 import { WebStorage } from '$lib/WebStorage';
-import { bookmarkEvent, runBookmarkCopyExclusively } from './Bookmark.svelte';
-import {
-	isLegacyBookmarkEvent,
-	mergeBookmarkReferences
-} from '../features/bookmarks/domain/bookmark-migration';
+import { bookmarkEvent, runBookmarkCopyExclusively } from '$lib/author/Bookmark.svelte';
+import { isLegacyBookmarkEvent, mergeBookmarkReferences } from '../domain/bookmark-migration';
 
 function isTagCollection(value: unknown): value is string[][] {
 	return (

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -24,7 +24,7 @@
 		resolveSelectedBookmarkList
 	} from './BookmarkListTabs';
 	import { BookmarkPageState } from './BookmarkPageState.svelte';
-	import { copyLegacyBookmarks } from '$lib/author/BookmarkCopy';
+	import { copyLegacyBookmarks } from '$lib/features/bookmarks/application/copy-legacy-bookmarks';
 	import { addToast } from '$lib/components/Toaster.svelte';
 	import { deleteLegacyBookmarks } from '$lib/author/legacy-bookmark-delete';
 


### PR DESCRIPTION
Move the legacy bookmark copy use case from `web/src/lib/author/BookmarkCopy.ts` into the bookmark feature application layer at `web/src/lib/features/bookmarks/application/copy-legacy-bookmarks.ts`.

- `copyLegacyBookmarks()`, `decryptBookmarkContentStrict()`, and the internal `fetchBookmarkSources()` / `tagsEqual()` helpers are moved unchanged.
- `rxNostr` and `tie` are now imported directly from the canonical relay owners (`/nostr/relay/client`, `/nostr/relay/relay-hints`) instead of via `/timelines/MainTimeline`; relay behavior is unchanged.
- Bookmark pure rules are reused from `../domain/bookmark-migration`.
- The test moves alongside and keeps the same coverage (mocks updated for the new relay import paths).
- The bookmarks page imports the new module directly; the old module and its test are removed.