### PR TITLE
Migrate Relay remove event to callback prop

### DIFF
--- a/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
+++ b/web/src/routes/(app)/[slug=npub]/relays/+page.svelte
@@ -153,7 +153,7 @@
 		</li>
 		{#each relays as relay}
 			<li>
-				<Relay {relay} readonly={!editable} on:remove={() => remove(relay.url)} />
+				<Relay {relay} readonly={!editable} onRemove={() => remove(relay.url)} />
 			</li>
 		{:else}
 			<div class="loading">

--- a/web/src/routes/(app)/[slug=npub]/relays/Relay.svelte
+++ b/web/src/routes/(app)/[slug=npub]/relays/Relay.svelte
@@ -1,21 +1,16 @@
 <script lang="ts">
-	import { preventDefault } from 'svelte/legacy';
-
-	import { createEventDispatcher } from 'svelte';
 	import IconTrash from '@tabler/icons-svelte-runes/icons/trash';
 
 	interface Props {
 		relay: { url: string; read: boolean; write: boolean };
 		readonly: boolean;
+		onRemove?: () => void;
 	}
 
-	let { relay = $bindable(), readonly }: Props = $props();
+	let { relay = $bindable(), readonly, onRemove }: Props = $props();
 
-	const dispatch = createEventDispatcher();
-
-	function remove() {
-		dispatch('remove');
-		return false;
+	function remove(): void {
+		onRemove?.();
 	}
 </script>
 
@@ -29,7 +24,7 @@
 	</div>
 	{#if !readonly}
 		<div class="remove">
-			<button onclick={preventDefault(remove)} class="clear">
+			<button type="button" onclick={remove} class="clear">
 				<IconTrash size={17} />
 			</button>
 		</div>

--- a/web/src/routes/(app)/[slug=npub]/relays/Relay.test.ts
+++ b/web/src/routes/(app)/[slug=npub]/relays/Relay.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import Relay from './Relay.svelte';
+
+const relay = { url: 'wss://relay.example.com', read: true, write: true };
+
+describe('Relay', () => {
+	it('renders the remove button as type="button" so it does not submit a form', () => {
+		const { body } = render(Relay, { props: { relay, readonly: false } });
+		expect(body).toMatch(/<button[^>]*type="button"/);
+	});
+
+	it('does not render the remove button when readonly', () => {
+		const { body } = render(Relay, { props: { relay, readonly: true } });
+		expect(body).not.toMatch(/<button/);
+	});
+});


### PR DESCRIPTION
Refs #2374

Migrates `Relay`'s `remove` component event to a Svelte 5 callback prop and removes the `svelte/legacy` `preventDefault` modifier, as part of the Svelte 5 migration tracked in #2374.

## Changes

- `Relay.svelte` no longer uses `createEventDispatcher`. It now exposes an optional `onRemove` callback prop:

  ```ts
  interface Props {
  	relay: { url: string; read: boolean; write: boolean };
  	readonly: boolean;
  	onRemove?: () => void;
  }
  ```

- The `remove` event carried no payload and subscribers did not use the event object, so the callback is argument-free (`onRemove?.()`).
- Removed the `svelte/legacy` `preventDefault` wrapper. The delete button is an ordinary action button inside the parent `<form>`, so it is now declared `<button type="button">`, which has no submit behavior and makes `preventDefault` unnecessary. `remove()` was reduced to a plain `void` callback (the legacy-only `return false` was removed).
- Updated the parent usage in `+page.svelte` from `on:remove={() => remove(relay.url)}` to `onRemove={() => remove(relay.url)}`.
- Added a small SSR test (`Relay.test.ts`) asserting the remove button renders with `type="button"` and is absent when readonly, confirming the delete action cannot submit the parent form.

The other `preventDefault()` calls in `+page.svelte` (`add`, `save`, Edit button) are plain DOM handlers and were left untouched.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — pass
- `npx vitest run src/routes/(app)/[slug=npub]/relays/Relay.test.ts` — 2 passed
- `npm test` — 442 passed