### PR TITLE
Migrate ModalDialog close event to callback prop

### DIFF
--- a/web/src/lib/components/ModalDialog.svelte
+++ b/web/src/lib/components/ModalDialog.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
-
 	interface Props {
 		open?: boolean;
 		children?: import('svelte').Snippet;
+		onclose?: () => void;
 	}
 
-	let { open = $bindable(false), children }: Props = $props();
+	let { open = $bindable(false), children, onclose }: Props = $props();
 
 	let dialog: HTMLDialogElement | undefined = $state();
-
-	const dispatch = createEventDispatcher();
 
 	$effect(() => {
 		if (open) {
@@ -32,7 +29,7 @@
 	function onClose(): void {
 		console.debug('[dialog on close]');
 		open = false;
-		dispatch('close');
+		onclose?.();
 	}
 </script>
 

--- a/web/src/lib/components/actions/ListDialog.svelte
+++ b/web/src/lib/components/actions/ListDialog.svelte
@@ -104,7 +104,7 @@
 	}
 </script>
 
-<ModalDialog bind:open on:close={save}>
+<ModalDialog bind:open onclose={save}>
 	<article>
 		<h2>{$_('lists.title')}</h2>
 		<table>

--- a/web/src/routes/(app)/profile/+page.svelte
+++ b/web/src/routes/(app)/profile/+page.svelte
@@ -164,7 +164,7 @@
 <h1>{$_('pages.profile_edit')}</h1>
 
 {#if $authorProfile}
-	<ModalDialog bind:open on:close={close}>
+	<ModalDialog bind:open onclose={close}>
 		<div class="crop">
 			<Cropper image={url} aspect={1} maxZoom={10} oncropcomplete={onCropComplete} />
 		</div>


### PR DESCRIPTION
Refs #2374

Migrate `ModalDialog`'s `close` component event from `createEventDispatcher` to a Svelte 5 callback prop, as part of the legacy component-event migration.

- `ModalDialog.svelte`: removed `createEventDispatcher`, added an `onclose?: () => void` callback prop, and replaced `dispatch('close')` with `onclose?.()`.
- Updated the only `on:close` callers to the new API: `profile/+page.svelte` and `ListDialog.svelte` now use `onclose={...}`.
- Behavior is unchanged: ESC closes the dialog (open becomes false), the close callback fires at the same time, `bind:open` works as before, and the backdrop-click close path is untouched.

Validation (run in order):
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: prettier passes; eslint clean on all changed files (full-repo eslint is OOM-terminated in this container, unrelated to the change)
- No `on:close` usage remains on `ModalDialog` callers