### PR TITLE
Fix: Timelines scrolling back to the top when scrolled to the bottom

### DIFF
--- a/web/src/lib/components/shared/Foldable.svelte
+++ b/web/src/lib/components/shared/Foldable.svelte
@@ -13,6 +13,7 @@
 
 	let container = $state<HTMLDivElement>();
 	let overflowing = $state(false);
+	let measured = $state(false);
 	let folded = $state(true);
 
 	const measure: Attachment<HTMLElement> = (element) => {
@@ -21,6 +22,7 @@
 			for (const entry of entries) {
 				const blockSize = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
 				overflowing = blockSize > maxHeight;
+				measured = true;
 			}
 		});
 		observer.observe(element);
@@ -36,8 +38,13 @@
 	}
 </script>
 
+<!--
+	Cap the height until the first measurement. Otherwise long content is laid out at
+	full height for a frame, and virtua measures it and shifts the scroll position.
+-->
 <div
 	bind:this={container}
+	class:unmeasured={enabled && folded && !measured}
 	class:folded={enabled && overflowing && folded}
 	style:--fold-max-height="{maxHeightRem}rem"
 >
@@ -58,6 +65,11 @@
 </div>
 
 <style>
+	/* max-height only, so content shorter than the cap lays out exactly as before */
+	.unmeasured {
+		max-height: var(--fold-max-height);
+	}
+
 	.folded {
 		max-height: var(--fold-max-height);
 		overflow: hidden;

--- a/web/src/lib/components/shared/Foldable.svelte
+++ b/web/src/lib/components/shared/Foldable.svelte
@@ -38,10 +38,6 @@
 	}
 </script>
 
-<!--
-	Cap the height until the first measurement. Otherwise long content is laid out at
-	full height for a frame, and virtua measures it and shifts the scroll position.
--->
 <div
 	bind:this={container}
 	class:unmeasured={enabled && folded && !measured}
@@ -65,7 +61,6 @@
 </div>
 
 <style>
-	/* max-height only, so content shorter than the cap lays out exactly as before */
 	.unmeasured {
 		max-height: var(--fold-max-height);
 	}


### PR DESCRIPTION
# Problem

- Adjust the Chrome window height so that `innerHeight` is between 983 and 1111.
- Open http://nostter.app/search?q=%E7%94%9F%E8%87%AD%E5%9D%8A%E4%B8%BB&scope=nostr (the search page for "生臭坊主").
- Scroll to the bottom.
  - Problem:
    - About every 3 seconds, the page scrolls to the top by itself, so I can't read the notes at the bottom.
  - Expected:
    - After scrolling to the bottom, the page stays there and I can read the notes at the bottom.

# Cause

- The long note nevent1qvzqqqqqqypzq4gsddkzx2fjqtnw0m2tknlejw3zp7gsueprdlcnwuxpd5mxml7aqqs0ldkns3nu7pg520yyt76trggv9earqfqwu05l0q5fdze275l0l4gzalawt is shown folded (30rem). However, `Foldable.svelte` rendered it at
its full unfolded height on its first render, because folding was applied only afterwards by a ResizeObserver callback.
- virtua (the virtualized list that renders only part of the list) unmounts items outside the render range and mounts them again when they come
back into the range.
- Each time the note is mounted again, virtua measures its full height (about 29,771px) for a moment and calls `scrollBy(+29,166)`. The note is
then folded, and virtua calls `scrollBy(-29,166)`.
- By the time the note shrinks, however, the browser has already clamped the scroll position to the new maximum. The subtraction is therefore applied twice, and the page jumps to y=0 (the top).
- While the page is at the bottom, loading repeats, and showing and hiding the loading spinner changes the page height by about 68px. Each time, the long note moves in and out of the edge of the render range, so the
jump happens again and again. When the 7th result is added, the long note sits exactly at that edge.

# Changes

- Only `web/src/lib/components/shared/Foldable.svelte` is changed.
- Until the first measurement (ResizeObserver) arrives, the height is capped with `max-height` only (`.unmeasured` class).
  - A long note is laid out at its folded height right after it is mounted again, so virtua no longer measures its full height or shifts the scroll position.
  - `overflow` and `position` are not changed, so short notes are displayed as before.

# Affected pages

- pages that show notes with virtua's `TimelineView`
  - Search `/search`, Notifications `/notifications`
  - Profile tabs (notes, media, reactions, timeline, pins, bookmarks, lists, date pages)
  - `/[note]`, `/[note]/quotes`, `/[note]/reposts/after`
  - `/relays/[url]`, `/latest`, `/replay/home`
  - `/home`, `/public`

# test
- unit tests
  - `npm run check` → 0 errors, 0 warnings
  - `npm run lint` → passed
  - `npm test` → 56 test files, 442 tests passed
  - `npm run build` → passed
- E2E tests
  - main effect
    - Follow the steps above in a browser → the problem disappeared
  - side effects
    - Check affected pages → no problem is found

# Appendix: problematic results on my search
The following posts were shown when I got the issue:

top of the page
↑
- nevent1qvzqqqqqqypzqm8gf0gguqfg72cxrj8kevnfw9qswp24ylfn29pndrzg7x0smt57qyt8wumn8ghj7um9v9exx6pwdehhxtn5dajxz7gpzpmhxue69uhkummnw3ezuamfdejsqgxnervz3sc2mef6rmj209ryumfq2pcest0zhqha57es723f9sckrvdwpnl8
- nevent1qvzqqqqqqypzq4gsddkzx2fjqtnw0m2tknlejw3zp7gsueprdlcnwuxpd5mxml7aqyt8wumn8ghj7um9v9exx6pwdehhxtn5dajxz7gpzpmhxue69uhkummnw3ezuamfdejsqg8lkmfcge70q5298jz9ld935yxzu73sys8w860hs2yk3v4020hl650pn6nt
- nevent1qvzqqqqqqypzql4peaajd4tzcspm3ra9ecwtpe7guc53uya2n7nhf2hm54n6ta08qyt8wumn8ghj7um9v9exx6pwdehhxtn5dajxz7gqypa48lu93dg5axm6xzkpfh5cnu7letr52extulu372yekg6rhrwuc8s6ag9
- nevent1qvzqqqqqqypzpxuypcfppx376t25ca0gwgjxuakedfzlehttzuwuwglw43er9c5mqyt8wumn8ghj7um9v9exx6pwdehhxtn5dajxz7gpzpmhxue69uhkummnw3ezuamfdejsqgzhqrkgq8fdzxkpywf3yx4ngzd03t5skz82dwepcg5mrava6nxduv46zeu4
- nevent1qvzqqqqqqypzpthgj8uwj0mydck4v8hd358mn4q8q09ucphmjyf78hnwtzsmckhtqyt8wumn8ghj7um9v9exx6pwdehhxtn5dajxz7gpzpmhxue69uhkummnw3ezuamfdejsqg99q5xm3hen8pmln09a9gg6ruurw683zun92kjgv2zpzartkf3uhskj4t64
- nevent1qvzqqqqqqypzqseqzw9ylcawxe8k6d29hnl8jledj2gw0kg3xgdfh3n4urwjgyc7qyg8wumn8ghj7mn0wd68ytnhd9hx2qpqjd2363an0g8ej6v372eapkc2mdtyzey9hzdx72ht9kfm4edz4ajqfy8zl9
- nevent1qvzqqqqqqypzpjqu0xvlwfmrsuchs789n47ryyyn5seewlhxsyw2wmwr49ecuxrfqyg8wumn8ghj7mn0wd68ytnhd9hx2qpqapkyrfl227psrplc954kuw8asy8nqdc6wa6w8xkk4yn3u4nme73s7h0nrn
↓
bottom of the page