### PR TITLE
Drop Poll stopPropagation and treat form as navigation boundary

### DIFF
--- a/web/src/lib/EventNavigation.ts
+++ b/web/src/lib/EventNavigation.ts
@@ -30,7 +30,7 @@ const shouldSkipNavigation = (e: MouseEvent | KeyboardEvent): boolean => {
 	if (target === null) {
 		return true;
 	}
-	if (target.closest('a, button, video, audio, dialog, .develop')) {
+	if (target.closest('a, button, form, video, audio, dialog, .develop')) {
 		return true;
 	}
 	return target.closest('p') !== null && String(document.getSelection()).length > 0;

--- a/web/src/lib/components/items/Poll.svelte
+++ b/web/src/lib/components/items/Poll.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	import { createBubbler, stopPropagation } from 'svelte/legacy';
-
-	const bubble = createBubbler();
 	import type { Item } from '$lib/Items';
 	import { _ } from 'svelte-i18n';
 	import Content from '../Content.svelte';
@@ -69,8 +66,7 @@
 	{#snippet content()}
 		<section>
 			<Content content={item.event.content} tags={item.event.tags} />
-			<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-			<form onsubmit={onSubmit} onmouseup={stopPropagation(bubble('mouseup'))}>
+			<form onsubmit={onSubmit}>
 				<div>
 					{#each optionTags as [, id, label]}
 						<div>


### PR DESCRIPTION
## Summary

Remove the `svelte/legacy` usage (`createBubbler` / `stopPropagation`) from `Poll.svelte` and move the interaction boundary to the shared navigation logic, as part of Issue #2374.

- `EventNavigation.shouldSkipNavigation()` now treats `form` as an interaction boundary: `target.closest('a, button, form, video, audio, dialog, .develop')`. Any interaction inside a form (checkbox, radio, label, input, select, textarea, submit controls, or the form's blank space) is no longer treated as post navigation. The check is shared by `navigateTo()` and `preventMiddleClickDefault()`, so left/middle en click behavior stays consistent. Since the form is the interaction boundary, no Poll-specific class names or selectors were added.
- `Poll.svelte` no longer needs to stop propagation itself, so the `createBubbler` / `stopPropagation` imports, the `bubble` instance, and `onmouseup={stopPropagation(bubble('mouseup'))}` are removed. The `svelte-ignore` comment that only existed for the removed `onmouseup` a11y warning was also dropped.
- The poll's actual submit/vote behavior is unchanged: `<form onsubmit={onSubmit}>` is kept, and `onSubmit()` still calls the plain DOM `SubmitEvent.preventDefault()` before voting. No caller listens to the component's `mouseup` event (`<Poll {item} {createdAtFormat} />` in `EventComponent.svelte`), so the forwarding is not reimplemented as another API.

This replaces the migration-tool output for the pre-migration `on:mouseup|stopPropagation` with a more natural responsibility split: the navigation layer decides what is a navigation target, rather than every interactive card component suppressing propagation.

Refs #2374

## Verification

- `npm run check` passed (0 errors, 0 warnings)
- `npm run lint` passed
- `npm test` passed (56 files, 442 tests)
- `npm run test:e2e` passed (1 test)

No existing unit test covers `EventNavigation.ts`, and validating form-descendant navigation through `navigateTo()` would require adding a DOM environment plus mocking `$app/navigation`, so no test was added.