### PR TITLE
Use plain event handler for CreateChannelButton form submit

### DIFF
--- a/web/src/lib/components/actions/CreateChannelButton.svelte
+++ b/web/src/lib/components/actions/CreateChannelButton.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { preventDefault } from 'svelte/legacy';
-
 	import { _ } from 'svelte-i18n';
 	import { now } from 'rx-nostr';
 	import { filter } from 'rxjs';
@@ -18,7 +16,8 @@
 
 	let creatable = $derived(name !== '');
 
-	function createChannel(): void {
+	function createChannel(event: SubmitEvent): void {
+		event.preventDefault();
 		console.log('[channel create]', name, about, picture);
 
 		if (name === '') {
@@ -58,7 +57,7 @@
 
 <ModalDialog bind:open>
 	<h2>{$_('public_chat.create_channel')}</h2>
-	<form onsubmit={preventDefault(createChannel)}>
+	<form onsubmit={createChannel}>
 		<div>
 			<label>
 				<div>{$_('public_chat.channel.name')}</div>


### PR DESCRIPTION
Refs #2374

Migrates the `svelte/legacy` `preventDefault` modifier off `CreateChannelButton.svelte`, as part of the Svelte 5 migration tracked in #2374.

## Changes

- Removed the `import { preventDefault } from 'svelte/legacy';` and its usage on the form.
- `createChannel` now takes the `SubmitEvent` directly and calls `event.preventDefault()` at the top, following the Svelte 5 migration guide:

  ```ts
  function createChannel(event: SubmitEvent): void {
  	event.preventDefault();
  	// existing logic
  }
  ```

  ```svelte
  <form onsubmit={createChannel}>
  ```

- The channel creation logic (name validation, trim/validation, `Signer.signEvent`, `rxNostr.send`, dialog close on first success) is unchanged.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — pass
- No unit tests cover this component (and a meaningful one would require DOM test infrastructure), so none were added
- `npm test` — 442 passed