### PR TITLE
Migrate ZapDialog zapped event to callback prop

### DIFF
--- a/web/src/lib/components/ZapDialog.svelte
+++ b/web/src/lib/components/ZapDialog.svelte
@@ -2,7 +2,6 @@
 	import { nip57 } from 'nostr-tools';
 	import QRCode from 'qrcode';
 	import { writeRelays } from '$lib/stores/Author';
-	import { createEventDispatcher } from 'svelte';
 	import { persistedStore } from '$lib/platform/storage/persisted-store';
 	import { WebStorage } from '$lib/WebStorage';
 	import { Signer } from '$lib/Signer';
@@ -18,9 +17,10 @@
 	interface Props {
 		pubkey: string;
 		item?: EventItem | undefined;
+		onZapped?: () => void;
 	}
 
-	let { pubkey, item }: Props = $props();
+	let { pubkey, item, onZapped }: Props = $props();
 
 	let metadata = $derived($metadataStore.get(pubkey));
 
@@ -45,8 +45,6 @@
 		}
 		satsList = [...counts].toSorted(([, x], [, y]) => y - x).map(([value]) => value);
 	});
-
-	const dispatch = createEventDispatcher();
 
 	async function zap(e: SubmitEvent) {
 		e.preventDefault();
@@ -95,7 +93,7 @@
 				const success = await zapWithWalletConnect(walletConnectUri, zapInvoice);
 				if (success) {
 					open = false;
-					dispatch('zapped');
+					onZapped?.();
 					return;
 				}
 			} catch (error) {
@@ -104,7 +102,7 @@
 		}
 
 		invoice = zapInvoice;
-		dispatch('zapped');
+		onZapped?.();
 	}
 </script>
 

--- a/web/src/lib/components/actions/ActionMenu.svelte
+++ b/web/src/lib/components/actions/ActionMenu.svelte
@@ -86,7 +86,7 @@
 	</button>
 	<MenuButton event={item.event} {iconSize} bind:showDetails={jsonDisplay} />
 </div>
-<ZapDialog pubkey={item.event.pubkey} {item} bind:this={zapDialogComponent} on:zapped={onZapped} />
+<ZapDialog pubkey={item.event.pubkey} {item} bind:this={zapDialogComponent} {onZapped} />
 {#if jsonDisplay}
 	<div class="develop">
 		<h5>Event ID</h5>


### PR DESCRIPTION
Refs #2374

Migrates `ZapDialog`'s `zapped` component event to a Svelte 5 callback prop, as part of the Svelte 5 migration tracked in #2374.

## Changes

- `ZapDialog.svelte` no longer uses `createEventDispatcher`. It now exposes an `onZapped` callback prop:

  ```ts
  interface Props {
  	pubkey: string;
  	item?: EventItem | undefined;
  	onZapped?: () => void;
  }
  ```

- The `zapped` event carried no payload and subscribers never used an argument, so the callback is argument-free rather than mimicking a `CustomEvent`.
- The two existing dispatch paths are preserved unchanged in timing:
  - NWC payment success: the dialog is closed first, then `onZapped?.()` is called.
  - Regular invoice flow: the invoice is set first, then `onZapped?.()` is called.
  - Error paths do not call the callback.
- Updated the only subscriber, `ActionMenu.svelte`, from `on:zapped={onZapped}` to `{onZapped}`.
- `ZapButton.svelte` and `ChannelMessage.svelte` do not subscribe to `zapped`, so they were left unchanged; the new prop is optional.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — pass
- No unit tests exist for `ZapDialog`/`ActionMenu`
- `npm test` — 440 passed