### PR TITLE
Remove unneeded stopPropagation from LongFormContent

### DIFF
--- a/web/src/lib/components/content/LongFormContent.svelte
+++ b/web/src/lib/components/content/LongFormContent.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { stopPropagation } from 'svelte/legacy';
-
 	import { nip19, type Event } from 'nostr-tools';
 	import { getOpenNoteDialog } from '$lib/NoteDialogContext';
 	import IconCodeDots from '@tabler/icons-svelte-runes/icons/code-dots';
@@ -49,10 +47,10 @@
 			<h1>{title ?? '-'}</h1>
 			<p>{summary ?? ''}</p>
 			<div class="action-menu">
-				<button onclick={stopPropagation(quote)}>
+				<button onclick={quote}>
 					<IconQuote size={iconSize} />
 				</button>
-				<button onclick={stopPropagation(toggleJsonDisplay)}>
+				<button onclick={toggleJsonDisplay}>
 					<IconCodeDots size={iconSize} />
 				</button>
 			</div>


### PR DESCRIPTION
## Summary

Remove the `stopPropagation` wrapper from `svelte/legacy` in `LongFormContent.svelte`.

This no longer serves a purpose for the quote button and the JSON display toggle button, since the parent-side navigation logic already excludes clicks that land on a `button`:

- `EventNavigation.ts` skips navigation when the click target is inside `a, button, video, audio, dialog, .develop`
- `ReferenceNip27.svelte` similarly skips navigation for clicks inside `a, button, img, video, audio, dialog`

Rather than replacing `stopPropagation(...)` with `event.stopPropagation()`, the unnecessary propagation control is removed entirely. The quote handler and `jsonDisplay` toggle logic are unchanged.

Refs #2374

## Verification

- `npm run check` passed (0 errors, 0 warnings)
- `npm run lint` passed
- `npm test` passed (56 files, 442 tests)

No unit test directly exercises the click handling of `LongFormContent.svelte`, and covering it would require adding DOM test infrastructure, so no test was added in this PR.