### PR TITLE
Remove svelte/legacy from TimelineFilter

### DIFF
--- a/web/src/routes/(app)/preferences/TimelineFilter.svelte
+++ b/web/src/routes/(app)/preferences/TimelineFilter.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	import { run, createBubbler, preventDefault } from 'svelte/legacy';
-
-	const bubble = createBubbler();
 	import { _ } from 'svelte-i18n';
 	import { browser } from '$app/environment';
 	import { diff } from '$lib/array';
@@ -18,14 +15,12 @@
 		categories.filter((category) => !excludeCategories.includes(category))
 	);
 
-	run(() => {
-		if (browser) {
-			setTimelineFilter(diff(categories, includeCategories));
-		}
+	$effect(() => {
+		setTimelineFilter(diff(categories, includeCategories));
 	});
 </script>
 
-<form onsubmit={preventDefault(bubble('submit'))}>
+<div>
 	{#each categories as category}
 		<div>
 			<label>
@@ -34,4 +29,4 @@
 			</label>
 		</div>
 	{/each}
-</form>
+</div>


### PR DESCRIPTION
## Summary

Remove the remaining `svelte/legacy` usage from `TimelineFilter.svelte` as part of Issue #2374.

`run()`, `createBubbler()`, and `preventDefault` were all compatibility code produced by the Svelte 5 migration tool for what was originally `<form on:submit|preventDefault>` backed by a reactive statement.

- Migrate the filter saving in `run()` to `$effect`. Since `$effect` only runs on the client, the `if (browser)` guard is no longer needed, and this keeps the existing SSR behavior of never touching `localStorage`. Initial filter loading still uses `browser ? getTimelineFilter() : defaultTimelineFilter`, so `getTimelineFilter()` is not called during SSR.
- Remove `createBubbler` and the `submit` event forwarding. No caller subscribes to the component's `submit` event (the only usage is `<TimelineFilter />` in `home/+page.svelte`), so the forwarding API is unnecessary and is not recreated in another form.
- Remove the `<form>` element. The component is not a form-submit UI; checkboxes save the filter reactively on change, so the element becomes a plain `<div>` with no layout/code changes.

Refs #2374

## Verification

- `npm run check` passed (0 errors, 0 warnings)
- `npm run lint` passed
- `npm test` passed (56 files, 442 tests)
- `npm run test:e2e` passed (1 test)

No existing unit test covers `TimelineFilter.svelte`, and none was added.