### PR TITLE
Move legacy bookmark deletion use case to feature application module

### DIFF
--- a/web/src/lib/features/bookmarks/application/delete-legacy-bookmarks.test.ts
+++ b/web/src/lib/features/bookmarks/application/delete-legacy-bookmarks.test.ts
@@ -16,17 +16,17 @@ vi.mock('$lib/stores/Author', async () => {
 vi.mock('$lib/cache/Events', () => ({
 	eventCache: { addIfNotExists: vi.fn() }
 }));
-vi.mock('./Bookmark.svelte', async () => {
+vi.mock('$lib/author/Bookmark.svelte', async () => {
 	const { writable } = await import('svelte/store');
 	return { legacyBookmarkEvent: writable() };
 });
-vi.mock('../features/event-deletion/application/request-event-deletion', () => ({
+vi.mock('$lib/features/event-deletion/application/request-event-deletion', () => ({
 	requestEventDeletion: mocks.requestEventDeletion
 }));
 
 import { WebStorage } from '$lib/WebStorage';
-import { legacyBookmarkEvent } from './Bookmark.svelte';
-import { deleteLegacyBookmarks } from './legacy-bookmark-delete';
+import { legacyBookmarkEvent } from '$lib/author/Bookmark.svelte';
+import { deleteLegacyBookmarks } from './delete-legacy-bookmarks';
 
 class MemoryStorage implements Storage {
 	readonly #items = new Map<string, string>();

--- a/web/src/lib/features/bookmarks/application/delete-legacy-bookmarks.ts
+++ b/web/src/lib/features/bookmarks/application/delete-legacy-bookmarks.ts
@@ -1,9 +1,9 @@
 import { get } from 'svelte/store';
 import { legacyBookmarkIdentifier } from '$lib/Constants';
 import { WebStorage } from '$lib/WebStorage';
-import { legacyBookmarkEvent } from './Bookmark.svelte';
-import { isLegacyBookmarkEvent } from '../features/bookmarks/domain/bookmark-migration';
-import { requestEventDeletion } from '../features/event-deletion/application/request-event-deletion';
+import { legacyBookmarkEvent } from '$lib/author/Bookmark.svelte';
+import { isLegacyBookmarkEvent } from '$lib/features/bookmarks/domain/bookmark-migration';
+import { requestEventDeletion } from '$lib/features/event-deletion/application/request-event-deletion';
 
 export async function deleteLegacyBookmarks(): Promise<void> {
 	const legacyEvent = get(legacyBookmarkEvent);

--- a/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/bookmarks/+page.svelte
@@ -26,7 +26,7 @@
 	import { BookmarkPageState } from './BookmarkPageState.svelte';
 	import { copyLegacyBookmarks } from '$lib/features/bookmarks/application/copy-legacy-bookmarks';
 	import { addToast } from '$lib/components/Toaster.svelte';
-	import { deleteLegacyBookmarks } from '$lib/author/legacy-bookmark-delete';
+	import { deleteLegacyBookmarks } from '$lib/features/bookmarks/application/delete-legacy-bookmarks';
 
 	let { data }: LayoutProps = $props();
 


### PR DESCRIPTION
Move the legacy bookmark deletion use case from `web/src/lib/author/legacy-bookmark-delete.ts` into the bookmark feature application layer at `web/src/lib/features/bookmarks/application/delete-legacy-bookmarks.ts`.

- The use case body (state read, validation, deletion request, cache/state cleanup) is unchanged.
- Domain validation now comes directly from `/features/bookmarks/domain/bookmark-migration`, and the deletion request from `/features/event-deletion/application/request-event-deletion`.
- `legacyBookmarkEvent` is still referenced from `/author/Bookmark.svelte`; splitting that module is a separate migration.
- The test moves alongside with its mock/import paths updated for the new module location.
- The bookmarks page imports the new module directly; the old module and its test are removed.