### PR TITLE
Migrate MediaPicker pick event to callback prop

### DIFF
--- a/web/src/lib/components/MediaPicker.svelte
+++ b/web/src/lib/components/MediaPicker.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import IconPhoto from '@tabler/icons-svelte-runes/icons/photo';
 	import { _ } from 'svelte-i18n';
 
 	interface Props {
 		multiple?: boolean;
 		disabled?: boolean;
+		onPick?: (files: FileList) => void;
 	}
 
-	let { multiple = false, disabled = false }: Props = $props();
+	let { multiple = false, disabled = false, onPick }: Props = $props();
 
 	let input = $state<HTMLInputElement>();
 	let files = $state<FileList>();
-
-	const dispatch = createEventDispatcher();
 
 	function onclick(e: MouseEvent): void {
 		e.preventDefault();
@@ -22,7 +20,7 @@
 	}
 
 	function onchange(): void {
-		if (!disabled) dispatch('pick', files);
+		if (!disabled && files !== undefined) onPick?.(files);
 		if (input !== undefined) {
 			input.value = '';
 		}

--- a/web/src/lib/components/composer/NoteComposer.svelte
+++ b/web/src/lib/components/composer/NoteComposer.svelte
@@ -588,7 +588,7 @@
 		addAttachments(files);
 	}
 
-	function mediaPicked({ detail: files }: { detail: FileList }): void {
+	function mediaPicked(files: FileList): void {
 		console.log('[media picked]', files);
 		addAttachments(files);
 	}
@@ -716,7 +716,7 @@
 
 	<div class="actions">
 		<div class="options">
-			<MediaPicker multiple={true} disabled={composerLocked} on:pick={mediaPicked} />
+			<MediaPicker multiple={true} disabled={composerLocked} onPick={mediaPicked} />
 			<EmojiPicker
 				containsDefaultEmoji={false}
 				autoClose={false}

--- a/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
+++ b/web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte
@@ -152,7 +152,7 @@
 		addAttachments(files);
 	}
 
-	function mediaPicked({ detail: files }: { detail: FileList }): void {
+	function mediaPicked(files: FileList): void {
 		addAttachments(files);
 	}
 
@@ -217,7 +217,7 @@
 		onAddUrls={addAttachmentUrls}
 	/>
 	<div class="input">
-		<MediaPicker multiple={true} disabled={composerLocked} on:pick={mediaPicked} />
+		<MediaPicker multiple={true} disabled={composerLocked} onPick={mediaPicked} />
 		<EmojiPicker inComposer={true} onPick={onEmojiPick} />
 		<textarea
 			bind:this={textarea}

--- a/web/src/routes/(app)/profile/+page.svelte
+++ b/web/src/routes/(app)/profile/+page.svelte
@@ -84,7 +84,7 @@
 
 	//#endregion
 
-	async function picturePicked({ detail: files }: { detail: FileList }): Promise<void> {
+	async function picturePicked(files: FileList): Promise<void> {
 		console.log('[profile picture]', files);
 		if (files.length !== 1) {
 			console.error('[profile picture error]', files);
@@ -111,7 +111,7 @@
 		}
 	}
 
-	async function bannerPicked({ detail: files }: { detail: FileList }): Promise<void> {
+	async function bannerPicked(files: FileList): Promise<void> {
 		console.log('[profile banner]', files);
 		if (files.length !== 1) {
 			console.error('[profile banner error]', files);
@@ -184,7 +184,7 @@
 					placeholder="https://example.com/banner.webp"
 					bind:value={$authorProfile.banner}
 				/>
-				<MediaPicker on:pick={bannerPicked} />
+				<MediaPicker onPick={bannerPicked} />
 			</div>
 			{#if $authorProfile.banner}
 				<img src={$authorProfile.banner} alt="preview" />
@@ -199,7 +199,7 @@
 					placeholder="https://example.com/picture.png"
 					bind:value={$authorProfile.picture}
 				/>
-				<MediaPicker on:pick={picturePicked} />
+				<MediaPicker onPick={picturePicked} />
 			</div>
 			{#if $authorProfile.picture}
 				<img src={$authorProfile.picture} alt="preview" />


### PR DESCRIPTION
Refs #2374

Migrates `MediaPicker`'s `pick` component event to a Svelte 5 callback prop, as part of the Svelte 5 migration tracked in #2374.

## Changes

- `MediaPicker.svelte` no longer uses `createEventDispatcher`. It now exposes an `onPick` callback prop that receives the selected `FileList` directly, replacing the previous `CustomEvent`/`detail` indirection:

  ```ts
  onPick?: (files: FileList) => void;
  ```

- Existing behavior is preserved: the callback is invoked once per file selection, `multiple`/`disabled` semantics are unchanged, and the input value is still reset after selection so the same file can be picked again.
- Updated the direct callers:
  - `web/src/routes/(app)/profile/+page.svelte` (`picturePicked`, `bannerPicked`)
  - `web/src/lib/components/composer/NoteComposer.svelte` (`mediaPicked`)
  - `web/src/routes/(app)/channels/[nevent=note]/ChannelComposer.svelte` (`mediaPicked`)

  Their handlers now take `FileList` directly instead of `{ detail: FileList }`.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — pass
- `npx vitest run src/lib/components/MediaPicker.test.ts` — 1 passed
- `npm test` — 440 passed